### PR TITLE
fix(#2387): 명시 탭 의향 환승 계승(device 권위) + fusion cross-line ssot 오염 방지

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -24,6 +24,7 @@ import {
 import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
 import { useAlarmEventStore } from '../../store/useAlarmEventStore';
+import { useUserIntentStore } from '../../store/useUserIntentStore';
 import type { Station } from '../../../../shared/types/station';
 import type { AlarmEvent } from '../../utils/stationAlarm';
 import {
@@ -258,6 +259,7 @@ describe('useStationAlarm', () => {
     mockFireFgAuxStationPassedNotification.mockResolvedValue(undefined);
     useSettingsStore.setState({ sleepMode: false, allowSpeaker: true });
     useAlarmEventStore.setState({ alarmEvent: null, dismissSilence: null });
+    useUserIntentStore.setState({ infoModeEnabled: false });
     mockEvaluateAlarmPhase.mockReturnValue(null);
     mockResolveAlarmDirection.mockReturnValue(undefined);
     mockResolveNextTarget.mockReturnValue(null);
@@ -5861,6 +5863,137 @@ describe('useStationAlarm', () => {
         ),
       );
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    // #2387 — 명시 탭 의향(infoModeEnabled) 환승 계승. 환승서 lock release 후에도 사용자가
+    // 이전에 명시 탭(BoardingTrainList)했으면 infoModeEnabled=true가 살아있어 device 알람 권위를
+    // 유지해야 한다(lock 재생성 아님, CLAUDE.md "명시 탭=lock 동급" 정합).
+    describe('#2387 infoModeEnabled 계승 — lock=null + infoModeEnabled=true → 게이트 통과', () => {
+      it('lock=null + infoModeEnabled=true → station-passed FG GPS path 정상 발사 (게이트 832/1420 무관 — GPS path는 1420)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        useUserIntentStore.setState({ infoModeEnabled: true });
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '왕십리',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 3,
+        });
+
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({
+              route: routeDirect,
+              destination,
+              nearestStation: onRouteStation,
+              accuracyMeters: 50,
+              speedMps: 10,
+            }),
+          ),
+        );
+
+        // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+        await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+        expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
+      });
+
+      it('lock=null + infoModeEnabled=true → transfer phase ETA 정상 발사 (게이트 832)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        useUserIntentStore.setState({ infoModeEnabled: true });
+        mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+
+        const route = makeTransferRoute({
+          transferName: '시청',
+          fromLine: '5',
+          toLine: '2',
+          stopsToTransfer: 1,
+          stopsFromTransfer: 3,
+        });
+
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({
+              route,
+              destination,
+              userLocation: { lat: 37.5, lng: 127.0 },
+              speedMps: 10,
+              accuracyMeters: 50,
+            }),
+          ),
+        );
+
+        await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
+        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
+      });
+
+      it('lock=null + infoModeEnabled=true → destination phase ETA 정상 발사 (게이트 832)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        useUserIntentStore.setState({ infoModeEnabled: true });
+        mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({
+              route: routeDirect,
+              destination,
+              userLocation: { lat: 37.498, lng: 127.028 },
+              speedMps: 10,
+              accuracyMeters: 50,
+            }),
+          ),
+        );
+
+        await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
+        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
+      });
+
+      it('lock=null + infoModeEnabled=true → subsurface station-passed 정상 발사 (게이트 1664)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        useUserIntentStore.setState({ infoModeEnabled: true });
+        const subsurfaceStation = makeStation('S-SUB-2387', '지하역2', 37.5, 127.0);
+
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({
+              route: routeDirect,
+              destination,
+              nearestStation: subsurfaceStation,
+              subsurfaceStationDetected: true,
+            }),
+          ),
+        );
+
+        await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
+      });
+
+      it('lock=null + infoModeEnabled=true + sleep ON → 무크래시 (첫 hop suppress는 sleep rule이 담당, lockless 게이트가 아님)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        useUserIntentStore.setState({ infoModeEnabled: true });
+        useSettingsStore.setState({ sleepMode: true });
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '왕십리',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 3,
+        });
+
+        expect(() =>
+          renderHook(() =>
+            useStationAlarm(
+              defaultInputs({
+                route: routeDirect,
+                destination,
+                nearestStation: onRouteStation,
+                accuracyMeters: 50,
+                speedMps: 10,
+              }),
+            ),
+          ),
+        ).not.toThrow();
+      });
     });
   });
 

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -5869,102 +5869,98 @@ describe('useStationAlarm', () => {
     // 이전에 명시 탭(BoardingTrainList)했으면 infoModeEnabled=true가 살아있어 device 알람 권위를
     // 유지해야 한다(lock 재생성 아님, CLAUDE.md "명시 탭=lock 동급" 정합).
     describe('#2387 infoModeEnabled 계승 — lock=null + infoModeEnabled=true → 게이트 통과', () => {
-      it('lock=null + infoModeEnabled=true → station-passed FG GPS path 정상 발사 (게이트 832/1420 무관 — GPS path는 1420)', async () => {
+      // 게이트 3곳(832/1420/1664) 각각에 도달하는 이벤트/mock 조합만 다르고 arrange(lock=null +
+      // infoModeEnabled 세팅)·act(renderHook)·최종 공통 assert(logSuppressedLocklessNoUserIntent
+      // 미호출)는 동일 — it.each로 축약(SonarCloud dup 회피). 분기 실행(각 게이트의 true-path)은
+      // 케이스별로 그대로 보존돼 커버리지 100% 유지.
+      const gateCases = [
+        {
+          name: 'station-passed FG GPS path (게이트 1420)',
+          setup: () => {
+            mockGetLastNotifiedStationId.mockResolvedValue(null);
+            mockResolveNextTarget.mockReturnValue({
+              nextStationName: '왕십리',
+              stopsToNextStation: 1,
+              isTransfer: false,
+              stopsToDestination: 3,
+            });
+          },
+          inputs: (): Partial<UseStationAlarmInputs> => ({
+            route: routeDirect,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: 10,
+          }),
+          assertFired: async () => {
+            // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+            await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+            expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+          },
+        },
+        {
+          name: 'transfer phase ETA (게이트 832)',
+          setup: () => {
+            mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+          },
+          inputs: (): Partial<UseStationAlarmInputs> => ({
+            route: makeTransferRoute({
+              transferName: '시청',
+              fromLine: '5',
+              toLine: '2',
+              stopsToTransfer: 1,
+              stopsFromTransfer: 3,
+            }),
+            destination,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+          assertFired: async () => {
+            await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
+          },
+        },
+        {
+          name: 'destination phase ETA (게이트 832)',
+          setup: () => {
+            mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+          },
+          inputs: (): Partial<UseStationAlarmInputs> => ({
+            route: routeDirect,
+            destination,
+            userLocation: { lat: 37.498, lng: 127.028 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+          assertFired: async () => {
+            await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
+          },
+        },
+        {
+          name: 'subsurface station-passed (게이트 1664)',
+          setup: () => {
+            /* no-op — subsurface path엔 GPS/phase mock 불필요 */
+          },
+          inputs: (): Partial<UseStationAlarmInputs> => ({
+            route: routeDirect,
+            destination,
+            nearestStation: makeStation('S-SUB-2387', '지하역2', 37.5, 127.0),
+            subsurfaceStationDetected: true,
+          }),
+          assertFired: async () => {
+            await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+          },
+        },
+      ];
+
+      it.each(gateCases)('lock=null + infoModeEnabled=true → $name 정상 발사', async ({ setup, inputs, assertFired }) => {
         mockGetBoardingLock.mockResolvedValue(null);
         useUserIntentStore.setState({ infoModeEnabled: true });
-        mockGetLastNotifiedStationId.mockResolvedValue(null);
-        mockResolveNextTarget.mockReturnValue({
-          nextStationName: '왕십리',
-          stopsToNextStation: 1,
-          isTransfer: false,
-          stopsToDestination: 3,
-        });
+        setup();
 
-        renderHook(() =>
-          useStationAlarm(
-            defaultInputs({
-              route: routeDirect,
-              destination,
-              nearestStation: onRouteStation,
-              accuracyMeters: 50,
-              speedMps: 10,
-            }),
-          ),
-        );
+        renderHook(() => useStationAlarm(defaultInputs(inputs())));
 
-        // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
-        await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
-        expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
-      });
-
-      it('lock=null + infoModeEnabled=true → transfer phase ETA 정상 발사 (게이트 832)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        useUserIntentStore.setState({ infoModeEnabled: true });
-        mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
-
-        const route = makeTransferRoute({
-          transferName: '시청',
-          fromLine: '5',
-          toLine: '2',
-          stopsToTransfer: 1,
-          stopsFromTransfer: 3,
-        });
-
-        renderHook(() =>
-          useStationAlarm(
-            defaultInputs({
-              route,
-              destination,
-              userLocation: { lat: 37.5, lng: 127.0 },
-              speedMps: 10,
-              accuracyMeters: 50,
-            }),
-          ),
-        );
-
-        await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
-        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
-      });
-
-      it('lock=null + infoModeEnabled=true → destination phase ETA 정상 발사 (게이트 832)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        useUserIntentStore.setState({ infoModeEnabled: true });
-        mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-
-        renderHook(() =>
-          useStationAlarm(
-            defaultInputs({
-              route: routeDirect,
-              destination,
-              userLocation: { lat: 37.498, lng: 127.028 },
-              speedMps: 10,
-              accuracyMeters: 50,
-            }),
-          ),
-        );
-
-        await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
-        expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
-      });
-
-      it('lock=null + infoModeEnabled=true → subsurface station-passed 정상 발사 (게이트 1664)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        useUserIntentStore.setState({ infoModeEnabled: true });
-        const subsurfaceStation = makeStation('S-SUB-2387', '지하역2', 37.5, 127.0);
-
-        renderHook(() =>
-          useStationAlarm(
-            defaultInputs({
-              route: routeDirect,
-              destination,
-              nearestStation: subsurfaceStation,
-              subsurfaceStationDetected: true,
-            }),
-          ),
-        );
-
-        await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+        await assertFired();
         expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
       });
 
@@ -5972,26 +5968,10 @@ describe('useStationAlarm', () => {
         mockGetBoardingLock.mockResolvedValue(null);
         useUserIntentStore.setState({ infoModeEnabled: true });
         useSettingsStore.setState({ sleepMode: true });
-        mockGetLastNotifiedStationId.mockResolvedValue(null);
-        mockResolveNextTarget.mockReturnValue({
-          nextStationName: '왕십리',
-          stopsToNextStation: 1,
-          isTransfer: false,
-          stopsToDestination: 3,
-        });
+        gateCases[0].setup();
 
         expect(() =>
-          renderHook(() =>
-            useStationAlarm(
-              defaultInputs({
-                route: routeDirect,
-                destination,
-                nearestStation: onRouteStation,
-                accuracyMeters: 50,
-                speedMps: 10,
-              }),
-            ),
-          ),
+          renderHook(() => useStationAlarm(defaultInputs(gateCases[0].inputs()))),
         ).not.toThrow();
       });
     });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -179,6 +179,29 @@ function logSuppressedStationPassedLockless(stationName: string): void {
   });
 }
 
+/**
+ * #2387 — lockless trip + 사용자 명시 의향(infoModeEnabled) 부재 판정 공통 헬퍼.
+ * lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭.
+ * infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
+ * 권위를 유지한다(lock 재생성 아님 — CLAUDE.md "명시 탭=lock 동급" 정합). fireAndLog phase(:837)와
+ * station-passed 두 경로(:1427/:1673) 3곳에서 동일 조건식이 반복돼 SonarCloud CPD 해소.
+ */
+function isLocklessNoUserIntent(lock: BoardingLock | null): boolean {
+  return !lock && !useUserIntentStore.getState().infoModeEnabled;
+}
+
+/**
+ * #2387 — station-passed 경로(GPS IIFE :1427 / subsurface IIFE :1673) 공통 lockless-no-user-intent
+ * 억제 블록. `isLocklessNoUserIntent` 참고. true 반환 시 호출자는 즉시 return.
+ */
+function suppressIfLocklessStationPassed(lock: BoardingLock | null, candidateStation: Station): boolean {
+  if (isLocklessNoUserIntent(lock)) {
+    logSuppressedStationPassedLockless(candidateStation.name);
+    return true;
+  }
+  return false;
+}
+
 /** #2362 — 매역 알림 본문에 배선할 "남은 정거장 수 + 다음 대상(환승역|도착역)". */
 interface StationPassedTarget {
   count: number;
@@ -829,12 +852,10 @@ export function useStationAlarm({
     const isFirstHop = isSameStationName(getFirstLeg(activeRoute, activeDestination.name).endName, rawEvent.stationName);
     const lock = await getBoardingLock();
     // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 ETA/imminent phase 발사 차단.
-    // lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭(#2387).
-    // infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
-    // 권위를 유지한다(lock 재생성 아님 — CLAUDE.md "명시 탭=lock 동급" 정합). 이 상태에서
-    // transfer/destination phase 알람(ETA 기반 early/imminent + API imminent)을 fire하면 paradigm shift 위반.
+    // #2387: lockless+무의향 억제 — isLocklessNoUserIntent 참고. 이 상태에서 transfer/destination
+    // phase 알람(ETA 기반 early/imminent + API imminent)을 fire하면 paradigm shift 위반.
     // firedAlarmsRef.current.delete(key): 진입부 add를 복구해 storage net-zero 유지 (sleep/cross-category 차단과 동일 패턴).
-    if (!lock && !useUserIntentStore.getState().infoModeEnabled) {
+    if (isLocklessNoUserIntent(lock)) {
       firedAlarmsRef.current.delete(key);
       logSuppressedLocklessNoUserIntent({
         source: 'fg-evaluated',
@@ -1420,14 +1441,9 @@ export function useStationAlarm({
         const lock = await getBoardingLock();
         if (cancelled) return;
         // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 station-passed 차단.
-        // lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭(#2387).
-        // infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
-        // 권위를 유지한다. paradigm shift 정합.
+        // #2387: lockless+무의향 억제 — isLocklessNoUserIntent 참고. paradigm shift 정합.
         // #1514 — origin hop lockless 차단(용마산 evidence)은 본 broad guard의 subset이 되어 하나로 통합.
-        if (!lock && !useUserIntentStore.getState().infoModeEnabled) {
-          logSuppressedStationPassedLockless(candidateStation.name);
-          return;
-        }
+        if (suppressIfLocklessStationPassed(lock, candidateStation)) return;
         // #1572 (T9) — backend SSoT 권위 게이트 (Path A). mirror.alarmEvents에 같은 alarmId가
         // 이미 있거나(Gate A) mirror.passedStations/alarmEvents에 같은 stationId가 station-passed로
         // 이미 결정됐으면(Gate B) fire 차단. mirror 부재/stale은 graceful no-block.
@@ -1667,13 +1683,8 @@ export function useStationAlarm({
       const lock = await getBoardingLock();
       if (cancelled) return;
       // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 subsurface station-passed 차단.
-      // lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭(#2387).
-      // infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
-      // 권위를 유지한다. paradigm shift 정합.
-      if (!lock && !useUserIntentStore.getState().infoModeEnabled) {
-        logSuppressedStationPassedLockless(candidateStation.name);
-        return;
-      }
+      // #2387: lockless+무의향 억제 — isLocklessNoUserIntent 참고. paradigm shift 정합.
+      if (suppressIfLocklessStationPassed(lock, candidateStation)) return;
       // #1572 (T9) — backend SSoT 권위 게이트 (Path C subsurface verdict). subsurface fusion이
       // backend가 이미 결정한 alarmId/stationId를 재발사하는 회귀 차단. dispatch helper 진입 직전 평가.
       // #1572 — 3 path 공통 helper로 통합 (SonarCloud CPD 회피).

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -81,6 +81,9 @@ import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-st
 import type { PositionStability } from '../../nearest-station/utils/positionStaticDetector';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
 import { useAlarmEventStore } from '../store/useAlarmEventStore';
+// #2387 — 명시 탭 의향(infoModeEnabled) 환승 계승. lock=null을 "미탭" proxy로 쓰던 게이트가
+// 환승 후 lock release 시 명시 탭 의향까지 함께 억제하던 회귀를 막는다.
+import { useUserIntentStore } from '../store/useUserIntentStore';
 import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
@@ -826,10 +829,12 @@ export function useStationAlarm({
     const isFirstHop = isSameStationName(getFirstLeg(activeRoute, activeDestination.name).endName, rawEvent.stationName);
     const lock = await getBoardingLock();
     // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 ETA/imminent phase 발사 차단.
-    // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. 이 상태에서 transfer/destination
-    // phase 알람(ETA 기반 early/imminent + API imminent)을 fire하면 paradigm shift 위반.
+    // lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭(#2387).
+    // infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
+    // 권위를 유지한다(lock 재생성 아님 — CLAUDE.md "명시 탭=lock 동급" 정합). 이 상태에서
+    // transfer/destination phase 알람(ETA 기반 early/imminent + API imminent)을 fire하면 paradigm shift 위반.
     // firedAlarmsRef.current.delete(key): 진입부 add를 복구해 storage net-zero 유지 (sleep/cross-category 차단과 동일 패턴).
-    if (!lock) {
+    if (!lock && !useUserIntentStore.getState().infoModeEnabled) {
       firedAlarmsRef.current.delete(key);
       logSuppressedLocklessNoUserIntent({
         source: 'fg-evaluated',
@@ -1415,9 +1420,11 @@ export function useStationAlarm({
         const lock = await getBoardingLock();
         if (cancelled) return;
         // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 station-passed 차단.
-        // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. paradigm shift 정합.
+        // lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭(#2387).
+        // infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
+        // 권위를 유지한다. paradigm shift 정합.
         // #1514 — origin hop lockless 차단(용마산 evidence)은 본 broad guard의 subset이 되어 하나로 통합.
-        if (!lock) {
+        if (!lock && !useUserIntentStore.getState().infoModeEnabled) {
           logSuppressedStationPassedLockless(candidateStation.name);
           return;
         }
@@ -1660,8 +1667,10 @@ export function useStationAlarm({
       const lock = await getBoardingLock();
       if (cancelled) return;
       // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 subsurface station-passed 차단.
-      // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. paradigm shift 정합.
-      if (!lock) {
+      // lock=null AND !infoModeEnabled = boardingPrompt 미응답 + BoardingTrainList 미탭(#2387).
+      // infoModeEnabled=true면 명시 탭 의향이 환승으로 lock release된 후에도 계승돼 device 알람
+      // 권위를 유지한다. paradigm shift 정합.
+      if (!lock && !useUserIntentStore.getState().infoModeEnabled) {
         logSuppressedStationPassedLockless(candidateStation.name);
         return;
       }

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
@@ -54,6 +54,7 @@ import {
 } from '../../../../testUtils/backendSsotMirrorFixtures';
 import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
 import { getFusionDebugEntries, clearFusionDebugEntries } from '../../utils/fusionDebugBuffer';
+import { useLegAdvanceStore } from '../../../alarm/store/useLegAdvanceStore';
 
 const mockNearest = useNearestStation as jest.Mock;
 const mockArrival = useArrivalInfo as jest.Mock;
@@ -92,10 +93,12 @@ describe('#2307 backend-ssot line guard — device 확정 노선과 mirror line 
     jest.useFakeTimers();
     jest.setSystemTime(T0);
     clearFusionDebugEntries();
+    useLegAdvanceStore.setState({ nextLine: null, stampedAt: null });
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    useLegAdvanceStore.setState({ nextLine: null, stampedAt: null });
   });
 
   it('DebugModal Fusion log 채널로 ssot-line-guard-reject entry가 push된다 (dedup: 지속 mismatch는 1건만)', async () => {
@@ -154,10 +157,41 @@ describe('#2307 backend-ssot line guard — device 확정 노선과 mirror line 
     expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
   });
 
-  it('positionTrainResult 없음(consensus 미충족/mirror만 존재) → 기존대로 mirror 채택 (가드 미적용)', async () => {
+  it('#2387 positionTrainResult 없음 + legAdvanceLine=2(환승 하차 응답 확인) + mirror=7호선(용마산, stuck) → approachLine 가드로 거부', async () => {
     setupPositionTrainAt(gangnam2, '2');
-    // train 없음 → candidateTrains 비어 positionTrainResult=null.
+    // train 없음 → candidateTrains 비어 positionTrainResult=null. 사용자가 환승역 하차 응답으로
+    // 2호선을 확인(legAdvance stamp)했는데 backend mirror는 여전히 7호선(용마산)에 stuck.
     mockPos.mockReturnValue(positionRet(null));
+    useLegAdvanceStore.setState({ nextLine: '2', stampedAt: T0 });
+    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).not.toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).not.toBe(yongmasan.id);
+    expect(hook.result.current.ssotLineGuardRejectCount).toBeGreaterThan(0);
+  });
+
+  it('#2387 positionTrainResult 없음 + legAdvanceLine=7(아직 환승 전) + mirror=7호선(청담) → line 일치, 기존대로 mirror 채택 (무오탐)', async () => {
+    setupPositionTrainAt(yongmasan, '7');
+    mockPos.mockReturnValue(positionRet(null));
+    useLegAdvanceStore.setState({ nextLine: '7', stampedAt: T0 });
+    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: chungdam.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(chungdam.id);
+    expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
+  });
+
+  it('#2387 positionTrainResult 없음 + route/legAdvance 둘 다 없음(approach.confirmed=false) → 기존대로 mirror 채택 (잔여 엣지, 정직 인정)', async () => {
+    setupPositionTrainAt(gangnam2, '2');
+    mockPos.mockReturnValue(positionRet(null));
+    // route(undefined)/boardingLock(undefined)/legAdvanceLine(null) 전부 부재 →
+    // getApproachLineWithConfirmation의 candidate=null → confirmed=false → 가드 skip.
     mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
     const hook = renderHook(() => useFusedNearestStation());
     await flushBackendSsotMirrorTick();

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
@@ -157,48 +157,61 @@ describe('#2307 backend-ssot line guard — device 확정 노선과 mirror line 
     expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
   });
 
-  it('#2387 positionTrainResult 없음 + legAdvanceLine=2(환승 하차 응답 확인) + mirror=7호선(용마산, stuck) → approachLine 가드로 거부', async () => {
-    setupPositionTrainAt(gangnam2, '2');
-    // train 없음 → candidateTrains 비어 positionTrainResult=null. 사용자가 환승역 하차 응답으로
-    // 2호선을 확인(legAdvance stamp)했는데 backend mirror는 여전히 7호선(용마산)에 stuck.
-    mockPos.mockReturnValue(positionRet(null));
-    useLegAdvanceStore.setState({ nextLine: '2', stampedAt: T0 });
-    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
-    const hook = renderHook(() => useFusedNearestStation());
-    await flushBackendSsotMirrorTick();
-    await waitFor(() => {
-      expect(hook.result.current.source).not.toBe('backend-ssot');
-    });
-    expect(hook.result.current.result?.station.id).not.toBe(yongmasan.id);
-    expect(hook.result.current.ssotLineGuardRejectCount).toBeGreaterThan(0);
-  });
+  // #2387 — approachLine(legAdvance) 기반 추가 가드 3케이스. arrange(positionTrainResult=null
+  // 강제 + legAdvance stamp + mirror 주입)와 act(renderHook+flush)가 동일 패턴이라 it.each로
+  // 축약(SonarCloud dup 회피) — 거부/채택 두 분기(approach.confirmed true+mismatch / true+match /
+  // false)는 파라미터로 그대로 보존해 커버리지 100% 유지.
+  it.each([
+    {
+      name: 'legAdvanceLine=2(환승 하차 응답 확인) + mirror=7호선(용마산, stuck) → approachLine 가드로 거부',
+      positionStation: gangnam2,
+      positionLine: '2' as const,
+      legAdvanceLine: '2' as const,
+      mirrorStationId: yongmasan.name,
+      mirrorAccepted: false,
+      expectedStationId: undefined as string | undefined,
+    },
+    {
+      name: 'legAdvanceLine=7(아직 환승 전) + mirror=7호선(청담) → line 일치, 기존대로 mirror 채택 (무오탐)',
+      positionStation: yongmasan,
+      positionLine: '7' as const,
+      legAdvanceLine: '7' as const,
+      mirrorStationId: chungdam.name,
+      mirrorAccepted: true,
+      expectedStationId: chungdam.id,
+    },
+    {
+      name: 'route/legAdvance 둘 다 없음(approach.confirmed=false) → 기존대로 mirror 채택 (잔여 엣지, 정직 인정)',
+      positionStation: gangnam2,
+      positionLine: '2' as const,
+      legAdvanceLine: null,
+      mirrorStationId: yongmasan.name,
+      mirrorAccepted: true,
+      expectedStationId: yongmasan.id,
+    },
+  ])(
+    '#2387 positionTrainResult 없음 + $name',
+    async ({ positionStation, positionLine, legAdvanceLine, mirrorStationId, mirrorAccepted, expectedStationId }) => {
+      setupPositionTrainAt(positionStation, positionLine);
+      // train 없음 → candidateTrains 비어 positionTrainResult=null.
+      mockPos.mockReturnValue(positionRet(null));
+      useLegAdvanceStore.setState({ nextLine: legAdvanceLine, stampedAt: legAdvanceLine ? T0 : null });
+      mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: mirrorStationId }));
+      const hook = renderHook(() => useFusedNearestStation());
+      await flushBackendSsotMirrorTick();
 
-  it('#2387 positionTrainResult 없음 + legAdvanceLine=7(아직 환승 전) + mirror=7호선(청담) → line 일치, 기존대로 mirror 채택 (무오탐)', async () => {
-    setupPositionTrainAt(yongmasan, '7');
-    mockPos.mockReturnValue(positionRet(null));
-    useLegAdvanceStore.setState({ nextLine: '7', stampedAt: T0 });
-    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: chungdam.name }));
-    const hook = renderHook(() => useFusedNearestStation());
-    await flushBackendSsotMirrorTick();
-    await waitFor(() => {
-      expect(hook.result.current.source).toBe('backend-ssot');
-    });
-    expect(hook.result.current.result?.station.id).toBe(chungdam.id);
-    expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
-  });
-
-  it('#2387 positionTrainResult 없음 + route/legAdvance 둘 다 없음(approach.confirmed=false) → 기존대로 mirror 채택 (잔여 엣지, 정직 인정)', async () => {
-    setupPositionTrainAt(gangnam2, '2');
-    mockPos.mockReturnValue(positionRet(null));
-    // route(undefined)/boardingLock(undefined)/legAdvanceLine(null) 전부 부재 →
-    // getApproachLineWithConfirmation의 candidate=null → confirmed=false → 가드 skip.
-    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
-    const hook = renderHook(() => useFusedNearestStation());
-    await flushBackendSsotMirrorTick();
-    await waitFor(() => {
-      expect(hook.result.current.source).toBe('backend-ssot');
-    });
-    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
-    expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
-  });
+      if (mirrorAccepted) {
+        await waitFor(() => {
+          expect(hook.result.current.source).toBe('backend-ssot');
+        });
+        expect(hook.result.current.result?.station.id).toBe(expectedStationId);
+        expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
+      } else {
+        await waitFor(() => {
+          expect(hook.result.current.source).not.toBe('backend-ssot');
+        });
+        expect(hook.result.current.ssotLineGuardRejectCount).toBeGreaterThan(0);
+      }
+    },
+  );
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -81,6 +81,11 @@ import {
   readBackendSsotMirror,
   type BackendSsotMirrorEntry,
 } from '../../alarm/utils/backendSsotMirror';
+// #2387 — route/lock/legAdvance 권위 line 판정. GPS raw proximity(gps.liveResult)는 line 권위로
+// 부적합(환승역 좌표 근접 오탐, lockless cascade의 "backend 신뢰" 설계 무력화) — approachLine이
+// 대신 route+lock+legAdvance SSoT 기반 확정(confirmed) 여부까지 함께 제공한다.
+import { getApproachLineWithConfirmation } from '../../route/utils/approachLine';
+import { useLegAdvanceStore } from '../../alarm/store/useLegAdvanceStore';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
 import {
@@ -520,6 +525,10 @@ export function useFusedNearestStation(
   // routeContext는 HomeScreen에서 trip 시작 시 채워지고 종료 시 undefined로 돌아간다.
   const tripActive = routeContext != null;
   const gps = useNearestStation({ barometerSubsurface, tripActive });
+  // #2387 — approachLine(route/lock/legAdvance 권위 line 판정)의 legAdvance 입력. reactive 구독
+  // 필수 — getState()는 useMemo 재계산을 트리거하지 않아 store 값이 바뀌어도 ssotGuardResult가
+  // stale하게 남는다.
+  const legAdvanceLine = useLegAdvanceStore((s) => s.nextLine);
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
   // useNearestStation의 userLocation 변경마다 자동 누적/판정.
   const positionStability = usePositionStability(gps.userLocation);
@@ -1177,8 +1186,31 @@ export function useFusedNearestStation(
       ssotLineGuardRejectRef.current += 1;
       return { station: null, lineGuardRejected: true, mirrorLine };
     }
+    // #2387 — lock/legAdvance 권위(approachLine) 기반 추가 cross-line 가드. 위 positionTrainResult
+    // 가드가 무력화되는 사이클(지하/GPS열화, positionTrainResult=null)에도 사용자가 명시적으로
+    // 확인한 line(BoardingLock 또는 환승역 하차 응답 legAdvance stamp)과 mirror가 다르면 거부한다.
+    // route는 의도적으로 전달하지 않는다(항상 null) — bare route progression(candidate 3/4,
+    // stopsToTransfer 기반 추정)은 사용자 확인이 아닌 "계획값"이라 positionTrainResult급 신뢰도가
+    // 아니다. #1605 회귀(lockless + route만 있고 lock/legAdvance 둘 다 없는 trip에서 backend가
+    // route와 다른 line으로 정당하게 advance한 경우도 backend-ssot-override로 채택돼야 하는 시나리오)가
+    // route를 신뢰 소스로 쓰면 깨진다 — getApproachLineWithConfirmation(route=null, ...)이면
+    // resolveCandidateLine이 boardingLock/legAdvanceLine만 확인하고 route 분기는 건너뛰어
+    // confirmed는 오직 lock/legAdvance 존재 시에만 true가 된다.
+    // 기존 positionTrainResult 가드와 OR 조건 — additive, 기존 분기는 그대로 유지.
+    if (resolved) {
+      const approach = getApproachLineWithConfirmation(
+        null,
+        boardingLock ?? null,
+        null,
+        legAdvanceLine,
+      );
+      if (approach.confirmed && resolved.line !== approach.line) {
+        ssotLineGuardRejectRef.current += 1;
+        return { station: null, lineGuardRejected: true, mirrorLine };
+      }
+    }
     return { station: resolved, lineGuardRejected: false, mirrorLine };
-  }, [backendSsotMirror, boardingLock, positionTrainResult]);
+  }, [backendSsotMirror, boardingLock, positionTrainResult, legAdvanceLine]);
   const ssotStation = ssotGuardResult.station;
   // #2307 — DebugModal Fusion log 관측 채널. false→true 전환 시에만 push해 동일 mismatch가
   // 지속되는 cycle(수 분)에 매번 재적재되어 fusionDebugBuffer 500 cap을 점령하는 것을 방지


### PR DESCRIPTION
## 요약

Part of #2381

명시 탭 의향(`infoModeEnabled`)을 환승 넘어 계승해 device 알람 권위를 복원한다. Change 2(fusion 오염 방지)를 Change 1(게이트 intent 계승)보다 먼저 적용 — 오염원 차단 선행.

### Change 2 — fusion 오염 방지 (커밋 1)

`src/features/nearest-station/hooks/useFusedNearestStation.ts` `ssotGuardResult` useMemo에 approachLine(route/lock/legAdvance 권위) 기반 추가 cross-line 가드.

- 기존 positionTrainResult 가드(`resolved.line !== positionTrainResult.station.line`)는 그대로 유지 — OR 조건으로 additive.
- 신규: `getApproachLineWithConfirmation(null, boardingLock, null, legAdvanceLine)`으로 BoardingLock 또는 legAdvance(환승역 하차 응답 stamp)가 확인한 line과 mirror가 다르면 거부. positionTrainResult가 없는 사이클(지하/GPS열화)에도 stale backend-ssot 채택을 막는다.
- **route는 의도적으로 전달하지 않는다** (항상 `null`). 최초 스펙은 `gps.liveResult`를 line 권위로 쓰자는 것이었으나, raw GPS 근접성이 환승역 좌표 중첩 오탐(lock 활성 시 `#1657` 회귀)과 lockless cascade의 "backend 신뢰" 설계 무력화(`#1705` 회귀)를 유발해 3개 기존 회귀 테스트를 깼다 — 폐기. bare route progression(stopsToTransfer 추정)도 "계획값"일 뿐 사용자 확인이 아니라서 신뢰 소스로 넣으면 `#1605`(lockless + route만 있고 lock/legAdvance 둘 다 없을 때 backend가 route와 다른 line으로도 정당하게 override해야 하는 케이스) 회귀가 발생 — 배제.
- 최종 신뢰 소스: **BoardingLock, legAdvanceLine(환승역 하차 응답/버튼) 두 개뿐** — 둘 다 명시적 사용자 확인 신호.

### Change 1 — 게이트 intent 계승 (커밋 2)

`src/features/alarm/hooks/useStationAlarm.ts` 게이트 3곳(`:832` fireAndLog phase, `:1420` GPS station-passed IIFE, `:1664` subsurface IIFE)을 `if (!lock)` → `if (!lock && !useUserIntentStore.getState().infoModeEnabled)`로 변경. `:1516` fg-arvlcd fast-path는 `findFgArvlCdFireSignal`이 `lock.trainCode` 매칭을 구조적으로 요구(#640)해 그대로 유지(비대칭 의도).

## 금지/주의 준수

- 무탭 auto-lock 재도입 없음 — lock 재생성이 아니라 intent 계승만.
- positionTrainResult 존재(lock-active) flow 무회귀 — 관련 전체 스위트(`src/features/nearest-station`, 1858 tests) green.

## 테스트

- `useFusedNearestStation.ssotLineGuard.test.ts` — approachLine 가드 신규 3케이스(legAdvance 불일치 거부/일치 채택/미확정 skip) 추가, 기존 3케이스 무회귀.
- `useStationAlarm.test.ts` — 게이트 3곳 각각 `infoModeEnabled=true` + `lock=null` → 정상 발사 케이스 4건 + sleep ON 동시 조합 무크래시 케이스 1건 추가.
- 전체 스위트 대신 관련 파일만 로컬 검증(정책): `src/features/nearest-station` 전체(1858 passed), `useStationAlarm.test.ts`(244 passed), `approachLine`/`useLegAdvanceStore`/`useUserIntentStore` 관련(129 passed). `useStationAlarm.ts` 100% 커버리지 확인.
- `npm run type-check` clean, `npm run lint:orphan` — 0 orphan.

## Wire-completion 5단

1. **Orphan**: 신규 export 없음(기존 store/util import). `lint:orphan` pass.
2. **V/X dashboard**: DebugModal Fusion log — 기존 `ssot-line-guard-reject` 채널 그대로 재사용(신규 채널 추가 안 함, 코디네이터 지시대로 debug push 블록은 positionTrainResult 기준 원복 유지). 환승 후 station-passed가 정확 역만 발사되는지는 alarmLog `logSuppressedLocklessNoUserIntent` 미호출로 관측.
3. **의존 PR**: N/A (device-only).
4. **측정 plan**: 7→2호선 환승 탑승 시 device가 정확 역만 발사 / 어린이대공원 미발사. `logSuppressedLocklessNoUserIntent` 호출 빈도가 환승 이후 구간에서 0이 되는지 확인.
5. **Device verify**: **필수 — 리빌드 후 7호선 탭 탑승→건대입구 환승→2호선.** (MINIMAL_ALARM 플래그 밖). unit은 로직만 검증.

Closes #2387