### PR TITLE
fix(#2377): 위젯 딥링크 흰화면+슬라이드 제거 — +native-intent alias로 중간 라우트 삭제

### DIFF
--- a/app/+native-intent.ts
+++ b/app/+native-intent.ts
@@ -1,0 +1,6 @@
+// 위젯 딥링크 alias — 라우터 마운트 전에 경로 재작성해 중간 리다이렉트 라우트를 제거한다.
+// subwaynow://current-station → 홈 탭 직행 (흰 화면·push 슬라이드 없음).
+export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
+  if (path === 'current-station' || path.endsWith('/current-station')) return '/';
+  return path;
+}

--- a/app/__tests__/native-intent.test.ts
+++ b/app/__tests__/native-intent.test.ts
@@ -1,0 +1,20 @@
+/**
+ * #2377: 위젯 딥링크(subwaynow://current-station)가 중간 리다이렉트 라우트 없이
+ * 라우터 마운트 전에 홈으로 재작성되는지 검증한다.
+ */
+import { redirectSystemPath } from '../+native-intent';
+
+describe('redirectSystemPath', () => {
+  it("'current-station' 경로를 홈('/')으로 재작성한다", () => {
+    expect(redirectSystemPath({ path: 'current-station', initial: true })).toBe('/');
+  });
+
+  it("'/current-station' 경로(선행 슬래시 포함)도 홈으로 재작성한다", () => {
+    expect(redirectSystemPath({ path: '/current-station', initial: false })).toBe('/');
+  });
+
+  it('그 외 경로는 그대로 통과시킨다', () => {
+    expect(redirectSystemPath({ path: '/onboarding', initial: true })).toBe('/onboarding');
+    expect(redirectSystemPath({ path: 'language', initial: false })).toBe('language');
+  });
+});

--- a/app/current-station.tsx
+++ b/app/current-station.tsx
@@ -1,7 +1,0 @@
-// expo-router route entry — 위젯 딥링크(subwaynow://current-station) alias.
-// 홈(현재 역 탭)으로 redirect. thin route 컨벤션(redirect 전용).
-import { Redirect } from 'expo-router';
-
-export default function CurrentStationRedirect() {
-  return <Redirect href="/" />;
-}

--- a/src/shared/__tests__/deeplinkRoutes.test.ts
+++ b/src/shared/__tests__/deeplinkRoutes.test.ts
@@ -2,13 +2,18 @@
  * #2303 재발 차단 가드.
  *
  * 네이티브(위젯/Live Activity)·알림 코드가 앱 커스텀 스킴(`subwaynow://...`) 딥링크
- * URL 문자열을 만들면, 그 path에 대응하는 expo-router route 파일(`app/**`)이 실재해야
- * 한다. producer(SubwayWidget.swift 등)가 새 딥링크를 추가해도 이 테스트가 자동으로
- * 스캔 대상에 포함되므로 하드코딩된 path 목록을 유지할 필요가 없다(글로벌 규칙 3).
+ * URL 문자열을 만들면, 그 path에 대응하는 expo-router route 파일(`app/**`)이 실재하거나
+ * `app/+native-intent.ts`의 `redirectSystemPath` alias로 재작성돼야 한다. producer
+ * (SubwayWidget.swift 등)가 새 딥링크를 추가해도 이 테스트가 자동으로 스캔 대상에
+ * 포함되므로 하드코딩된 path 목록을 유지할 필요가 없다(글로벌 규칙 3).
  *
  * 원본 결함(#2303): SubwayWidget.swift가 `subwaynow://current-station`을 위젯 탭 시
  * 딥링크로 방출했지만 `app/current-station.tsx` route가 없어 expo-router가
  * "Unmatched Route"를 표출했다.
+ *
+ * #2377: 중간 리다이렉트 라우트(`app/current-station.tsx`)를 거치면 흰 화면 + push
+ * 슬라이드가 발생해, 라우터 마운트 전 경로를 재작성하는 `+native-intent.ts` alias로
+ * 대체했다. 이 가드는 route 파일 부재를 다시 회귀로 오탐하지 않도록 alias도 인정한다.
  */
 import fs from 'fs';
 import path from 'path';
@@ -74,6 +79,18 @@ function routeExists(routePath: string): boolean {
   return candidates.some((candidate) => fs.existsSync(candidate));
 }
 
+/**
+ * routePath가 `app/+native-intent.ts`의 `redirectSystemPath`에서 재작성 대상으로
+ * 다뤄지는지 확인한다. 라우터 마운트 전에 경로를 재작성하는 alias이므로 route 파일이
+ * 없어도 딥링크가 유효하게 처리된다(#2377).
+ */
+function nativeIntentAliasExists(routePath: string): boolean {
+  const nativeIntentPath = path.join(ROOT, 'app', '+native-intent.ts');
+  if (!fs.existsSync(nativeIntentPath)) return false;
+  const content = fs.readFileSync(nativeIntentPath, 'utf8');
+  return content.includes(`'${routePath}'`);
+}
+
 describe('딥링크 producer ↔ expo-router route 대응 (#2303 재발 차단)', () => {
   const appScheme = readAppScheme();
   const deepLinks = extractDeepLinks(appScheme);
@@ -83,9 +100,9 @@ describe('딥링크 producer ↔ expo-router route 대응 (#2303 재발 차단)'
   });
 
   it.each(deepLinks.map((link) => [`${link.scheme}://${link.routePath} (${path.relative(ROOT, link.file)})`, link] as const))(
-    '%s → app/ route가 실재해야 한다',
+    '%s → app/ route 또는 +native-intent alias가 실재해야 한다',
     (_label, link) => {
-      expect(routeExists(link.routePath)).toBe(true);
+      expect(routeExists(link.routePath) || nativeIntentAliasExists(link.routePath)).toBe(true);
     },
   );
 });


### PR DESCRIPTION
## Summary
- `app/+native-intent.ts` 신설 — `redirectSystemPath`로 라우터 마운트 전에 `current-station` → `/` 경로 재작성
- `app/current-station.tsx` 삭제 — 중간 리다이렉트 라우트 제거 (흰 화면 + push 슬라이드 원인)
- `src/shared/__tests__/deeplinkRoutes.test.ts` 갱신 — route 파일 부재 시 `+native-intent.ts` alias도 유효로 인정하도록 가드 확장
- `app/__tests__/native-intent.test.ts` 신규 — `redirectSystemPath` 단위 테스트 (current-station/ '/current-station' → '/', 그 외 passthrough)

위젯 Swift URL(`subwaynow://current-station`)은 변경하지 않음 — JS-only, prebuild 불필요.

Part of #2303

## Wire-completion 5단
1. **Orphan**: `app/current-station.tsx` 삭제 후 참조 0 (grep 확인). `app/+native-intent.ts`는 기존 IGNORE_PATTERN의 `app/|` 항목에 이미 포함되어 별도 갱신 불필요. `npm run lint:orphan` → "No orphan exports detected."
2. **V/X dashboard**: 위젯 탭 → 홈 직행(흰 화면·슬라이드 없음) 실기기 육안 확인 필요 (코드 변경 자체는 JS 로직이라 dashboard 관측 대상 아님).
3. **의존 PR**: N/A.
4. **측정 plan**: 위젯 탭 시 전환 애니메이션 실기기 육안 관측 (cold/warm start 둘 다).
5. **Device verify**: 필요 — 위젯 cold/warm start 탭. JS 로직(`redirectSystemPath`)은 unit 테스트로 검증했으나 실제 화면 전환 애니메이션은 실기기 전용.

## Test plan
- [x] `npx jest src/shared/__tests__/deeplinkRoutes.test.ts app/__tests__/native-intent.test.ts` pass (5 tests)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [ ] 실기기: 위젯 탭 → 홈 직행 (흰 화면/슬라이드 없음) 육안 확인

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9