### PR TITLE
fix(#2379): BG pipeline device 로컬 알람 발사 복원 — 잠금 화면 알림 전멸

### DIFF
--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -10,6 +10,7 @@ import {
   buildAlarmContent,
   buildStationPassedContent,
   fireFgAuxStationPassedNotification,
+  fireLocalAlarmNotification,
 } from '../stationNotification';
 import { buildStationNotifCollapseId } from '../stationNotifCollapseId';
 import { APNS_TOKEN_KEY } from '../../../../shared/constants/storageKeys';
@@ -953,6 +954,59 @@ describe('stationNotification', () => {
     it('dismiss 실패해도 에러를 던지지 않는다', async () => {
       (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
       await expect(clearAlarmNotification()).resolves.toBeUndefined();
+    });
+  });
+
+  // #2379 (Phase 2-device 복원, #2067 되돌리기) — EXPO_PUBLIC_MINIMAL_ALARM 플래그 ON일 때 BG
+  // pipeline이 직접 발사하는 device 로컬 transfer/destination 알람 배너.
+  describe('fireLocalAlarmNotification (#2379 — #2067 sendAlarmNotification 복원)', () => {
+    const earlyDest = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
+
+    it('buildAlarmContent와 동일한 title/body로 ALARM_NOTIFICATION_ID 알림을 예약한다', async () => {
+      await fireLocalAlarmNotification(earlyDest);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identifier: 'station-alarm',
+          content: expect.objectContaining({
+            title: '하차 알림',
+            body: '다음 역 강남에서 하차하세요!',
+            sound: 'alarm.wav',
+          }),
+        }),
+      );
+    });
+
+    it('iOS에서는 interruptionLevel: timeSensitive를 부착한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      await fireLocalAlarmNotification(earlyDest);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({ interruptionLevel: 'timeSensitive' }),
+        }),
+      );
+    });
+
+    it('Android에서는 ALARM_CHANNEL_ID + MAX priority를 부착한다', async () => {
+      jest.replaceProperty(Platform, 'OS', 'android');
+      await fireLocalAlarmNotification(earlyDest);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            channelId: 'station-alarm',
+            priority: Notifications.AndroidNotificationPriority.MAX,
+          }),
+        }),
+      );
+    });
+
+    it('source가 있으면 breadcrumb에 전달한다', async () => {
+      await fireLocalAlarmNotification(earlyDest, 'positionTrain');
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('alarm', 'fire-local', {
+        type: 'destination',
+        phase: 'early',
+        station: '강남',
+        source: 'positionTrain',
+      });
     });
   });
 

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -79,9 +79,17 @@ jest.mock('../safetyNetScheduler', () => ({
 
 const mockUpdateStationNotification = jest.fn();
 const mockSendStationPassedNotification = jest.fn();
+const mockFireLocalAlarmNotification = jest.fn();
+const mockFireFgAuxStationPassedNotification = jest.fn();
 jest.mock('../stationNotification', () => ({
   updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
   sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
+  // #2379 (Phase 2-device 복원, #2067 되돌리기) — BG pipeline이 EXPO_PUBLIC_MINIMAL_ALARM ON일 때
+  // 직접 호출하는 device 로컬 발사 함수. 내부 구현은 stationNotification.test.ts가 검증하므로
+  // 여기서는 호출 여부/인자만 mock으로 assert한다.
+  fireLocalAlarmNotification: (...args: unknown[]) => mockFireLocalAlarmNotification(...args),
+  fireFgAuxStationPassedNotification: (...args: unknown[]) =>
+    mockFireFgAuxStationPassedNotification(...args),
 }));
 
 const mockGetLastNotifiedStationId = jest.fn();
@@ -174,6 +182,8 @@ describe('processLocationUpdate', () => {
     require('../crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
     mockUpdateStationNotification.mockResolvedValue(undefined);
     mockSendStationPassedNotification.mockResolvedValue(undefined);
+    mockFireLocalAlarmNotification.mockResolvedValue(undefined);
+    mockFireFgAuxStationPassedNotification.mockResolvedValue(undefined);
     mockCalculateStaticETA.mockReturnValue(10);
     mockEvaluateAlarmPhase.mockReturnValue(null);
     mockIsStationOnRoute.mockReturnValue(true);
@@ -1390,6 +1400,171 @@ describe('processLocationUpdate', () => {
       await call();
 
       expect(mockGetBgHopWindowStation).not.toHaveBeenCalled();
+    });
+  });
+
+  // #2379 (Phase 2-device 복원, #2067 되돌리기) — EXPO_PUBLIC_MINIMAL_ALARM 플래그로 BG pipeline이
+  // 잠금 화면에서도 스스로 device 로컬 알림을 발사하게 한다(#2067이 제거한 sendAlarmNotification
+  // 상당물 복원). 플래그 OFF는 기존 동작(backend push 단일 의존) 완전 불변 — 회귀 가드.
+  describe('#2379 EXPO_PUBLIC_MINIMAL_ALARM — BG device 로컬 발사 복원', () => {
+    const originalEnv = process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      } else {
+        process.env.EXPO_PUBLIC_MINIMAL_ALARM = originalEnv;
+      }
+    });
+
+    describe('플래그 OFF (기본) — 회귀 가드: device 로컬 발사 없음, 과억제 게이트 그대로 유지', () => {
+      beforeEach(() => {
+        delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      });
+
+      it('phase 알람이 fire해도 fireLocalAlarmNotification을 호출하지 않는다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+        await call();
+
+        expect(mockLogFiredAlarm).toHaveBeenCalled();
+        expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+      });
+
+      it('station-passed가 fire해도 fireFgAuxStationPassedNotification을 호출하지 않는다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+
+        await call();
+
+        expect(mockFireFgAuxStationPassedNotification).not.toHaveBeenCalled();
+      });
+
+      it('정적 사용자(movement unreliable)는 여전히 억제된다 — 과억제 게이트 우회 없음', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+        await call({ speedMps: 0.1 });
+
+        expect(mockLogSuppressedMovement).toHaveBeenCalled();
+        expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+        expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('플래그 ON — device 로컬 발사 복원 + movement 과억제 게이트 우회', () => {
+      beforeEach(() => {
+        process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+      });
+
+      it('phase 알람(transfer/destination) fire 시 fireLocalAlarmNotification을 alarmEvent와 함께 발사한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+        await call();
+
+        expect(mockLogFiredAlarm).toHaveBeenCalled();
+        expect(mockFireLocalAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, undefined);
+      });
+
+      it('station-passed fire 시 fireFgAuxStationPassedNotification을 count/targetKind/targetName과 함께 발사한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+
+        await call();
+
+        expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+          mockStation.name,
+          mockRoute.stops,
+          'destination',
+          mockDestination.name,
+        );
+      });
+
+      it('정적 사용자(movement unreliable)여도 게이트를 우회해 phase 알람을 발사한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+        await call({ speedMps: 0.1 });
+
+        expect(mockLogSuppressedMovement).not.toHaveBeenCalled();
+        expect(mockLogFiredAlarm).toHaveBeenCalled();
+        expect(mockFireLocalAlarmNotification).toHaveBeenCalled();
+      });
+
+      it('정적 사용자(movement unreliable)여도 게이트를 우회해 station-passed를 발사한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+
+        await call({ speedMps: 0.1 });
+
+        expect(mockLogSuppressedMovement).not.toHaveBeenCalled();
+        expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalled();
+      });
+
+      it('target.isTransfer === true이면 targetKind="transfer"로 발사한다 (환승 전 구간)', async () => {
+        const transferRoute = makeTransferRoute({
+          transferName: '동대문',
+          fromLine: '2',
+          toLine: '4',
+          stopsToTransfer: 2,
+          stopsFromTransfer: 3,
+        });
+        mockFindNearestStation.mockReturnValue(mockNearestResult); // station.line = '2' = fromLine
+        mockFindRoute.mockReturnValue(transferRoute);
+        mockGetBoardingLock.mockResolvedValue(null); // currentLine = nearest.station.line('2')
+
+        await call();
+
+        expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+          mockStation.name,
+          2,
+          'transfer',
+          '동대문',
+        );
+      });
+
+      it('C 유지 — sleep 첫 hop 룰은 ON에서도 여전히 phase 알람(transfer)을 억제한다', async () => {
+        const lockSleeping = {
+          destinationId: 'station-2',
+          trainCode: 'T-1',
+          boardingStationId: 'station-1',
+          boardingLine: '2' as const,
+          boardedAt: 1_700_000_000_000,
+          expectedDurationMs: 600_000,
+        };
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockGetBoardingLock.mockResolvedValue(lockSleeping);
+        mockGetFirstLeg.mockReturnValue({ line: '2', endName: '시청' });
+        mockEvaluateAlarmPhase.mockReturnValue({ phaseId: 'early', type: 'transfer', stationName: '시청' });
+
+        await call({ sleepMode: true });
+
+        expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalled();
+        expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+      });
+
+      it('C 유지 — fire-once(markStationFired dedup)는 ON에서도 중복 발사를 차단한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+        // #1515 dedup 모듈(crossCategoryStationDedup)은 mock 대상이 아니라 실제 상태를 갖는다 —
+        // 직전 tick에서 이미 같은 (station, kind) phase가 fire됐다면 cross-category dedup으로 억제.
+        mockIsStationOnRoute.mockReturnValue(false); // station-passed 분기는 이번 assert 대상 밖.
+
+        await call();
+        expect(mockFireLocalAlarmNotification).toHaveBeenCalledTimes(1);
+
+        await call();
+        // 같은 station+kind 재평가 — cross-category dedup(#1515)이 두 번째 호출을 억제한다.
+        expect(mockFireLocalAlarmNotification).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -567,6 +567,40 @@ export function buildAlarmContent(
   return { title, body: withSource };
 }
 
+/**
+ * #2379 (Phase 2-device 복원, #2067 되돌리기) — `EXPO_PUBLIC_MINIMAL_ALARM` 플래그 ON일 때
+ * BG pipeline(`stationPipeline.ts`)이 잠금 화면에서도 스스로 발사하는 device 로컬 transfer/
+ * destination 알람 배너. #2067이 제거한 `sendAlarmNotification`의 visible-알림 발사 로직을
+ * `buildAlarmContent` + `scheduleNotification` 재사용으로 복원한다(TTS/진동은 companion
+ * (`AlarmLocalAuthority`, #2067 D3)이 별도 채널로 이미 담당하므로 이 함수는 배너만 발사 — 중복
+ * 방지).
+ */
+export async function fireLocalAlarmNotification(
+  event: AlarmEvent,
+  source?: NotificationSource,
+): Promise<void> {
+  const { title, body } = buildAlarmContent(event, source);
+
+  await scheduleNotification(ALARM_NOTIFICATION_ID, {
+    title,
+    body,
+    sound: 'alarm.wav',
+    ...(Platform.OS === 'android' && {
+      channelId: ALARM_CHANNEL_ID,
+      priority: Notifications.AndroidNotificationPriority.MAX,
+    }),
+    // NOTE: critical Entitlement 승인 후 'critical'로 변경 → Sleep Focus 완전 관통
+    ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
+  });
+  notifLogger.info('로컬 알람(minimal-alarm):', title, body);
+  addDomainBreadcrumb('alarm', 'fire-local', {
+    type: event.type,
+    phase: event.phaseId,
+    station: event.stationName,
+    source,
+  });
+}
+
 export async function clearAlarmNotification(): Promise<void> {
   stopVibration();
   try {

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -10,7 +10,8 @@ import { findNearestStation } from '../../nearest-station/utils/findNearestStati
 import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition, getStationsOnLine, arcIndexOf, computeHopWindowSize, isStationWithinHopWindow } from '../../../shared/utils/stationRoute';
 import { hasConsumedOriginWait } from '../../../shared/utils/boardingWait';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
-import { updateStationNotification } from './stationNotification';
+import { updateStationNotification, fireLocalAlarmNotification, fireFgAuxStationPassedNotification } from './stationNotification';
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 import { distanceMetersBetween, estimateEtaSeconds, estimateTransitEtaSeconds } from '../../../shared/utils/stationEta';
 import { cancelSafetyNetByStationKind } from './safetyNetScheduler';
 import { getBoardingLock } from './boardingLockStorage';
@@ -392,9 +393,10 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       sleepMode,
       isFirstHop,
     });
-    if (!movementSignal.reliable) {
+    if (!movementSignal.reliable && !isMinimalAlarmEnabled()) {
       // #2204 — FG와 동일 정적 misfire 가드. destination/transfer early가 정적 사용자에게
       // 발사되던 phantom fire(뚝섬 evidence)를 차단.
+      // #2379 — EXPO_PUBLIC_MINIMAL_ALARM ON일 때는 이 과억제 게이트를 우회한다(스펙 B).
       logSuppressedMovement({
         source,
         stationName: alarmEvent.stationName,
@@ -494,6 +496,12 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       );
       // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거. 알람 배너는 원격 visible push가
       // 담당(Phase 2-backend). BG pipeline은 dedup ledger 기록 + alarmLog 적재만 수행한다.
+      // #2379 (Phase 2-device 복원, #2067 되돌리기) — 플래그 ON이면 BG가 스스로 device 로컬
+      // visible 알림을 발사한다(잠금 화면에서 backend push 단독 의존 시 화면에 아무것도 안 뜨는
+      // 회귀 대응). fire-once(markStationFired)는 위에서 이미 통과했으므로 중복 발사 없음.
+      if (isMinimalAlarmEnabled()) {
+        await fireLocalAlarmNotification(alarmEvent, notificationSource);
+      }
       logFiredAlarm(source, alarmEvent);
     }
   }
@@ -516,8 +524,9 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     // dedup(lastNotifiedStationId) 위에 위치 — sleep으로 차단되면 lastNotifiedStationId 갱신 안 함
     // → sleep OFF 토글 후 정상 첫 hop 알림이 재발사 가능.
     // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
-    if (!movementSignal.reliable) {
+    if (!movementSignal.reliable && !isMinimalAlarmEnabled()) {
       // #2204 — FG와 동일 정적 misfire 가드. 정적 사용자에게 station-passed가 발사되던 회귀 차단.
+      // #2379 — EXPO_PUBLIC_MINIMAL_ALARM ON일 때는 이 과억제 게이트를 우회한다(스펙 B).
       logSuppressedMovement({
         source,
         stationName: nearest.station.name,
@@ -605,6 +614,20 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
           // #1515 — cross-category 윈도우 갱신. category='station-passed'.
           markStationFired(destination.id, nearest.station.name, 'station-passed', Date.now());
           await setLastNotifiedStationId(destination.id, nearest.station.id);
+
+          // #2379 (Phase 2-device 복원, #2067 되돌리기) — 플래그 ON이면 BG가 스스로 device 로컬
+          // station-passed 배너를 발사한다. 기존 FG 보조 발사(`fireFgAuxStationPassedNotification`,
+          // #2122)를 재사용 — count/targetKind/targetName은 위에서 이미 계산한 target(NextTarget)의
+          // stopsToNextStation/isTransfer/nextStationName을 그대로 매핑(FG dispatchStationPassed의
+          // deriveStationPassedTarget과 동일 의미). fire-once는 위 markStationFired로 이미 보장.
+          if (isMinimalAlarmEnabled()) {
+            await fireFgAuxStationPassedNotification(
+              nearest.station.name,
+              target.stopsToNextStation,
+              target.isTransfer ? 'transfer' : 'destination',
+              target.nextStationName,
+            );
+          }
 
           // #624 → #2089 — BG-safe stale alarm 차단. 통과한 waypoint의 safety-net 사전 예약을
           // 능동 cancel(더 이상 lock 필요 없음 — safetyNetScheduler는 tripToken 기반 lockless).

--- a/src/shared/constants/__tests__/debugFlags.test.ts
+++ b/src/shared/constants/__tests__/debugFlags.test.ts
@@ -1,0 +1,28 @@
+import { isMinimalAlarmEnabled } from '../debugFlags';
+
+describe('isMinimalAlarmEnabled', () => {
+  const originalEnv = process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+    } else {
+      process.env.EXPO_PUBLIC_MINIMAL_ALARM = originalEnv;
+    }
+  });
+
+  it('EXPO_PUBLIC_MINIMAL_ALARM 미설정 시 false (기본값 — 회귀 가드)', () => {
+    delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+    expect(isMinimalAlarmEnabled()).toBe(false);
+  });
+
+  it('EXPO_PUBLIC_MINIMAL_ALARM="true"일 때 true', () => {
+    process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+    expect(isMinimalAlarmEnabled()).toBe(true);
+  });
+
+  it('EXPO_PUBLIC_MINIMAL_ALARM이 "true" 이외 값이면 false', () => {
+    process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'false';
+    expect(isMinimalAlarmEnabled()).toBe(false);
+  });
+});

--- a/src/shared/constants/debugFlags.ts
+++ b/src/shared/constants/debugFlags.ts
@@ -12,3 +12,12 @@ export function isDebugModalEnabled(): boolean {
 export const DEBUG_MODAL_TRIGGER_TAP_COUNT = 7;
 /** 탭 간격이 이 시간을 넘으면 카운트 reset — 우발적 누적 트리거 방지. */
 export const DEBUG_MODAL_TRIGGER_RESET_MS = 1500;
+
+// #2379 (Phase 2-device 복원, #2067 되돌리기) — BG pipeline(stationPipeline.ts)이 device 로컬
+// visible 알림을 직접 발사하게 하는 빌드타임 플래그. OFF(기본)면 기존 동작(backend push 단일
+// 의존) 완전 불변 — 회귀 0. ON이면 잠금 화면에서도 발사되도록 로컬 발사 경로 + 과억제 게이트
+// (movement) 우회가 활성화된다. isDebugModalEnabled와 동일 패턴 — __DEV__ 자동 활성 없이
+// env 값만으로 게이트(의도적 opt-in, 실기기 dogfood 빌드 전용).
+export function isMinimalAlarmEnabled(): boolean {
+  return process.env.EXPO_PUBLIC_MINIMAL_ALARM === 'true';
+}


### PR DESCRIPTION
## 배경

#2067(2026-07-30)이 BG pipeline(`stationPipeline.ts`)의 device 로컬 알람 발사(`sendAlarmNotification`)를 제거하고 backend visible push 단일 채널로 전환했다. 그 결과 잠금 화면에서 backend push가 실기기(sandbox 로컬 빌드)에서 표시되지 않아 알람이 전멸하는 회귀가 2026-08-24 실탑승 RCA로 확정됐다(#2379 이슈 본문).

이 PR은 `EXPO_PUBLIC_MINIMAL_ALARM` 빌드타임 플래그 뒤에서 device self-contained 발사 경로를 복원한다. 플래그 OFF(기본)면 기존 동작 완전 불변.

## #2067이 제거한 함수를 어떻게 복원했는지

`git log --all -S "sendAlarmNotification"` → `02ff688b`(#2067)에서 `stationNotification.ts`의 `sendAlarmNotification`(`buildAlarmContent` + `scheduleNotification` + vibrate/speak)이 제거된 것을 확인했다.

- **복원**: `stationNotification.ts`에 `fireLocalAlarmNotification(event, source)`을 신설 — 기존 `buildAlarmContent`(문구 조립, 이미 존재/제거 안 됨) + 파일 내부 `scheduleNotification`(비export, 재사용) 재사용. vibrate/speak는 복원하지 않음 — `AlarmLocalAuthority`(#2067 D3 companion)가 이미 별도 채널로 TTS+진동을 담당하므로 배너만 발사해 중복을 피한다(스펙 D 준수).
- **station-passed**: 새로 만들지 않고 기존 `fireFgAuxStationPassedNotification`(#2122 FG 보조 발사)를 BG 경로에서도 그대로 호출.

## 변경 사항

- `src/shared/constants/debugFlags.ts`: `isMinimalAlarmEnabled()` 추가(`isDebugModalEnabled` 패턴, `EXPO_PUBLIC_MINIMAL_ALARM==='true'`)
- `src/features/alarm/utils/stationNotification.ts`: `fireLocalAlarmNotification` 추가
- `src/features/alarm/utils/stationPipeline.ts`:
  - phase(transfer/destination) fire 지점(구 L488~497)에서 플래그 ON 시 `fireLocalAlarmNotification` 호출
  - station-passed fire 지점에서 플래그 ON 시 `fireFgAuxStationPassedNotification` 호출(count/targetKind/targetName은 기존 `NextTarget`을 그대로 매핑)
  - movement(#2204) 과억제 게이트(`!movementSignal.reliable`)를 플래그 ON일 때만 우회(`&& !isMinimalAlarmEnabled()`) — phase/station-passed 두 지점 모두
  - `gate-phase-time-integration`은 FG(`useStationAlarm.ts`) 전용 게이트라 BG(`stationPipeline.ts`)에는 애초에 없음 — 우회 대상 없음(스펙 B 조건부 문구 그대로)

## 유지(KEEP, C — 지우지 않음)

- fire-once(`markStationFired`/`lastNotifiedStationId`) — 테스트로 회귀 가드
- lockless-no-user-intent, sleep 룰(`shouldSuppressBySleepRule`) — 테스트로 회귀 가드
- passed-event-on-lock-origin — 미변경

## 금지 사항 준수

- dedup 7종 통합 범위 밖 — fire-once 그대로 유지
- FG(`useStationAlarm.ts`) 미변경
- app.config.js 관련 없음

## Wire-completion 5단

1. **Orphan**: 신규 export(`isMinimalAlarmEnabled`, `fireLocalAlarmNotification`) 모두 caller 존재. `npm run lint:orphan` → 0 orphan.
2. **V/X dashboard**: 잠금 구간에서 알람 배너 표시 여부(현재 0 → ON 시 표시)는 실기기 화면 관찰 + `alarmLog`의 `logFiredAlarm`/`logFiredStationPassed`(기존 DebugModal 알람 로그 탭)로 fire 여부 교차 확인 가능.
3. **의존 PR**: N/A (device-only, backend 무관)
4. **측정 plan**: 다음 탑승에서 `EXPO_PUBLIC_MINIMAL_ALARM=true` 로컬 빌드 → 잠금 leg에서 알람 배너 표시 여부 관찰. 표시되면 회귀 종결.
5. **Device verify**: **필요** — 잠금 화면 실기기 검증(로컬 알림은 시뮬레이터/유닛 테스트로 실제 잠금 화면 표시까지 검증 불가). type+unit은 발사 함수 호출까지만 검증.

## 검증

- 관련 테스트만 직접 실행(전체 스위트는 미실행 — 메인 세션이 CI로 전역 커버리지 확인 예정):
  - `stationPipeline.test.ts`(신규 99 tests, 플래그 ON/OFF 양쪽 + movement bypass + C유지 게이트) — 전부 pass, 파일 단독 커버리지 stationPipeline.ts 100% branches/lines/functions (statements 99.25%는 본 PR과 무관한 기존 mock 미커버 라인 1개, `for (const event of suppressed) ...` — evaluateAlarmPhase가 mock이라 이 파일 단독 실행 시 항상 도달 불가, 기존부터 존재)
  - `stationNotification.test.ts`(신규 5 tests) — pass
  - `debugFlags.test.ts`(신규 3 tests) — pass
  - `e2e.test.ts` — pass (회귀 없음 확인용 인접 파일)
  - 총 213 tests pass
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan
- **전역 커버리지(`npm test`) 미실행** — full suite watchdog stall 회피 지침에 따라 미실행. 메인 세션이 CI(`Type Check & Test`)로 확인 필요.

Closes #2379
