### PR TITLE
fix(#2373): BG 채널에 FG hop-window 게이트 이식 (Option A)

### DIFF
--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -16,6 +16,7 @@ import {
   isStationWithinHopWindow,
   arcIndexOf,
   LOCKLESS_HOP_WINDOW_DEFAULT,
+  computeHopWindowSize,
 } from '../../../shared/utils/stationRoute';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
@@ -480,69 +481,8 @@ function inferHopIndexFromFiredAlarms(
   return Math.min(maxIdx + 1, arcStations.length - 1);
 }
 
-/**
- * #1922 (M1+M3) — station-passed hop window 동적 확장.
- *
- * 환승 leg에서 estimator가 시간 적분 strategy로 stuck됐을 때 (live-position이 아닌 strategy +
- * effectiveHopIndex와 candidateIndex 사이에 transfer point가 끼어 있음), 기본 windowSize(1)로는
- * 정상 진행 candidate(실측)도 reject된다. 본 helper가 동적으로 windowSize를 확장해 dump line
- * 169~244의 61회 suppress 회귀를 차단한다.
- *
- * 게이트:
- *   1. route.type이 'transfer' 또는 'multi-transfer' — direct route는 환승 없음, 동적 확장 의미 X.
- *   2. currentHopStrategy !== 'live-position' — live-position에서 격차 큰 경우는 GPS jitter / wrong
- *      train 같은 abnormal jump 신호. 확장하면 false positive 알람 발생. (M3 신뢰도 게이트)
- *   3. effectiveHopIndex와 candidateIndex 사이 arc에 transfer point가 끼어 있음 — 인접 station이
- *      같은 name + 다른 line이면 transfer point (computeRouteArc는 양쪽 노선 entry 모두 보존).
- *
- * 모두 충족 시 windowSize = max(LOCKLESS_HOP_WINDOW_DEFAULT, |candidateIndex - effectiveHopIndex|)로
- * 확장. 한 가지라도 미충족이면 기본 windowSize 유지.
- *
- * arc에 candidate가 없으면 (-1), 호출자가 어차피 isStationWithinHopWindow에서 false 반환하므로
- * 본 helper는 -1을 받아도 안전(기본 windowSize 반환).
- */
-function computeHopWindowSize(
-  arcStations: readonly Station[],
-  route: Route,
-  effectiveHopIndex: number,
-  candidateIndex: number,
-  currentHopStrategy:
-    | import('../../route/utils/stationProgressEstimator').StationProgressStrategy
-    | null,
-): number {
-  // M1 게이트 1: transfer/multi-transfer route만 동적 확장 대상.
-  if (!route || route.type === 'direct') return LOCKLESS_HOP_WINDOW_DEFAULT;
-  // M3 신뢰도 게이트: live-position 실측 strategy에서는 확장 X (abnormal jump 신호).
-  if (currentHopStrategy === 'live-position') return LOCKLESS_HOP_WINDOW_DEFAULT;
-  // 인덱스 가드: candidate가 arc 밖이면 default — isStationWithinHopWindow가 어차피 false.
-  if (candidateIndex < 0 || effectiveHopIndex < 0) return LOCKLESS_HOP_WINDOW_DEFAULT;
-  /* istanbul ignore next -- 호출 시점 invariant: arcIndexOf 결과 candidate는 arc 내부.
-     effectiveHopIndex도 currentHopIndex(estimator 또는 firedAlarms inferred, 둘 다 clamp) 후
-     사용되므로 out-of-bounds 도달 불가. 방어적 가드 — 직접 호출자 추가 시 안전. */
-  if (candidateIndex >= arcStations.length || effectiveHopIndex >= arcStations.length) {
-    return LOCKLESS_HOP_WINDOW_DEFAULT;
-  }
-
-  // M1 게이트 3: effectiveHopIndex와 candidateIndex 사이 transfer crossover 감지.
-  // computeRouteArc는 환승 시 fromLine 쪽 + toLine 쪽 entry 둘 다 push하므로
-  // 인접 station이 같은 name + 다른 line이면 transfer crossover 표지다.
-  const lo = Math.min(effectiveHopIndex, candidateIndex);
-  const hi = Math.max(effectiveHopIndex, candidateIndex);
-  let crossesTransfer = false;
-  for (let i = lo; i < hi; i++) {
-    const a = arcStations[i];
-    const b = arcStations[i + 1];
-    if (isSameStationName(a.name, b.name) && a.line !== b.line) {
-      crossesTransfer = true;
-      break;
-    }
-  }
-  if (!crossesTransfer) return LOCKLESS_HOP_WINDOW_DEFAULT;
-
-  // 모든 게이트 통과 → windowSize를 격차만큼 확장.
-  const gap = hi - lo;
-  return Math.max(LOCKLESS_HOP_WINDOW_DEFAULT, gap);
-}
+// #2373 — computeHopWindowSize는 src/shared/utils/stationRoute.ts로 추출됐다(BG 채널 재사용).
+// FG는 위 import에서 shared 버전을 그대로 사용 — 동작 동일, 회귀 없음.
 
 export interface UseStationAlarmInputs {
   route: Route;

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -1007,6 +1007,31 @@ describe('alarmLog', () => {
       });
     });
 
+    it('#2373 logSuppressedHopWindow: kind/phaseId 전달 시(BG phase 알람 게이트) 그대로 stamp', async () => {
+      logSuppressedHopWindow({
+        source: 'bg',
+        stationName: '건대입구',
+        currentHopIndex: 1,
+        candidateIndex: 3,
+        kind: 'transfer',
+        phaseId: 'early',
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'gate-hop-window',
+        stationName: '건대입구',
+        kind: 'transfer',
+        phaseId: 'early',
+        currentHopIndex: 1,
+        candidateIndex: 3,
+      });
+    });
+
     it('#1208 logSuppressedHopWindowNoSource: reason=gate-hop-window-no-source + kind=station-passed', async () => {
       logSuppressedHopWindowNoSource({ source: 'fg', stationName: '용마산' });
       await flushAlarmLog();

--- a/src/features/alarm/utils/__tests__/hopWindowState.test.ts
+++ b/src/features/alarm/utils/__tests__/hopWindowState.test.ts
@@ -1,0 +1,89 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getBgHopWindowStation, setBgHopWindowStation } from '../hopWindowState';
+import { BG_HOP_WINDOW_STATION_KEY } from '../../../../shared/constants/storageKeys';
+import type { Station } from '../../../../shared/types/station';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const station: Station = {
+  id: 'station-1',
+  name: '강남',
+  line: '2',
+  lineColor: '#009246',
+  lat: 37.498,
+  lng: 127.028,
+};
+
+describe('hopWindowState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getBgHopWindowStation', () => {
+    it('AsyncStorage가 null이면 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      expect(await getBgHopWindowStation('dest-1')).toBeNull();
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(BG_HOP_WINDOW_STATION_KEY);
+    });
+
+    it('destinationId가 일치하면 저장된 station을 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', station }),
+      );
+      expect(await getBgHopWindowStation('dest-1')).toEqual(station);
+    });
+
+    it('destinationId가 다르면(새 trip) stale로 간주해 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', station }),
+      );
+      expect(await getBgHopWindowStation('dest-2')).toBeNull();
+    });
+
+    it('파싱 실패 시 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+      expect(await getBgHopWindowStation('dest-1')).toBeNull();
+    });
+
+    it('destinationId 누락된 record는 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ station }));
+      expect(await getBgHopWindowStation('dest-1')).toBeNull();
+    });
+
+    it('station 필드가 station 형태가 아니면 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ destinationId: 'dest-1', station: { name: '강남' } }),
+      );
+      expect(await getBgHopWindowStation('dest-1')).toBeNull();
+    });
+
+    it('record가 object가 아니면 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify('string-value'));
+      expect(await getBgHopWindowStation('dest-1')).toBeNull();
+    });
+
+    it('AsyncStorage 예외 시 graceful null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      expect(await getBgHopWindowStation('dest-1')).toBeNull();
+    });
+  });
+
+  describe('setBgHopWindowStation', () => {
+    it('destinationId + station을 JSON으로 저장한다', async () => {
+      await setBgHopWindowStation('dest-1', station);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        BG_HOP_WINDOW_STATION_KEY,
+        JSON.stringify({ destinationId: 'dest-1', station }),
+      );
+    });
+
+    it('AsyncStorage 예외 시 silent (throw 안 함)', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(setBgHopWindowStation('dest-1', station)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -19,15 +19,34 @@ const mockIsStationOnRoute = jest.fn();
 const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
 const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
 const mockGetRouteRemainingSeconds = jest.fn((..._args: unknown[]) => 360);
-jest.mock('../../../../shared/utils/stationRoute', () => ({
-  findRoute: (...args: unknown[]) => mockFindRoute(...args),
-  calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
-  updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
-  isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
-  isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
-  getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
-  // #2279 — processLocationUpdate가 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
-  getRouteRemainingSeconds: (...args: unknown[]) => mockGetRouteRemainingSeconds(...args),
+const mockGetStationsOnLine = jest.fn((..._args: unknown[]) => [] as Station[]);
+jest.mock('../../../../shared/utils/stationRoute', () => {
+  // #2373 — computeHopWindowSize/isStationWithinHopWindow/arcIndexOf/LOCKLESS_HOP_WINDOW_DEFAULT는
+  // FG(useStationAlarm) 검증 로직을 그대로 재사용하는 게이트라 실제 구현을 requireActual로 통과시킨다.
+  // (mock으로 대체하면 게이트 정확성 자체를 검증할 수 없다 — 이 파일의 red→green fixture 목적과 배치.)
+  const actual = jest.requireActual('../../../../shared/utils/stationRoute');
+  return {
+    findRoute: (...args: unknown[]) => mockFindRoute(...args),
+    calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
+    updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
+    isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
+    isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
+    getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
+    // #2279 — processLocationUpdate가 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
+    getRouteRemainingSeconds: (...args: unknown[]) => mockGetRouteRemainingSeconds(...args),
+    getStationsOnLine: (...args: unknown[]) => mockGetStationsOnLine(...args),
+    arcIndexOf: actual.arcIndexOf,
+    computeHopWindowSize: actual.computeHopWindowSize,
+    isStationWithinHopWindow: actual.isStationWithinHopWindow,
+    LOCKLESS_HOP_WINDOW_DEFAULT: actual.LOCKLESS_HOP_WINDOW_DEFAULT,
+  };
+});
+
+const mockGetBgHopWindowStation = jest.fn();
+const mockSetBgHopWindowStation = jest.fn();
+jest.mock('../hopWindowState', () => ({
+  getBgHopWindowStation: (...args: unknown[]) => mockGetBgHopWindowStation(...args),
+  setBgHopWindowStation: (...args: unknown[]) => mockSetBgHopWindowStation(...args),
 }));
 
 const mockEvaluateAlarmPhase = jest.fn();
@@ -84,6 +103,7 @@ const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
 const mockLogSuppressedChannelAgnosticDedup = jest.fn();
 const mockLogSuppressedMovement = jest.fn();
+const mockLogSuppressedHopWindow = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -95,6 +115,7 @@ jest.mock('../alarmLog', () => ({
     mockLogSuppressedSleepStationPassed(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
   logSuppressedMovement: (...args: unknown[]) => mockLogSuppressedMovement(...args),
+  logSuppressedHopWindow: (...args: unknown[]) => mockLogSuppressedHopWindow(...args),
   logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryDedup(...args),
   logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
@@ -170,6 +191,10 @@ describe('processLocationUpdate', () => {
     // #746: dismissSilence 기본은 null — silence 없음.
     mockGetDismissSilence.mockResolvedValue(null);
     mockClearDismissSilence.mockResolvedValue(undefined);
+    // #2373: hop-window 게이트 기본 — 기준 없음(첫 tick 취급) → 기존 테스트 전부 회귀 없음.
+    mockGetBgHopWindowStation.mockResolvedValue(null);
+    mockSetBgHopWindowStation.mockResolvedValue(undefined);
+    mockGetStationsOnLine.mockReturnValue([]);
   });
 
   it('returns null nearest and null alarm when findNearestStation returns null', async () => {
@@ -1267,6 +1292,104 @@ describe('processLocationUpdate', () => {
       });
       await call({ source: 'bg' });
       expect(mockUpdateStationNotification).toHaveBeenCalled();
+    });
+  });
+
+  // #2373 (RCA #2180, Option A) — FG의 검증된 station-passed hop-window 게이트를 BG 채널에
+  // 이식. GPS drift로 findNearestStation이 직전 tick 기준(hopWindowState 영속)보다 hop window
+  // 밖의 station을 반환하면 phase 알람(early transfer 등) 발사를 차단한다.
+  // 이 게이트가 없던 코드에서는 아래 '조기 오발사 evidence 재현' 테스트가 fired로 실패했다
+  // (2026-08-23 14분 조기 오발사 — 2호선 건대입구 구간 evidence).
+  describe('#2373 BG hop-window 게이트 (RCA #2180 transfer-early 조기 오발사)', () => {
+    const lineStationA: Station = { id: 'line2-a', name: 'A역', line: '2', lineColor: '#009246', lat: 37.50, lng: 127.02 };
+    const lineStationB: Station = { id: 'line2-b', name: 'B역', line: '2', lineColor: '#009246', lat: 37.51, lng: 127.03 };
+    const lineStationC: Station = { id: 'line2-c', name: 'C역', line: '2', lineColor: '#009246', lat: 37.52, lng: 127.04 };
+    const lineStationD: Station = { id: 'line2-d', name: 'D역', line: '2', lineColor: '#009246', lat: 37.53, lng: 127.05 };
+    const otherLineStation: Station = { id: 'line5-a', name: 'E역', line: '5', lineColor: '#996CAC', lat: 37.54, lng: 127.06 };
+    const lineStations = [lineStationA, lineStationB, lineStationC, lineStationD];
+
+    beforeEach(() => {
+      mockGetStationsOnLine.mockReturnValue(lineStations);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'early',
+        type: 'transfer',
+        stationName: '건대입구',
+      });
+    });
+
+    it('직전 tick 기준(index 1) 대비 2 hop 이상 앞선 candidate(index 3)는 조기 발사를 차단한다 (RCA #2180 재현)', async () => {
+      mockGetBgHopWindowStation.mockResolvedValue(lineStationB); // 직전 tick 기준 = index 1
+      mockFindNearestStation.mockReturnValue({ station: lineStationD, distanceKm: 0.1 }); // GPS drift → index 3
+
+      await call();
+
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: '건대입구',
+        kind: 'transfer',
+        phaseId: 'early',
+        currentHopIndex: 1,
+        candidateIndex: 3,
+      });
+      // 차단된 candidate로 기준을 덮어쓰지 않는다 — 다음 tick도 같은 기준(index 1)으로 재평가.
+      expect(mockSetBgHopWindowStation).not.toHaveBeenCalled();
+    });
+
+    it('직전 tick 기준(index 1) 대비 1 hop 이내(index 2)는 정상 발사하고 기준을 갱신한다', async () => {
+      mockGetBgHopWindowStation.mockResolvedValue(lineStationB);
+      mockFindNearestStation.mockReturnValue({ station: lineStationC, distanceKm: 0.1 }); // index 2, diff=1
+
+      await call();
+
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockSetBgHopWindowStation).toHaveBeenCalledWith(mockDestination.id, lineStationC);
+    });
+
+    it('기준 없음(첫 tick)이면 게이트 없이 발사하고 candidate를 새 기준으로 저장한다', async () => {
+      mockGetBgHopWindowStation.mockResolvedValue(null);
+      mockFindNearestStation.mockReturnValue({ station: lineStationD, distanceKm: 0.1 });
+
+      await call();
+
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockSetBgHopWindowStation).toHaveBeenCalledWith(mockDestination.id, lineStationD);
+    });
+
+    it('직전 기준과 candidate의 노선이 다르면(환승 완료) 게이트를 skip하고 새 기준으로 채택한다', async () => {
+      mockGetBgHopWindowStation.mockResolvedValue(otherLineStation); // line '5'
+      mockFindNearestStation.mockReturnValue({ station: lineStationD, distanceKm: 0.1 }); // line '2'
+
+      await call();
+
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockSetBgHopWindowStation).toHaveBeenCalledWith(mockDestination.id, lineStationD);
+    });
+
+    it('같은 노선이지만 arcStations에서 기준/candidate 인덱스를 찾지 못하면 게이트 없이 새 기준으로 채택한다', async () => {
+      mockGetBgHopWindowStation.mockResolvedValue(lineStationB);
+      mockFindNearestStation.mockReturnValue({ station: lineStationD, distanceKm: 0.1 });
+      // getStationsOnLine이 두 station을 포함하지 않는 다른 노선 구간을 반환(방어적 edge case).
+      mockGetStationsOnLine.mockReturnValue([]);
+
+      await call();
+
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockSetBgHopWindowStation).toHaveBeenCalledWith(mockDestination.id, lineStationD);
+    });
+
+    it('route가 없으면 게이트를 평가하지 않는다 (alarmEvent도 항상 null이라 대상 없음)', async () => {
+      mockFindRoute.mockReturnValue(null);
+      mockFindNearestStation.mockReturnValue({ station: lineStationD, distanceKm: 0.1 });
+
+      await call();
+
+      expect(mockGetBgHopWindowStation).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1758,6 +1758,10 @@ export function logSuppressedHopWindow(input: {
   stationName: string;
   currentHopIndex: number;
   candidateIndex: number;
+  // #2373 — BG 채널은 station-passed가 아닌 phase 알람(transfer/destination)을 이 게이트로
+  // 차단한다. kind/phaseId 미전달 시 기존 FG station-passed 호출부와 동일하게 동작(회귀 없음).
+  kind?: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
 }): void {
   appendAlarmLog({
     ts: Date.now(),
@@ -1765,7 +1769,8 @@ export function logSuppressedHopWindow(input: {
     outcome: 'suppressed',
     reason: 'gate-hop-window',
     stationName: input.stationName,
-    kind: 'station-passed',
+    kind: input.kind ?? 'station-passed',
+    phaseId: input.phaseId,
     currentHopIndex: input.currentHopIndex,
     candidateIndex: input.candidateIndex,
   });

--- a/src/features/alarm/utils/hopWindowState.ts
+++ b/src/features/alarm/utils/hopWindowState.ts
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BG_HOP_WINDOW_STATION_KEY } from '../../../shared/constants/storageKeys';
+import type { Station } from '../../../shared/types/station';
+
+/**
+ * #2373 — BG 채널(stationPipeline.processLocationUpdate) hop-window 게이트의 직전 tick 기준점.
+ *
+ * FG(useStationAlarm)는 D1 estimator의 currentHopIndex(또는 firedAlarms 기반 fallback)를 SSOT로
+ * 쓰지만, BG는 매 tick 독립 호출되는 stateless 함수라 그 컨텍스트가 없다. 대신 직전 tick에 게이트를
+ * 통과한 nearestStation을 여기 영속화해 다음 tick의 hop 기준으로 삼는다.
+ *
+ * destinationId로 scoping — read 시점 destinationId가 저장된 값과 다르면 stale로 간주하고
+ * null을 반환한다. 새 destination(=새 trip) 시작 시 자동 무효화되므로 명시적 reset 호출이
+ * 필요 없다 (notificationState.ts의 LAST_NOTIFIED_STATION_KEY와 동일 패턴).
+ */
+interface BgHopWindowRecord {
+  destinationId: string;
+  station: Station;
+}
+
+function isStation(value: unknown): value is Station {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as Station).id === 'string' &&
+    typeof (value as Station).line === 'string'
+  );
+}
+
+function isBgHopWindowRecord(value: unknown): value is BgHopWindowRecord {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as BgHopWindowRecord).destinationId === 'string' &&
+    isStation((value as BgHopWindowRecord).station)
+  );
+}
+
+/**
+ * destinationId가 저장된 record와 일치할 때만 직전 tick 기준 station을 반환.
+ * 부재/파싱 실패/다른 trip이면 null — 호출자는 이번 tick을 "기준 없음"으로 graceful 처리한다.
+ */
+export async function getBgHopWindowStation(destinationId: string): Promise<Station | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_HOP_WINDOW_STATION_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isBgHopWindowRecord(parsed)) return null;
+    if (parsed.destinationId !== destinationId) return null;
+    return parsed.station;
+  } catch {
+    return null;
+  }
+}
+
+export async function setBgHopWindowStation(
+  destinationId: string,
+  station: Station,
+): Promise<void> {
+  const record: BgHopWindowRecord = { destinationId, station };
+  try {
+    await AsyncStorage.setItem(BG_HOP_WINDOW_STATION_KEY, JSON.stringify(record));
+  } catch {
+    // storage 실패는 silent — 다음 tick이 "기준 없음"으로 graceful skip.
+  }
+}

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -7,7 +7,7 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
-import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
+import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition, getStationsOnLine, arcIndexOf, computeHopWindowSize, isStationWithinHopWindow } from '../../../shared/utils/stationRoute';
 import { hasConsumedOriginWait } from '../../../shared/utils/boardingWait';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { updateStationNotification } from './stationNotification';
@@ -15,6 +15,7 @@ import { distanceMetersBetween, estimateEtaSeconds, estimateTransitEtaSeconds } 
 import { cancelSafetyNetByStationKind } from './safetyNetScheduler';
 import { getBoardingLock } from './boardingLockStorage';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
+import { getBgHopWindowStation, setBgHopWindowStation } from './hopWindowState';
 import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
 import {
   logFiredAlarm,
@@ -25,6 +26,7 @@ import {
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
+  logSuppressedHopWindow,
   logSuppressedMovement,
   logSuppressedSleepFirstTransfer,
   logSuppressedSleepStationPassed,
@@ -214,6 +216,61 @@ export interface ProcessLocationInputs {
   arrivalsAtTransfers?: ReadonlyArray<{ arrivalSeconds: number; receivedAtMs: number } | null>;
 }
 
+/**
+ * #2373 (Option A, RCA #2180) — FG의 검증된 station-passed hop-window 게이트를 BG 채널에 이식.
+ *
+ * 배경: BG(stationPipeline)는 findNearestStation의 raw GPS 좌표 최근접 스냅을 그대로 route/phase
+ * 평가에 사용한다 — 매 tick 독립 계산, 이전 hop/경과시간 무관 = stateless. 지하 GPS drift가 실제보다
+ * 앞선 역(예: 2 hop 전인데 1 hop 전 역)을 스냅하면 remainingStops가 즉시 줄어 transfer-early가
+ * 조기 발사한다(2026-08-23 14분 조기 오발사 evidence, 2호선 건대입구 구간).
+ *
+ * FG(useStationAlarm.ts)는 D1 estimator의 currentHopIndex(부재 시 firedAlarms 기반 fallback)를
+ * hop 기준으로 삼지만 BG는 estimator가 없는 stateless 함수다. 대신 직전 tick에 게이트를 통과한
+ * nearestStation을 AsyncStorage에 영속화(hopWindowState.ts)해 다음 tick의 기준으로 쓴다.
+ *
+ * arcStations는 candidate와 같은 노선 전체 station 순서(getStationsOnLine)로 유도한다 — FG의
+ * computeRouteArc(환승 양쪽 노선을 이어붙인 arc)를 그대로 쓰지 않는 이유: 기준 station과
+ * candidate가 다른 노선이면(=방금 환승 완료) 그 자체가 정상 진행 신호이므로 게이트를 skip하고
+ * 새 기준으로 채택한다. computeHopWindowSize/isStationWithinHopWindow는 FG와 동일 함수를
+ * 그대로 재사용(shared 추출, 신규 게이트 로직 발명 아님) — route.type이 transfer/multi-transfer면
+ * windowSize 동적 확장도 동일하게 적용된다.
+ *
+ * 반환:
+ *   - null: 게이트 미적용(기준 없음 / 방금 환승 / arc 인덱스 미발견) — candidate를 새 기준으로 채택.
+ *   - { blocked: true, ... }: hop window 밖 — 기준 station 유지(overwrite 안 함), caller가 이번
+ *     tick의 phase 알람 발사만 suppress한다. candidate 자체(route/notification)는 계속 갱신된다
+ *     (FG와 동일 — hop window는 "발사"만 가드, "현재 위치 추정"은 가드하지 않음).
+ */
+async function evaluateBgHopWindowGate(params: {
+  destinationId: string;
+  candidateStation: Station;
+  route: Route;
+}): Promise<{ blocked: true; currentHopIndex: number; candidateIndex: number } | null> {
+  const { destinationId, candidateStation, route } = params;
+  const prevStation = await getBgHopWindowStation(destinationId);
+  if (!prevStation || prevStation.line !== candidateStation.line) {
+    // 기준 없음(첫 tick) 또는 방금 환승선 전환 — 게이트 미적용, candidate를 새 기준으로 채택.
+    await setBgHopWindowStation(destinationId, candidateStation);
+    return null;
+  }
+
+  const arcStations = getStationsOnLine(candidateStation.line);
+  const currentHopIndex = arcIndexOf(arcStations, prevStation);
+  const candidateIndex = arcIndexOf(arcStations, candidateStation);
+  if (currentHopIndex < 0 || candidateIndex < 0) {
+    await setBgHopWindowStation(destinationId, candidateStation);
+    return null;
+  }
+
+  const windowSize = computeHopWindowSize(arcStations, route, currentHopIndex, candidateIndex, null);
+  if (isStationWithinHopWindow(candidateStation, arcStations, currentHopIndex, windowSize)) {
+    await setBgHopWindowStation(destinationId, candidateStation);
+    return null;
+  }
+
+  return { blocked: true, currentHopIndex, candidateIndex };
+}
+
 export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
   const {
     lat,
@@ -244,6 +301,16 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   if (!route) {
     route = findRoute(nearest.station.id, destination.id);
   }
+
+  // #2373 (RCA #2180) — FG의 검증된 station-passed hop-window 게이트를 BG 채널에 이식.
+  // route 없으면 게이트 대상 자체가 없다(evaluateAlarmPhase도 route=null이면 항상 alarmEvent=null).
+  const hopWindowGate = route
+    ? await evaluateBgHopWindowGate({
+        destinationId: destination.id,
+        candidateStation: nearest.station,
+        route,
+      })
+    : null;
 
   const distanceToDestM = distanceMetersBetween(lat, lng, destination.lat, destination.lng);
   // #2279 — route가 있으면 실측 hop 시간 합(getRouteRemainingSeconds)을 상한으로 clamp해
@@ -334,6 +401,17 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         kind: alarmEvent.type,
         phaseId: alarmEvent.phaseId,
         reason: MOVEMENT_TO_ALARM_LOG_REASON[movementSignal.reason],
+      });
+    } else if (hopWindowGate?.blocked) {
+      // #2373 — candidate가 직전 tick 기준 station 대비 hop window 밖(GPS drift로 앞선 역 스냅).
+      // transfer-early 14분 조기 오발사(2호선 건대입구 구간, 2026-08-23) 차단.
+      logSuppressedHopWindow({
+        source,
+        stationName: alarmEvent.stationName,
+        kind: alarmEvent.type,
+        phaseId: alarmEvent.phaseId,
+        currentHopIndex: hopWindowGate.currentHopIndex,
+        candidateIndex: hopWindowGate.candidateIndex,
       });
     } else if (suppressBySleep) {
       logSuppressedSleepFirstTransfer({

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -96,19 +96,33 @@ jest.mock('../../utils/findNearestStation', () => ({
 }));
 
 const mockFindRoute = jest.fn();
-jest.mock('../../../../shared/utils/stationRoute', () => ({
-  findRoute: (...args: unknown[]) => mockFindRoute(...args),
-  calculateStaticETA: jest.fn(() => 10),
-  updateRouteFromPosition: jest.fn(() => null),
-  isStationOnRoute: jest.fn(() => true),
-  // #750 — stationPipeline의 sleep 게이트가 isSameStationName으로 첫 hop을 매칭.
-  // 결정적 fake: strict equality로 충분 (테스트는 동일 한국어 이름 사용).
-  isSameStationName: (a: string, b: string) => a === b,
-  // direct route 테스트만 사용 — 첫 leg endName은 항상 destinationName.
-  getFirstLeg: (_route: unknown, destinationName: string) => ({ line: '2', endName: destinationName }),
-  // #2279 — stationPipeline이 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
-  getRouteRemainingSeconds: jest.fn(() => 120),
-}));
+jest.mock('../../../../shared/utils/stationRoute', () => {
+  // #2373 — stationPipeline의 BG hop-window 게이트가 getStationsOnLine/arcIndexOf/
+  // computeHopWindowSize/isStationWithinHopWindow/LOCKLESS_HOP_WINDOW_DEFAULT를 참조한다.
+  // 이 파일의 fake station("station-1"/"station-2")은 실제 stations.json에 없는 id라
+  // requireActual의 getStationsOnLine이 반환하는 실제 노선 배열에서 항상 arcIndexOf가 -1을
+  // 반환한다 — 게이트가 "인덱스 미발견 → 미적용" graceful skip 경로로만 진입해 기존
+  // FG/BG dedup 계약(이 파일의 검증 대상)을 건드리지 않는다.
+  const actual = jest.requireActual('../../../../shared/utils/stationRoute');
+  return {
+    findRoute: (...args: unknown[]) => mockFindRoute(...args),
+    calculateStaticETA: jest.fn(() => 10),
+    updateRouteFromPosition: jest.fn(() => null),
+    isStationOnRoute: jest.fn(() => true),
+    // #750 — stationPipeline의 sleep 게이트가 isSameStationName으로 첫 hop을 매칭.
+    // 결정적 fake: strict equality로 충분 (테스트는 동일 한국어 이름 사용).
+    isSameStationName: (a: string, b: string) => a === b,
+    // direct route 테스트만 사용 — 첫 leg endName은 항상 destinationName.
+    getFirstLeg: (_route: unknown, destinationName: string) => ({ line: '2', endName: destinationName }),
+    // #2279 — stationPipeline이 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
+    getRouteRemainingSeconds: jest.fn(() => 120),
+    getStationsOnLine: actual.getStationsOnLine,
+    arcIndexOf: actual.arcIndexOf,
+    computeHopWindowSize: actual.computeHopWindowSize,
+    isStationWithinHopWindow: actual.isStationWithinHopWindow,
+    LOCKLESS_HOP_WINDOW_DEFAULT: actual.LOCKLESS_HOP_WINDOW_DEFAULT,
+  };
+});
 
 const mockSendStationPassedNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
 const mockUpdateStationNotification = jest.fn((..._args: unknown[]) => Promise.resolve());

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -57,6 +57,12 @@ export const BG_PERMISSION_DENIED_DISMISSED_KEY = 'subway-now:bg-permission-deni
 // 형식: {"station": Station, "distanceKm": number, "timestamp": number} JSON.
 // WhileInUse 권한 사용자에게는 BG task 자체가 동작하지 않으므로 graceful no-op (key 없음).
 export const BG_LAST_STATION_KEY = 'subway-now:bg-last-station';
+// #2373 — BG 채널(stationPipeline)의 hop-window 게이트가 참조하는 직전 tick 수용 station.
+// FG(useStationAlarm)는 D1 estimator의 currentHopIndex를 SSOT로 쓰지만 BG는 그 컨텍스트가
+// 없는 stateless 함수라 별도로 영속화한다. 형식: {"destinationId": string, "station": Station} JSON.
+// destinationId가 read 시점 destination과 다르면 stale로 간주(새 trip 시작 시 자동 무효화, 명시
+// clear 불필요) — notificationState.ts의 LAST_NOTIFIED_STATION_KEY 스코핑 패턴과 동일.
+export const BG_HOP_WINDOW_STATION_KEY = 'subway-now:bg-hop-window-station';
 // #816 B — boardingPrompt 발사 추적 (trip당 1회 발사 + dismiss 시 5분 silence).
 // 형식: {"tripKey": string, "promptedAt": number, "dismissedAt"?: number} JSON.
 // tripKey는 `${destinationId}|${createdAtBucketMs}` — destination 변경 시 자동 reset.

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -474,6 +474,74 @@ export function arcIndexOf(arcStations: readonly Station[], station: Station): n
   return arcStations.findIndex((s) => s.id === station.id);
 }
 
+/**
+ * #1922 (M1+M3) — station-passed hop window 동적 확장.
+ *
+ * 환승 leg에서 estimator가 시간 적분 strategy로 stuck됐을 때 (live-position이 아닌 strategy +
+ * effectiveHopIndex와 candidateIndex 사이에 transfer point가 끼어 있음), 기본 windowSize(1)로는
+ * 정상 진행 candidate(실측)도 reject된다. 본 helper가 동적으로 windowSize를 확장해 dump line
+ * 169~244의 61회 suppress 회귀를 차단한다.
+ *
+ * 게이트:
+ *   1. route.type이 'transfer' 또는 'multi-transfer' — direct route는 환승 없음, 동적 확장 의미 X.
+ *   2. currentHopStrategy !== 'live-position' — live-position에서 격차 큰 경우는 GPS jitter / wrong
+ *      train 같은 abnormal jump 신호. 확장하면 false positive 알람 발생. (M3 신뢰도 게이트)
+ *   3. effectiveHopIndex와 candidateIndex 사이 arc에 transfer point가 끼어 있음 — 인접 station이
+ *      같은 name + 다른 line이면 transfer point (computeRouteArc는 양쪽 노선 entry 모두 보존).
+ *
+ * 모두 충족 시 windowSize = max(LOCKLESS_HOP_WINDOW_DEFAULT, |candidateIndex - effectiveHopIndex|)로
+ * 확장. 한 가지라도 미충족이면 기본 windowSize 유지.
+ *
+ * arc에 candidate가 없으면 (-1), 호출자가 어차피 isStationWithinHopWindow에서 false 반환하므로
+ * 본 helper는 -1을 받아도 안전(기본 windowSize 반환).
+ *
+ * #2373 — useStationAlarm.ts(FG)에서 shared로 추출. BG 채널(stationPipeline.ts)도 재사용해
+ * transfer-early 조기 오발사(hop-window 게이트 부재)를 차단한다. `currentHopStrategy`는
+ * 원래 route feature의 `StationProgressStrategy` 타입이었으나, shared는 features를 import할 수
+ * 없어(디렉토리 경계 룰) `'live-position' | string`으로 좁혔다 — 비교 로직(`=== 'live-position'`)은
+ * 동일하므로 FG/BG 호출부 모두 회귀 없음.
+ */
+export function computeHopWindowSize(
+  arcStations: readonly Station[],
+  route: Route,
+  effectiveHopIndex: number,
+  candidateIndex: number,
+  currentHopStrategy: string | null,
+): number {
+  // M1 게이트 1: transfer/multi-transfer route만 동적 확장 대상.
+  if (!route || route.type === 'direct') return LOCKLESS_HOP_WINDOW_DEFAULT;
+  // M3 신뢰도 게이트: live-position 실측 strategy에서는 확장 X (abnormal jump 신호).
+  if (currentHopStrategy === 'live-position') return LOCKLESS_HOP_WINDOW_DEFAULT;
+  // 인덱스 가드: candidate가 arc 밖이면 default — isStationWithinHopWindow가 어차피 false.
+  if (candidateIndex < 0 || effectiveHopIndex < 0) return LOCKLESS_HOP_WINDOW_DEFAULT;
+  /* istanbul ignore next -- 호출 시점 invariant: arcIndexOf 결과 candidate는 arc 내부.
+     effectiveHopIndex도 currentHopIndex(estimator 또는 firedAlarms inferred, 둘 다 clamp) 후
+     사용되므로 out-of-bounds 도달 불가. 방어적 가드 — 직접 호출자 추가 시 안전. */
+  if (candidateIndex >= arcStations.length || effectiveHopIndex >= arcStations.length) {
+    return LOCKLESS_HOP_WINDOW_DEFAULT;
+  }
+
+  // M1 게이트 3: effectiveHopIndex와 candidateIndex 사이 transfer crossover 감지.
+  // computeRouteArc는 환승 시 fromLine 쪽 + toLine 쪽 entry 둘 다 push하므로
+  // 인접 station이 같은 name + 다른 line이면 transfer crossover 표지다.
+  const lo = Math.min(effectiveHopIndex, candidateIndex);
+  const hi = Math.max(effectiveHopIndex, candidateIndex);
+  let crossesTransfer = false;
+  for (let i = lo; i < hi; i++) {
+    const a = arcStations[i];
+    const b = arcStations[i + 1];
+    if (isSameStationName(a.name, b.name) && a.line !== b.line) {
+      crossesTransfer = true;
+      break;
+    }
+  }
+  if (!crossesTransfer) return LOCKLESS_HOP_WINDOW_DEFAULT;
+
+  // 모든 게이트 통과 → windowSize를 격차만큼 확장.
+  const gap = hi - lo;
+  return Math.max(LOCKLESS_HOP_WINDOW_DEFAULT, gap);
+}
+
 export function isStationOnRoute(station: Station, route: NonNullable<Route>): boolean {
   if (route.type === 'direct') {
     return station.line === route.line;


### PR DESCRIPTION
## 배경

transfer-early(환승 1역 전) 알람이 14분 조기 오발사(2026-08-23, 2호선 건대입구 구간). RCA(#2180)가 확인한 근본 원인: FG(`useStationAlarm.ts`)는 `arcStations` 기반 hop-window 게이트(`computeHopWindowSize`/`isStationWithinHopWindow`)가 있어 candidate가 현재 hop 대비 과도하게 forward 점프하면 차단하지만, BG 채널(`stationPipeline.ts`)엔 대응물이 전혀 없었다 — 지하 GPS drift로 실제보다 앞선 역을 스냅하면 그대로 `remainingStops`가 줄어 phase 알람이 조기 발사됐다.

Closes #2180

## 구현 (Option A — FG 게이트를 BG로 이식, 신규 게이트 발명 아님)

1. **추출**: `computeHopWindowSize`를 `useStationAlarm.ts`(FG-private)에서 `src/shared/utils/stationRoute.ts`로 옮겨 export. `isStationWithinHopWindow`/`arcIndexOf`/`LOCKLESS_HOP_WINDOW_DEFAULT`는 이미 shared에 있었다. `currentHopStrategy` 파라미터 타입을 `route` feature의 `StationProgressStrategy`(inline `import()` type)에서 `'live-position' | string`으로 좁혀 shared→features 디렉토리 경계 위반을 회피했다 — 비교 로직(`=== 'live-position'`)은 동일해 FG 회귀 없음.
2. **BG 게이트**: `stationPipeline.ts`에 `evaluateBgHopWindowGate` 신설. `getStationsOnLine(candidateStation.line)`으로 같은 노선의 station 순서를 arcStations로 삼아(FG의 `computeRouteArc`처럼 환승 양쪽 노선을 잇지 않음 — 노선이 바뀌면 그 자체가 정상 환승 진행 신호이므로 게이트 skip 후 새 기준 채택), 직전 tick 수용 station 대비 candidate가 hop window 밖이면 phase 알람(transfer/destination) 발사를 차단한다.
3. **BG 상태 영속화**: `hopWindowState.ts` 신설. BG는 매 tick 독립 호출되는 stateless 함수라 estimator가 없다 — 직전 tick에 게이트를 통과한 station을 `destinationId`로 scoping해 AsyncStorage에 저장(`notificationState.ts`의 `LAST_NOTIFIED_STATION_KEY` 스코핑과 동일 패턴). 새 destination(=새 trip) 시작 시 자동 무효화되므로 명시적 reset 호출이 불필요하다. 차단된 tick은 기준을 덮어쓰지 않는다(drift 누적 방지).
4. `logSuppressedHopWindow`에 `kind`/`phaseId` 옵션 추가 — 기존 FG station-passed 호출부는 인자 생략 시 기본값(`'station-passed'`)으로 동일 동작, BG는 실제 phase kind로 alarmLog에 남긴다.

## 금지 사항 준수

- 신규 게이트 로직 미발명 — `computeHopWindowSize`/`isStationWithinHopWindow`를 FG와 동일하게 재사용.
- `isPlausibleJump`(50m/s) 임계값 미변경.
- FG 회귀 없음 — `useStationAlarm.test.ts` 239개 전량 pass, `stationRoute.test.ts` 전량 pass 확인.

## 테스트 (red→green)

`stationPipeline.test.ts`에 RCA #2180 재현 fixture 추가: 직전 tick 기준 대비 2 hop 앞선 candidate가 게이트 없이는(가정) 조기 발사되는 것을 구현 전 별도로 gate 로직을 주석 처리해 재현 확인 후, 게이트 적용 코드로 차단됨을 확인(green). 추가 케이스: 1 hop 이내 정상 통과+기준 갱신, 첫 tick(기준 없음) graceful skip, 노선 전환(환승 완료) skip, route 없음 skip, arc 인덱스 미발견 방어. `hopWindowState.ts` 전용 테스트(get/set/scoping/파싱실패/AsyncStorage 예외) 신규.

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass 확인(0 orphan).
2. **V/X dashboard**: 차단 시 `alarmLog`에 `reason='gate-hop-window'`, `kind`(transfer/destination), `phaseId`, `currentHopIndex`/`candidateIndex`가 남는다 — DebugModal의 alarmLog 뷰에서 관측 가능. X1(잘못된 알람)/X6(늦은/틀린 시점 알람) 수리 대상.
3. **의존 PR**: N/A — 순수 device 코드, backend/infra 의존 없음.
4. **측정 plan**: 다음 지하 탑승(2호선 등 GPS drift 취약 구간) transfer-early 조기 발사 재발 0건. alarmLog `gate-hop-window` 차단 카운트(kind=transfer/destination)를 1주 관측 — 과다 발생 시 windowSize=1이 지나치게 보수적일 가능성 있어 후속 조정 검토.
5. **Device verify**: 필요 — 지하 GPS drift 구간 실기기 탑승 검증(2호선 건대입구 등 evidence 재현 구간). type-check + unit은 게이트 로직(같은 노선 hop 거리 계산 + 상태 영속/reset)만 검증, GPS drift 실측 재현은 실기기 전용.

## 검증 결과

- `npx jest src/features/alarm/utils/__tests__/stationPipeline.test.ts src/features/alarm/utils/__tests__/hopWindowState.test.ts src/features/alarm/hooks/__tests__/useStationAlarm.test.ts src/features/alarm/utils/__tests__/alarmLog.test.ts src/shared/utils/__tests__/stationRoute.test.ts src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts` — 전량 pass(관련 커버리지 신규/변경 라인 100%, 기존 gap 미포함).
- `npm run type-check` pass.
- `npm run lint:orphan` pass (0 orphan).
- 전역 100% coverage 게이트는 CI(`Type Check & Test`)로 확인 예정.

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9