### PR TITLE
feat: 지하 BG 자가감지 — arvlCd BG폴링 + undergroundSSOTConsensus를 BG로

### DIFF
--- a/src/features/alarm/utils/__tests__/undergroundConsensusFire.test.ts
+++ b/src/features/alarm/utils/__tests__/undergroundConsensusFire.test.ts
@@ -1,0 +1,314 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+const mockProcessLocationUpdate = jest.fn();
+jest.mock('../stationPipeline', () => ({
+  processLocationUpdate: (...args: unknown[]) => mockProcessLocationUpdate(...args),
+}));
+
+const mockAlarmKey = jest.fn();
+jest.mock('../stationAlarm', () => ({
+  alarmKey: (...args: unknown[]) => mockAlarmKey(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+}));
+
+const mockGetFiredAlarms = jest.fn();
+const mockSetFiredAlarms = jest.fn();
+jest.mock('../notificationState', () => ({
+  getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
+  setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
+}));
+
+const mockIsMinimalAlarmEnabled = jest.fn();
+jest.mock('../../../../shared/constants/debugFlags', () => ({
+  isMinimalAlarmEnabled: () => mockIsMinimalAlarmEnabled(),
+}));
+
+const mockIsUndergroundProfile = jest.fn();
+jest.mock('../../../nearest-station/utils/bgLocationProfile', () => ({
+  isUndergroundProfile: () => mockIsUndergroundProfile(),
+}));
+
+const mockUndergroundSSOTConsensus = jest.fn();
+jest.mock('../../../nearest-station/utils/undergroundSSotConsensus', () => ({
+  undergroundSSOTConsensus: (...args: unknown[]) => mockUndergroundSSOTConsensus(...args),
+}));
+
+const mockPollUndergroundArrivalIfDue = jest.fn();
+jest.mock('../../../nearest-station/tasks/bgUndergroundArrivalPoll', () => ({
+  pollUndergroundArrivalIfDue: (...args: unknown[]) => mockPollUndergroundArrivalIfDue(...args),
+}));
+
+const mockGetCurrentWifiSsid = jest.fn();
+jest.mock('../../../nearest-station/utils/wifiSsidNative', () => ({
+  getCurrentWifiSsid: () => mockGetCurrentWifiSsid(),
+}));
+
+const mockLookupStationBySsid = jest.fn();
+jest.mock('../../../nearest-station/utils/wifiSsidLookup', () => ({
+  lookupStationBySsid: (...args: unknown[]) => mockLookupStationBySsid(...args),
+}));
+
+const mockGetLatestAccelerometerSnapshot = jest.fn();
+const mockClassifyAccelerometerPattern = jest.fn();
+jest.mock('../../../nearest-station/utils/accelerometerFingerprint', () => ({
+  getLatestAccelerometerSnapshot: () => mockGetLatestAccelerometerSnapshot(),
+  classifyAccelerometerPattern: (...args: unknown[]) => mockClassifyAccelerometerPattern(...args),
+}));
+
+const mockGetCurrentCellularTech = jest.fn();
+const mockStartCellularTechUpdates = jest.fn();
+const mockClassifyCellularEnvironment = jest.fn();
+jest.mock('../../../nearest-station/utils/cellularTech', () => ({
+  getCurrentCellularTech: () => mockGetCurrentCellularTech(),
+  startCellularTechUpdates: () => mockStartCellularTechUpdates(),
+  classifyCellularEnvironment: (...args: unknown[]) => mockClassifyCellularEnvironment(...args),
+}));
+
+const mockSaveStationToWidget = jest.fn();
+jest.mock('../../../widget/api/widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
+}));
+
+const mockBuildWidgetTripContext = jest.fn();
+jest.mock('../../../widget/utils/buildTripContext', () => ({
+  buildWidgetTripContext: (...args: unknown[]) => mockBuildWidgetTripContext(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { evaluateUndergroundConsensusFire } from '../undergroundConsensusFire';
+import {
+  DESTINATION_KEY,
+  SLEEP_MODE_KEY,
+  ROUTE_KEY,
+  ALARM_EVENT_KEY,
+  BG_LAST_STATION_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+const STATION = { id: 'S1', name: '교대', line: '2', lat: 37.1, lng: 127.1 };
+const DESTINATION = { id: 'dest-1', name: '강남', line: '2', lat: 37.2, lng: 127.2 };
+const LOCK = {
+  destinationId: 'dest-1',
+  trainCode: 'T1',
+  boardingStationId: 'S0',
+  boardingLine: '2',
+  boardedAt: 500,
+  expectedDurationMs: 100_000,
+};
+
+function mockAsyncStorageGet(map: Record<string, string | null>) {
+  mockGetItem.mockImplementation((key: string) =>
+    Promise.resolve(Object.prototype.hasOwnProperty.call(map, key) ? map[key] : null),
+  );
+}
+
+describe('evaluateUndergroundConsensusFire', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetItem.mockResolvedValue(undefined);
+    mockIsMinimalAlarmEnabled.mockReturnValue(true);
+    mockGetBoardingLock.mockResolvedValue(LOCK);
+    mockIsUndergroundProfile.mockResolvedValue(true);
+    mockGetCurrentWifiSsid.mockResolvedValue('SSID');
+    mockLookupStationBySsid.mockReturnValue(STATION);
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: 'false',
+      [ROUTE_KEY]: null,
+    });
+    mockPollUndergroundArrivalIfDue.mockResolvedValue({ up: [], down: [] });
+    mockGetCurrentCellularTech.mockReturnValue('LTE');
+    mockClassifyCellularEnvironment.mockReturnValue('underground');
+    mockGetLatestAccelerometerSnapshot.mockReturnValue(null);
+    mockClassifyAccelerometerPattern.mockReturnValue('automotive');
+    mockUndergroundSSOTConsensus.mockReturnValue({ station: STATION, trainCode: 'T1' });
+    mockGetFiredAlarms.mockResolvedValue(new Set<string>());
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockBuildWidgetTripContext.mockReturnValue({
+      currentStationName: STATION.name,
+      destinationName: DESTINATION.name,
+      tripActive: true,
+    });
+  });
+
+  it('플래그 OFF면 즉시 no-op한다', async () => {
+    mockIsMinimalAlarmEnabled.mockReturnValue(false);
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockGetBoardingLock).not.toHaveBeenCalled();
+  });
+
+  it('lock이 없으면 no-op한다', async () => {
+    mockGetBoardingLock.mockResolvedValue(null);
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockIsUndergroundProfile).not.toHaveBeenCalled();
+  });
+
+  it('profile이 underground가 아니면 no-op한다', async () => {
+    mockIsUndergroundProfile.mockResolvedValue(false);
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockGetCurrentWifiSsid).not.toHaveBeenCalled();
+  });
+
+  it('WiFi station이 미해상이면 arrival 폴링 없이 no-op한다', async () => {
+    mockLookupStationBySsid.mockReturnValue(null);
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockPollUndergroundArrivalIfDue).not.toHaveBeenCalled();
+  });
+
+  it('destination이 없으면 no-op한다', async () => {
+    mockAsyncStorageGet({ [DESTINATION_KEY]: null });
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockPollUndergroundArrivalIfDue).not.toHaveBeenCalled();
+  });
+
+  it('destination JSON 파싱 실패면 no-op한다', async () => {
+    mockAsyncStorageGet({ [DESTINATION_KEY]: 'not-json' });
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockPollUndergroundArrivalIfDue).not.toHaveBeenCalled();
+  });
+
+  it('destination에 id가 없으면 no-op한다', async () => {
+    mockAsyncStorageGet({ [DESTINATION_KEY]: JSON.stringify({ name: '강남' }) });
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockPollUndergroundArrivalIfDue).not.toHaveBeenCalled();
+  });
+
+  it('consensus가 채택 안 되면(null) processLocationUpdate를 호출하지 않는다', async () => {
+    mockUndergroundSSOTConsensus.mockReturnValue(null);
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+  });
+
+  it('consensus 채택 시 arrival 폴링 + cellular start + consensus station 좌표로 processLocationUpdate를 호출한다', async () => {
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockPollUndergroundArrivalIfDue).toHaveBeenCalledWith(STATION.name, STATION.line);
+    expect(mockStartCellularTechUpdates).toHaveBeenCalled();
+    expect(mockUndergroundSSOTConsensus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wifiStation: STATION,
+        positionTrainResult: null,
+        arrival: { up: [], down: [] },
+        cellularEnvironmentVote: 'underground',
+        accelerometerPattern: 'automotive',
+        tripStartedAt: LOCK.boardedAt,
+      }),
+    );
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lat: STATION.lat,
+        lng: STATION.lng,
+        destination: DESTINATION,
+        sleepMode: false,
+        storedRoute: null,
+        speedMps: null,
+        source: 'bg',
+        fusionSource: 'position-train',
+      }),
+    );
+  });
+
+  it('alarmEvent가 있으면 firedAlarms/ALARM_EVENT_KEY를 갱신한다', async () => {
+    const alarmEvent = { type: 'destination', stationName: '강남', phaseId: 'imminent' };
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent, nearest: null });
+    mockAlarmKey.mockReturnValue('imminent:강남');
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', expect.any(Set));
+    expect(mockSetItem).toHaveBeenCalledWith(ALARM_EVENT_KEY, JSON.stringify(alarmEvent));
+  });
+
+  it('nearest가 있으면 BG_LAST_STATION_KEY 및 위젯을 갱신한다', async () => {
+    mockProcessLocationUpdate.mockResolvedValue({
+      alarmEvent: null,
+      nearest: { station: STATION, distanceKm: 0 },
+    });
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockSetItem).toHaveBeenCalledWith(
+      BG_LAST_STATION_KEY,
+      expect.stringContaining(STATION.id),
+    );
+    expect(mockBuildWidgetTripContext).toHaveBeenCalledWith(
+      expect.objectContaining({ destination: DESTINATION, currentStation: STATION, route: null }),
+    );
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(STATION, 0, undefined, undefined, {
+      currentStationName: STATION.name,
+      destinationName: DESTINATION.name,
+      tripActive: true,
+    });
+  });
+
+  it('sleepMode/route JSON이 저장돼 있으면 파싱해 전달한다', async () => {
+    const route = { type: 'direct', stops: 3 };
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: 'true',
+      [ROUTE_KEY]: JSON.stringify(route),
+    });
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ sleepMode: true, storedRoute: route }),
+    );
+  });
+
+  it('sleepJson이 저장되지 않았으면 sleepMode=false로 기본 처리한다', async () => {
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: null,
+      [ROUTE_KEY]: null,
+    });
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ sleepMode: false }),
+    );
+  });
+
+  it('WiFi lookup이 예외를 던지면 graceful하게 null 취급한다', async () => {
+    mockGetCurrentWifiSsid.mockRejectedValue(new Error('native fail'));
+    mockLookupStationBySsid.mockImplementation((ssid: string | null) => (ssid ? STATION : null));
+
+    await evaluateUndergroundConsensusFire();
+
+    expect(mockLookupStationBySsid).toHaveBeenCalledWith(null);
+    expect(mockPollUndergroundArrivalIfDue).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/utils/undergroundConsensusFire.ts
+++ b/src/features/alarm/utils/undergroundConsensusFire.ts
@@ -1,0 +1,169 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: stationPipeline.ts / backgroundLocationTask.ts와 동일하게 여러
+ * features(nearest-station/widget)의 util을 조합하는 orchestrator다. Phase 5 enforce 모드에서
+ * file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { processLocationUpdate } from './stationPipeline';
+import { alarmKey } from './stationAlarm';
+import { getBoardingLock } from './boardingLockStorage';
+import { getFiredAlarms, setFiredAlarms } from './notificationState';
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
+import { isUndergroundProfile } from '../../nearest-station/utils/bgLocationProfile';
+import { undergroundSSOTConsensus } from '../../nearest-station/utils/undergroundSSotConsensus';
+import { pollUndergroundArrivalIfDue } from '../../nearest-station/tasks/bgUndergroundArrivalPoll';
+import { getCurrentWifiSsid } from '../../nearest-station/utils/wifiSsidNative';
+import { lookupStationBySsid } from '../../nearest-station/utils/wifiSsidLookup';
+import {
+  getLatestAccelerometerSnapshot,
+  classifyAccelerometerPattern,
+} from '../../nearest-station/utils/accelerometerFingerprint';
+import {
+  getCurrentCellularTech,
+  startCellularTechUpdates,
+  classifyCellularEnvironment,
+} from '../../nearest-station/utils/cellularTech';
+import { saveStationToWidget } from '../../widget/api/widgetStorage';
+import { buildWidgetTripContext } from '../../widget/utils/buildTripContext';
+import {
+  DESTINATION_KEY,
+  SLEEP_MODE_KEY,
+  ROUTE_KEY,
+  ALARM_EVENT_KEY,
+  BG_LAST_STATION_KEY,
+} from '../../../shared/constants/storageKeys';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('UndergroundConsensusFire');
+
+/**
+ * #2381 — 지하(GPS dead) BG 자가감지. `backgroundLocationTask.ts`의 gate-accuracy 연속 실패 →
+ * 'underground' profile 강등(#2345) + BoardingLock 존재(탑승 line 확정) tick에서만 진입한다.
+ *
+ * WiFi SSID로 candidate station을 얻고(BG에서 nil이 흔하지만 기존 position-upload 경로와 동일
+ * 패턴으로 시도 — 새 신호 아님), 그 station의 arvlCd(Gap A, `bgUndergroundArrivalPoll`) +
+ * accelerometer + cellular 환경 vote를 `undergroundSSOTConsensus`(FG `useFusedNearestStation`과
+ * 동일 순수 util, Gap B)로 평가한다. 채택되면 기존 `processLocationUpdate`(stationPipeline)에
+ * 그 station 좌표를 흘려 기존 검증된 fire-once/sleep/dedup 게이트를 그대로 통과시킨다 —
+ * 새 발사 로직 발명 없음.
+ *
+ * **스펙 편차 (issue #2381 대비)**: 이슈 본문은 "탑승 line 다음 waypoint 역" arrival 폴링을
+ * 제안했으나, `undergroundSSOTConsensus`(FG와 동일 계약)는 arrival이 candidate station과
+ * 동일 station이어야 station-pair가 성립한다(`findStationaryTrain(arrival, candidate.line)`) —
+ * 아직 도달하지 않은 역의 arrival로는 candidate를 형성할 수 없고, BG는 positionTrainResult
+ * (GPS 기반 fusion)도 없어 대체 후보가 없다. 따라서 폴링 대상을 WiFi 후보 station으로 조정 —
+ * WiFi 미해상 tick은 폴링 자체를 skip한다(quota 보호, "조건부 폴링" 의도는 보존).
+ * 대안(route 다음 waypoint를 candidate로 승격)은 GPS 없는 dead-reckoning 추정이라
+ * ADR-015 §5(GPS input reject) 정신에 위배될 소지가 있어 배제했다.
+ *
+ * BG task는 alarmEvent/nearest 후처리(firedAlarms bookkeeping, BG_LAST_STATION_KEY, 위젯 저장)를
+ * `backgroundLocationTask.ts` 안에서 GPS 경로와 별도로 수행한다 — 그 로직을 그대로 재사용하지
+ * 않고 여기서 다시 수행하는 이유는 이 함수가 GPS 좌표 없이(consensus station 좌표로) 완결된
+ * 독립 경로이기 때문(surgical: 기존 GPS 경로 코드를 건드리지 않는다).
+ *
+ * 반환 없음(void) — 게이트 미충족/consensus 미채택은 조용히 no-op, 호출자(backgroundLocationTask)는
+ * 항상 `return`으로 이번 tick을 마친다(GPS 좌표가 무효하므로 GPS 경로로 fall through하지 않음).
+ */
+export async function evaluateUndergroundConsensusFire(): Promise<void> {
+  if (!isMinimalAlarmEnabled()) return;
+
+  const lock = await getBoardingLock();
+  if (!lock) return;
+
+  const underground = await isUndergroundProfile();
+  if (!underground) return;
+
+  const wifiSsid = await getCurrentWifiSsid().catch(() => null);
+  const wifiStation = lookupStationBySsid(wifiSsid);
+  if (!wifiStation) return;
+
+  const destJson = await AsyncStorage.getItem(DESTINATION_KEY);
+  if (!destJson) return;
+
+  let destinationRaw: unknown;
+  try {
+    destinationRaw = JSON.parse(destJson);
+  } catch {
+    logger.error('목적지 JSON 파싱 실패');
+    return;
+  }
+  if (
+    !destinationRaw ||
+    typeof destinationRaw !== 'object' ||
+    typeof (destinationRaw as { id?: unknown }).id !== 'string'
+  ) {
+    logger.error('목적지에 id가 없음');
+    return;
+  }
+  const destination = destinationRaw as Station;
+
+  const [sleepJson, routeJson] = await Promise.all([
+    AsyncStorage.getItem(SLEEP_MODE_KEY),
+    AsyncStorage.getItem(ROUTE_KEY),
+  ]);
+  const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
+  const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
+
+  const arrival = await pollUndergroundArrivalIfDue(wifiStation.name, wifiStation.line);
+
+  // #1542 (ADR-016 S9) 패턴 재사용 — cellular listener도 idempotent 시작 보장 (native module
+  // 내부 가드, 미지원/실패는 graceful null).
+  startCellularTechUpdates();
+  const cellularEnvironmentVote = classifyCellularEnvironment(getCurrentCellularTech());
+  const accelerometerPattern = classifyAccelerometerPattern(getLatestAccelerometerSnapshot());
+
+  const consensus = undergroundSSOTConsensus({
+    wifiStation,
+    // BG는 GPS 기반 candidate-train fusion(trackTrainProgress)이 없어 positionTrainResult 부재.
+    // WiFi station pair 단독 + env vote(cellular/accel)로 quorum 평가(보수적 — PR 본문 명시).
+    positionTrainResult: null,
+    arrival,
+    cellularEnvironmentVote,
+    accelerometerPattern,
+    tripStartedAt: lock.boardedAt,
+  });
+  if (!consensus) return;
+
+  const firedAlarms = await getFiredAlarms(destination.id);
+  const { alarmEvent, nearest } = await processLocationUpdate({
+    lat: consensus.station.lat,
+    lng: consensus.station.lng,
+    destination,
+    firedAlarms,
+    sleepMode,
+    storedRoute,
+    speedMps: null,
+    source: 'bg',
+    // #327 — consensus로 채택된 station은 GPS가 아닌 train 데이터 기반 확정.
+    fusionSource: 'position-train',
+  });
+
+  if (alarmEvent) {
+    firedAlarms.add(alarmKey(alarmEvent));
+    await Promise.all([
+      setFiredAlarms(destination.id, firedAlarms),
+      AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
+    ]);
+  }
+
+  if (nearest) {
+    await AsyncStorage.setItem(
+      BG_LAST_STATION_KEY,
+      JSON.stringify({
+        station: nearest.station,
+        distanceKm: nearest.distanceKm,
+        timestamp: Date.now(),
+      }),
+    );
+    const tripContext = buildWidgetTripContext({
+      destination,
+      currentStation: nearest.station,
+      route: storedRoute,
+    });
+    await saveStationToWidget(nearest.station, nearest.distanceKm, undefined, undefined, tripContext);
+  }
+}

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -119,6 +119,18 @@ jest.mock('../../../alarm/utils/tripDeathPullBackstop', () => ({
   checkTripDeathByPull: (...args: unknown[]) => mockCheckTripDeathByPull(...args),
 }));
 
+// ── #2381 지하 BG 자가감지 게이트 모킹 — 내부 판정은 undergroundConsensusFire.test.ts 전담,
+// 여기서는 backgroundLocationTask가 올바른 조건(플래그 ON)에서만 호출하는지만 검증 ──
+const mockIsMinimalAlarmEnabled = jest.fn<boolean, []>(() => false);
+jest.mock('../../../../shared/constants/debugFlags', () => ({
+  isMinimalAlarmEnabled: () => mockIsMinimalAlarmEnabled(),
+}));
+const mockEvaluateUndergroundConsensusFire = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../alarm/utils/undergroundConsensusFire', () => ({
+  evaluateUndergroundConsensusFire: (...args: unknown[]) =>
+    mockEvaluateUndergroundConsensusFire(...args),
+}));
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AlarmEvent } from '../../../../shared/types/alarm';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
@@ -230,6 +242,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockApplyBgLocationProfile.mockResolvedValue(undefined);
     mockDemoteToUndergroundIfNeeded.mockResolvedValue(undefined);
     mockReleaseFromUndergroundIfNeeded.mockResolvedValue(false);
+    // #2381 — 기본: 플래그 OFF(현행 유지). 개별 테스트에서 override.
+    mockIsMinimalAlarmEnabled.mockReturnValue(false);
+    mockEvaluateUndergroundConsensusFire.mockResolvedValue(undefined);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -585,6 +600,46 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     const accuracy = MAX_ACCURACY_M + 50;
 
     await expect(runWithLocation(makeLocation(37.498, 127.028, { accuracy }))).resolves.toBeUndefined();
+  });
+
+  // #2381 (Gap A+B) — 지하 BG 자가감지 게이트. 상세 판정 로직은 undergroundConsensusFire.test.ts
+  // 전담, 여기서는 backgroundLocationTask가 플래그 상태에 따라 올바르게 호출/미호출하는지만 검증.
+  describe('#2381 — 지하 consensus 자가감지 게이트 (EXPO_PUBLIC_MINIMAL_ALARM)', () => {
+    const accuracy = MAX_ACCURACY_M + 50;
+
+    it('플래그 OFF면 evaluateUndergroundConsensusFire를 호출하지 않는다(현행 완전 불변)', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(false);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy }));
+
+      expect(mockEvaluateUndergroundConsensusFire).not.toHaveBeenCalled();
+    });
+
+    it('플래그 ON이면 gate-accuracy tick에서 evaluateUndergroundConsensusFire를 호출한다', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy }));
+
+      expect(mockEvaluateUndergroundConsensusFire).toHaveBeenCalledTimes(1);
+    });
+
+    it('플래그 ON + evaluateUndergroundConsensusFire가 reject해도 태스크는 크래시하지 않는다 (graceful)', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockEvaluateUndergroundConsensusFire.mockRejectedValueOnce(new Error('consensus failed'));
+
+      await expect(
+        runWithLocation(makeLocation(37.498, 127.028, { accuracy })),
+      ).resolves.toBeUndefined();
+    });
+
+    it('accuracy 게이트를 통과하는 정상 tick에서는 호출하지 않는다(gate-accuracy 실패 전용)', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockStorageValues(null);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: MAX_ACCURACY_M - 1 }));
+
+      expect(mockEvaluateUndergroundConsensusFire).not.toHaveBeenCalled();
+    });
   });
 
   // ── #527 jump gate: trip 컨텍스트(destJson 통과) 이후에만 동작 ──

--- a/src/features/nearest-station/tasks/__tests__/bgUndergroundArrivalPoll.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/bgUndergroundArrivalPoll.test.ts
@@ -1,0 +1,207 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+const mockGetArrival = jest.fn();
+const mockCreateArrivalProvider = jest.fn<{ getArrival: jest.Mock }, []>(() => ({
+  getArrival: mockGetArrival,
+}));
+jest.mock('../../../arrival/providers/factory', () => ({
+  createArrivalProvider: () => mockCreateArrivalProvider(),
+}));
+
+import {
+  pollUndergroundArrivalIfDue,
+  BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS,
+  __resetBgUndergroundArrivalPollForTests,
+} from '../bgUndergroundArrivalPoll';
+import {
+  BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY,
+  BG_UNDERGROUND_ARRIVAL_CACHE_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+const NOW = 1_000_000;
+
+describe('pollUndergroundArrivalIfDue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetBgUndergroundArrivalPollForTests();
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+  });
+
+  it('첫 폴링(타임스탬프 없음)은 즉시 fetch하고 캐시에 저장한다', async () => {
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(mockGetArrival).toHaveBeenCalledWith('교대', { lineHint: '2' });
+    expect(mockSetItem).toHaveBeenCalledWith(BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY, String(NOW));
+    expect(mockSetItem).toHaveBeenCalledWith(BG_UNDERGROUND_ARRIVAL_CACHE_KEY, JSON.stringify(arrival));
+    expect(result).toEqual(arrival);
+  });
+
+  it('최소 간격 미경과면 fetch 없이 캐시를 반환한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY) return Promise.resolve(String(NOW));
+      if (key === BG_UNDERGROUND_ARRIVAL_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify({ up: [], down: [] }));
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await pollUndergroundArrivalIfDue(
+      '교대',
+      '2',
+      NOW + BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS - 1,
+    );
+
+    expect(mockGetArrival).not.toHaveBeenCalled();
+    expect(result).toEqual({ up: [], down: [] });
+  });
+
+  it('최소 간격 미경과 + 캐시 없음이면 null을 반환한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY) return Promise.resolve(String(NOW));
+      return Promise.resolve(null);
+    });
+
+    const result = await pollUndergroundArrivalIfDue(
+      '교대',
+      '2',
+      NOW + BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS - 1,
+    );
+
+    expect(mockGetArrival).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('최소 간격 경과 시 다시 fetch한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY) return Promise.resolve(String(NOW));
+      return Promise.resolve(null);
+    });
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollUndergroundArrivalIfDue(
+      '교대',
+      '2',
+      NOW + BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS,
+    );
+
+    expect(mockGetArrival).toHaveBeenCalled();
+    expect(result).toEqual(arrival);
+  });
+
+  it('저장된 타임스탬프가 NaN이면(손상) 즉시 due로 처리한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY) return Promise.resolve('not-a-number');
+      return Promise.resolve(null);
+    });
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(mockGetArrival).toHaveBeenCalled();
+    expect(result).toEqual(arrival);
+  });
+
+  it('fetch 결과가 mock이면 캐시를 갱신하지 않고 기존 캐시를 반환한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify({ up: [], down: [], isMock: false, cached: true }));
+      }
+      return Promise.resolve(null);
+    });
+    mockGetArrival.mockResolvedValue({ up: [], down: [], isMock: true });
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(mockSetItem).not.toHaveBeenCalledWith(
+      BG_UNDERGROUND_ARRIVAL_CACHE_KEY,
+      expect.anything(),
+    );
+    expect(result).toEqual({ up: [], down: [], isMock: false, cached: true });
+  });
+
+  it('fetch 실패 시 캐시로 graceful fallback한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify({ up: [], down: [], cached: true }));
+      }
+      return Promise.resolve(null);
+    });
+    mockGetArrival.mockRejectedValue(new Error('network'));
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(result).toEqual({ up: [], down: [], cached: true });
+  });
+
+  it('캐시 파싱 실패 시 null을 반환한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_CACHE_KEY) return Promise.resolve('not-json');
+      return Promise.resolve(null);
+    });
+    mockGetArrival.mockRejectedValue(new Error('network'));
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(result).toBeNull();
+  });
+
+  it('폴링 시각 조회 실패(AsyncStorage getItem reject)도 due로 graceful 처리한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY) return Promise.reject(new Error('boom'));
+      return Promise.resolve(null);
+    });
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(result).toEqual(arrival);
+  });
+
+  it('폴링 시각 저장 실패도 graceful하게 fetch를 계속 진행한다', async () => {
+    mockSetItem.mockImplementation((key: string) => {
+      if (key === BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY) return Promise.reject(new Error('boom'));
+      return Promise.resolve(undefined);
+    });
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2', NOW);
+
+    expect(result).toEqual(arrival);
+  });
+
+  it('now 인자 미전달 시 Date.now() 기본값으로 동작한다', async () => {
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollUndergroundArrivalIfDue('교대', '2');
+
+    expect(mockGetArrival).toHaveBeenCalledWith('교대', { lineHint: '2' });
+    expect(result).toEqual(arrival);
+  });
+
+  it('provider는 모듈 스코프에서 재사용된다(재생성 없음)', async () => {
+    mockGetArrival.mockResolvedValue({ up: [], down: [], isMock: false });
+
+    await pollUndergroundArrivalIfDue('교대', '2', NOW);
+    await pollUndergroundArrivalIfDue(
+      '교대',
+      '2',
+      NOW + BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS,
+    );
+
+    expect(mockCreateArrivalProvider).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -51,6 +51,10 @@ import { lookupStationBySsid } from '../utils/wifiSsidLookup';
 // 편승해 저빈도(내부 쿨다운)로 backend trip status를 확인한다. alarm 슬라이스 cross-feature
 // import는 본 파일 헤더 file-level disable로 이미 옵트인.
 import { checkTripDeathByPull, getBackendUrl as getTripDeathPullBackendUrl } from '../../alarm/utils/tripDeathPullBackstop';
+// #2381 (Gap A+B) — 지하(GPS dead) BG 자가감지. gate-accuracy 연속 실패로 'underground'
+// profile 강등 + lock 존재 tick에서 arvlCd+accel+cellular consensus로 device가 스스로 판정·발사.
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
+import { evaluateUndergroundConsensusFire } from '../../alarm/utils/undergroundConsensusFire';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -163,6 +167,17 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     void demoteToUndergroundIfNeeded(BACKGROUND_LOCATION_TASK).catch((e: unknown) => {
       logger.warn('underground 강등 처리 실패 (graceful)', e);
     });
+    // #2381 (Gap A+B) — GPS 좌표가 무효한 이 tick에서, 지하(profile='underground')+lock
+    // 조건이면 arvlCd+accel+cellular consensus로 device가 스스로 역 통과를 판정해 발사한다.
+    // 플래그 OFF(기본값)면 evaluateUndergroundConsensusFire 내부 첫 줄에서 즉시 no-op —
+    // 아래 조건 자체를 생략해 플래그 OFF 경로를 완전히 그대로 유지한다.
+    if (isMinimalAlarmEnabled()) {
+      try {
+        await evaluateUndergroundConsensusFire();
+      } catch (e) {
+        logger.warn('지하 consensus 처리 실패 (graceful)', e);
+      }
+    }
     return;
   }
 

--- a/src/features/nearest-station/tasks/bgUndergroundArrivalPoll.ts
+++ b/src/features/nearest-station/tasks/bgUndergroundArrivalPoll.ts
@@ -1,0 +1,92 @@
+/**
+ * #2381 (Gap A) — BG 지하 arvlCd 폴링. `backgroundLocationTask.ts:319`가 의도적으로 제외한
+ * BG arrival 폴링 gap을 지하+lock 조건부로만 메운다(always-on 폴링 금지 — OS quota 보호).
+ *
+ * 호출자(`undergroundConsensusFire.ts`)가 지하(underground profile)+BoardingLock 존재 게이트를
+ * 이미 통과한 tick에서만 호출한다 — 본 모듈 자체는 그 게이트를 걸지 않는다(단일 책임: 폴링
+ * 주기 관리 + graceful fetch만).
+ *
+ * Provider는 `createArrivalProvider()`(순수 fetch, `useArrivalInfo`와 동일 factory)를 그대로
+ * 재사용 — 새 fetch 로직 발명 없음. 모듈 스코프 provider 싱글톤은 `useArrivalInfo.ts`의
+ * `prefetchProvider` 패턴과 동일.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createArrivalProvider } from '../../arrival/providers/factory';
+import type { ArrivalProvider } from '../../arrival/providers/types';
+import type { StationArrival } from '../../../shared/types/arrival';
+import type { LineNumber } from '../../../shared/types/station';
+import {
+  BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY,
+  BG_UNDERGROUND_ARRIVAL_CACHE_KEY,
+} from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('BgUndergroundArrivalPoll');
+
+/**
+ * 최소 폴링 간격 — 스펙 20~30s 범위의 중간값. `POSITION_UPLOAD_MIN_INTERVAL_MS`와 동일하게
+ * AsyncStorage 타임스탬프 쿨다운으로 강제한다(TaskManager invocation마다 새 컨텍스트라
+ * in-memory ref 불가 — `readBgLastPositionUploadAt`와 동일 패턴).
+ */
+export const BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS = 25_000;
+
+let arrivalProvider: ArrivalProvider | null = null;
+function getProvider(): ArrivalProvider {
+  if (!arrivalProvider) arrivalProvider = createArrivalProvider();
+  return arrivalProvider;
+}
+
+/** 테스트 격리용 — 본 모듈 사용처 외에는 호출하지 말 것. */
+export function __resetBgUndergroundArrivalPollForTests(): void {
+  arrivalProvider = null;
+}
+
+async function readCachedArrival(): Promise<StationArrival | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_UNDERGROUND_ARRIVAL_CACHE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as StationArrival;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 지하 candidate station(WiFi 매칭 대상)의 arvlCd를 조건부 폴링한다.
+ * - 최소 간격 미경과: 네트워크 호출 없이 직전 캐시 반환(quota 보호).
+ * - fetch 성공(mock 아님): 캐시 갱신 + 결과 반환.
+ * - fetch 성공(mock) 또는 실패: 캐시 fallback(graceful) — undergroundSSOTConsensus는 arrival이
+ *   null이어도 다른 신호(cellular/accel)로 계속 평가 가능하므로 실패가 전체 파이프라인을 막지 않는다.
+ * - 폴링 시각은 fetch 시도 직전에 먼저 기록한다 — 실패해도 쿨다운이 적용돼 연속 실패 tick마다
+ *   재시도로 quota를 소진하지 않는다.
+ */
+export async function pollUndergroundArrivalIfDue(
+  stationName: string,
+  lineHint: LineNumber,
+  now: number = Date.now(),
+): Promise<StationArrival | null> {
+  const lastPolledRaw = await AsyncStorage.getItem(BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY).catch(
+    () => null,
+  );
+  const lastPolled = lastPolledRaw ? Number(lastPolledRaw) : null;
+  const isDue =
+    lastPolled === null || !Number.isFinite(lastPolled) ||
+    now - lastPolled >= BG_UNDERGROUND_ARRIVAL_POLL_MIN_INTERVAL_MS;
+  if (!isDue) return readCachedArrival();
+
+  try {
+    await AsyncStorage.setItem(BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY, String(now));
+  } catch (e) {
+    logger.warn('지하 arrival 폴링 타임스탬프 저장 실패 (graceful)', e);
+  }
+
+  try {
+    const data = await getProvider().getArrival(stationName, { lineHint });
+    if (data.isMock) return readCachedArrival();
+    await AsyncStorage.setItem(BG_UNDERGROUND_ARRIVAL_CACHE_KEY, JSON.stringify(data));
+    return data;
+  } catch (e) {
+    logger.warn('지하 arrival 폴링 실패 (graceful, 캐시 fallback)', e);
+    return readCachedArrival();
+  }
+}

--- a/src/features/nearest-station/utils/__tests__/bgLocationProfile.test.ts
+++ b/src/features/nearest-station/utils/__tests__/bgLocationProfile.test.ts
@@ -30,6 +30,7 @@ import {
   demoteToUndergroundIfNeeded,
   releaseFromUndergroundIfNeeded,
   resetUndergroundFailCount,
+  isUndergroundProfile,
 } from '../bgLocationProfile';
 import {
   BG_LOCATION_PROFILE_KEY,
@@ -355,6 +356,24 @@ describe('bgLocationProfile', () => {
       mockSetItem.mockRejectedValue(new Error('fail'));
 
       await expect(resetUndergroundFailCount()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isUndergroundProfile', () => {
+    it('저장된 profile이 underground면 true를 반환한다', async () => {
+      mockGetItem.mockImplementation((key: string) =>
+        key === BG_LOCATION_PROFILE_KEY ? Promise.resolve('underground') : Promise.resolve(null),
+      );
+
+      await expect(isUndergroundProfile()).resolves.toBe(true);
+    });
+
+    it('저장된 profile이 surface/stationary/부재면 false를 반환한다', async () => {
+      mockGetItem.mockImplementation((key: string) =>
+        key === BG_LOCATION_PROFILE_KEY ? Promise.resolve('stationary') : Promise.resolve(null),
+      );
+
+      await expect(isUndergroundProfile()).resolves.toBe(false);
     });
   });
 });

--- a/src/features/nearest-station/utils/bgLocationProfile.ts
+++ b/src/features/nearest-station/utils/bgLocationProfile.ts
@@ -92,6 +92,15 @@ async function readCurrentProfile(): Promise<BgLocationProfile> {
   }
 }
 
+/**
+ * #2381 — 현재 영속 profile이 'underground'(gate-accuracy 연속 실패로 강등된 상태)인지 조회.
+ * BG 지하 arrival 폴링/consensus 진입 게이트 판정용 — readCurrentProfile을 그대로 재사용해
+ * profile 판정 로직을 이원화하지 않는다.
+ */
+export async function isUndergroundProfile(): Promise<boolean> {
+  return (await readCurrentProfile()) === 'underground';
+}
+
 async function bumpFlipCount(): Promise<number> {
   try {
     const raw = await AsyncStorage.getItem(BG_LOCATION_PROFILE_FLIP_COUNT_KEY);

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -272,3 +272,11 @@ export const BG_FOREGROUND_SERVICE_TEXT_KEY = 'subway-now:bg-foreground-service-
 // AsyncStorage로 invocation 간 상태를 공유한다(BG_LOCATION_PROFILE_KEY와 동일 패턴).
 // 형식: 숫자 문자열. 키 부재 = 0.
 export const BG_UNDERGROUND_FAIL_COUNT_KEY = 'subway-now:bg-underground-fail-count';
+// #2381 — 지하 BG arvlCd 폴링 최소 간격 가드용 마지막 폴링 시각(epoch ms). BG_LAST_POSITION_UPLOAD_AT_KEY와
+// 동일 패턴 — TaskManager invocation 간 쿨다운 상태를 AsyncStorage로 공유한다.
+// 형식: 숫자 문자열. 키 부재 = 첫 폴링(즉시 fetch).
+export const BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY = 'subway-now:bg-underground-arrival-polled-at';
+// #2381 — 지하 BG arvlCd 폴링 결과 캐시. 최소 간격 미경과 tick 또는 fetch 실패 시 이 캐시를
+// undergroundSSOTConsensus 입력으로 재사용(quota 보호 + graceful fallback).
+// 형식: StationArrival JSON. 키 부재 = 캐시 없음(null).
+export const BG_UNDERGROUND_ARRIVAL_CACHE_KEY = 'subway-now:bg-underground-arrival-cache';


### PR DESCRIPTION
Closes #2381

## 요약

지하(GPS dead)에서 device가 BG로 스스로 역을 감지 → #2380 `fireLocalAlarmNotification`으로 로컬 발사. 이슈가 지적한 2개 gap을 메웠다.

1. **Gap A** — `bgUndergroundArrivalPoll.ts`: 지하(profile='underground')+BoardingLock 존재(탑승 line 확정) tick에서만 arvlCd를 폴링한다. 최소 간격 25s(20~30s 범위) AsyncStorage 쿨다운으로 quota를 보호하고, 실패/mock 응답은 직전 캐시로 graceful fallback한다. always-on 폴링 없음 — 지상 복귀 시 게이트가 즉시 막아 폴링이 멈춘다.
2. **Gap B** — `undergroundConsensusFire.ts`: WiFi SSID로 candidate station을 얻고(기존 `backgroundLocationTask.ts`의 position-upload 경로와 동일한 `getCurrentWifiSsid`+`lookupStationBySsid` 재사용), 그 station의 arvlCd(Gap A) + accelerometer + cellular 환경 vote로 **기존 검증된 순수 util** `undergroundSSOTConsensus`(FG `useFusedNearestStation`과 동일 계약)를 평가한다. 채택되면 그 station 좌표를 기존 `processLocationUpdate`(stationPipeline)에 흘려 **이미 검증된 fire-once/sleep/dedup 게이트를 그대로 재사용**해 발사한다 — 새 발사 로직 발명 없음.

전부 `EXPO_PUBLIC_MINIMAL_ALARM` 플래그(#2379/#2380 재사용) 뒤에 게이트. OFF(기본값)면 `evaluateUndergroundConsensusFire`가 첫 줄에서 즉시 no-op하고, `backgroundLocationTask.ts`의 신규 분기 자체가 진입하지 않아 기존 GPS 경로는 완전히 불변이다.

## 설계 판단 — 스펙 편차 및 근거

이슈 본문은 "탑승 line 다음 waypoint 역" arrival 폴링을 제안했으나, 구현 전 조사에서 `undergroundSSOTConsensus`(및 FG `useFusedNearestStation.ts:1263~1289`의 실제 호출 방식)를 확인한 결과 **arrival은 candidate station(WiFi/position 매칭 대상)과 동일한 station이어야 station-pair가 성립**한다(`findStationaryTrain(arrival, candidate.line)` — "그 station의 arrival이 정착 열차를 보고하는가"를 확인하는 구조). 아직 도달하지 않은 "다음 waypoint"의 arrival로는 candidate 자체를 만들 수 없고, BG는 `positionTrainResult`(GPS 기반 열차-arc fusion)도 없어 대체 후보가 없다.

**대안 검토**:
- (채택) WiFi 후보 station을 폴링 대상으로 조정 — 기존 검증된 util 계약을 그대로 따름, 새 로직 없음. WiFi 미해상(BG에서 흔함) tick은 폴링 자체 skip.
- (배제) route 다음 waypoint를 candidate로 승격 — GPS 없는 dead-reckoning 추정이라 ADR-015 §5(GPS input reject) 정신 위배 소지.
- (배제) `undergroundSSOTConsensus`/`weightedVoteFusion`에 "미도달 waypoint" 후보 타입 신규 추가 — 검증된 fusion 알고리즘 변경은 이 PR 범위를 넘는 근본 재설계.

보수적으로 WiFi 단독 station-pair(+ env vote 2종)로 quorum을 채우는 경로만 구현했다. `positionTrainResult`는 항상 `null`로 전달 — BG에 GPS 기반 fusion이 없으므로 이 신호는 이 PR에서 미도입(향후 별도 이슈 후보).

## Wire-completion 5단

1. **Orphan** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal fusion tier에 `fusionSource: 'position-train'`으로 노출(#327 라벨 매핑). 신규 arrival 폴링/consensus 자체는 별도 UI 노출 없음 — alarmLog(`logFiredAlarm`/`logSuppressed*`)를 통해 기존 alarmLog 경로로 관측 가능(wrangler tail/Cloudflare Dashboard 대상 아님, device-local).
3. **의존 PR** — #2380(`fireLocalAlarmNotification`) 이미 dev에 머지됨(선행 완료).
4. **측정 plan** — 지하 탑승 시나리오에서 `undergroundConsensusFire` 진입/consensus 채택/발사 여부를 alarmLog(`logFiredAlarm` source='bg', fusionSource='position-train')로 1주 캡처. WiFi 미해상 빈도(consensus 미진입 비율)도 함께 관측해 "WiFi 후보 station" 설계 편차의 실효성을 검증.
5. **Device verify** — **필수, A7(지하 실기기)**. unit은 로직만 검증(게이트 조건/consensus 입력 매핑/기존 pipeline 재사용 경로) — 실제 지하 WiFi 해상률, arvlCd 폴링 quota 소진 여부, consensus 채택률, 발사 정확도는 실기기 전용. 코드 리뷰 clean이어도 지하 탑승 1회 검증 없이는 close 불가.

## 검증

- 관련 테스트: `bgUndergroundArrivalPoll.test.ts`(12), `undergroundConsensusFire.test.ts`(15), `bgLocationProfile.test.ts`(신규 2건 추가), `backgroundLocationTask.test.ts`(신규 4건 추가) — 4개 파일 146 tests all pass, 각 신규/변경 파일 100% coverage(개별 `--collectCoverageFrom` 확인).
- `npx tsc --noEmit -p .` — clean.
- `npm run lint:orphan` — 0 orphan.
- 전역 `npm test`(전체 커버리지 100% 게이트)는 watchdog stall 우려로 미실행 — 위 4개 관련 스위트만 개별/합산 실행해 100% 확인. 전역 커버리지는 CI에서 최종 확인 필요.
