### PR TITLE
fix(#2393): lockless trip ETA 출발대기 과다합산 차단 — firedAlarms in-trip 신호 추가

### DIFF
--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -369,6 +369,44 @@ describe('processLocationUpdate', () => {
     });
   });
 
+  // #2393 — lockless(lock=null) + legAdvance 없음 + firedAlarms non-empty(이 trip에 이미 알람
+  // 발사됨) 조합에서 excludeOriginWait이 true가 돼야 한다(성수→뚝섬 evidence: 실제 1분 hop인데
+  // 출발 대기 ~5분이 합산돼 "6분"으로 표시됐다). lock/legAdvance 신호는 기존과 동일하게 무변경이며
+  // firedAlarms만 신규 OR 항으로 추가된다.
+  it('lockless + legAdvance 없음이어도 firedAlarms가 non-empty면 excludeOriginWait: true를 전달한다(#2393)', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockGetBoardingLock.mockResolvedValue(null);
+
+    await call({ firedAlarms: new Set(['destination:시청']) });
+
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute, {
+      currentLocation: { lat: 37.498, lng: 127.028 },
+      originStation: { lat: mockStation.lat, lng: mockStation.lng },
+      arrivalAtOrigin: undefined,
+      arrivalsAtTransfers: undefined,
+      excludeOriginWait: true,
+    });
+  });
+
+  // 회귀 없음 — firedAlarms가 empty(출발역 대기 중, 아직 아무 알람도 발사 안 됨)이면 기존대로
+  // excludeOriginWait: false를 유지한다(#2290의 "과다표시 안전" 방향 비역행).
+  it('lockless + legAdvance 없음 + firedAlarms empty면 기존대로 excludeOriginWait: false를 유지한다(회귀 없음)', async () => {
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockGetBoardingLock.mockResolvedValue(null);
+
+    await call({ firedAlarms: new Set() });
+
+    expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute, {
+      currentLocation: { lat: 37.498, lng: 127.028 },
+      originStation: { lat: mockStation.lat, lng: mockStation.lng },
+      arrivalAtOrigin: undefined,
+      arrivalsAtTransfers: undefined,
+      excludeOriginWait: false,
+    });
+  });
+
   it('passes alarmEvent to updateStationNotification only when sleepMode is true', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -8,7 +8,7 @@
  */
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
 import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition, getStationsOnLine, arcIndexOf, computeHopWindowSize, isStationWithinHopWindow } from '../../../shared/utils/stationRoute';
-import { hasConsumedOriginWait } from '../../../shared/utils/boardingWait';
+import { isInTripByEvidence } from '../../../shared/utils/boardingWait';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { updateStationNotification, fireLocalAlarmNotification, fireFgAuxStationPassedNotification } from './stationNotification';
 import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
@@ -654,9 +654,15 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // 대기 중에도 "이미 탑승"으로 오판했다 — `hasConsumedOriginWait`로 일반화(device-side evidence
   // 즉시 소진 / user-tap은 initialEtaSeconds 경과분만). lockForLineGuard는 위에서 이미 조회한
   // boardingLock(신규 감지 경로 아님, 재사용). legAdvance stamp는 하차 응답=확정 evidence라 그대로 유지.
-  const isInTrip =
-    hasConsumedOriginWait(lockForLineGuard, Date.now()) ||
-    useLegAdvanceStore.getState().nextLine !== null;
+  // #2393 — firedAlarms(이 함수 입력으로 이미 존재, 신규 read 아님) non-empty도 in-trip 신호로 추가.
+  // 이 trip에 station-passed/도착 알람이 이미 발사됐다면 device는 이미 주행 중으로 판단한 것이므로
+  // ETA가 출발 대기를 계속 합산하는 자기모순(2026-08-27 성수→뚝섬 "1정거장 6분" evidence)을 차단한다.
+  const isInTrip = isInTripByEvidence(
+    lockForLineGuard,
+    Date.now(),
+    useLegAdvanceStore.getState().nextLine,
+    firedAlarms.size > 0,
+  );
   const eta = calculateStaticETA(route, {
     currentLocation: { lat, lng },
     originStation: { lat: nearest.station.lat, lng: nearest.station.lng },

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -25,7 +25,8 @@ import {
   clearNavigationPausedAt,
 } from '../features/alarm/utils/navigationPauseStorage';
 import { findRouteCandidatesByCategory, findRoutes, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
-import { hasConsumedOriginWait } from '../shared/utils/boardingWait';
+import { isInTripByEvidence } from '../shared/utils/boardingWait';
+import { getFiredAlarms } from '../features/alarm/utils/notificationState';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
 import { EditorialTimeline } from '../features/arrival/components/EditorialTimeline';
 import { arrivalInfoToArrivalTrain, journeyDisplayToStops, nearestResultToNearest } from '../features/route/utils/journeyAdapter';
@@ -634,7 +635,26 @@ export default function HomeScreen() {
   // 수 있다 — user-tap lock의 initialEtaSeconds 경과 시점을 넘겨도 최대 30초간 origin wait가
   // 계속 표시될 수 있다는 뜻. 방향은 여전히 "과다표시"(과소표시보다 안전)이므로 코드 변경 없이
   // 관찰만 유지 — 실시간 1Hz 재평가가 필요해지면 useCountdown류 tick과 연결을 고려.
-  const isInTrip = hasConsumedOriginWait(fusionBoardingLock, Date.now()) || legAdvanceLine !== null;
+  // #2393 — firedAlarms(이 trip의 station-passed/도착 알람 발사 원장) non-empty를 in-trip 신호로
+  // 추가. getFiredAlarms가 async라 useEffect+state로 hasFiredThisTrip을 도출한다. destination.id가
+  // 바뀌면(새 trip) 재조회하고, effectiveOrigin.id가 바뀔 때도 재조회한다 — nearest station 변경은
+  // station-passed 발사와 같은 계기(사용자 이동)에서 일어나므로, 이 시점에 재조회해야 발사 직후의
+  // 원장 갱신을 화면이 놓치지 않는다(2026-08-27 성수→뚝섬 evidence 재현 경로).
+  const [hasFiredThisTrip, setHasFiredThisTrip] = useState(false);
+  useEffect(() => {
+    if (!destination) {
+      setHasFiredThisTrip(false);
+      return;
+    }
+    let cancelled = false;
+    getFiredAlarms(destination.id).then((fired) => {
+      if (!cancelled) setHasFiredThisTrip(fired.size > 0);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [destination?.id, effectiveOrigin?.id]);
+  const isInTrip = isInTripByEvidence(fusionBoardingLock, Date.now(), legAdvanceLine, hasFiredThisTrip);
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
     ? calculateETA(nextTrainMinutes, route, { excludeOriginWait: isInTrip })
     : null;

--- a/src/shared/utils/__tests__/boardingWait.test.ts
+++ b/src/shared/utils/__tests__/boardingWait.test.ts
@@ -1,4 +1,4 @@
-import { hasConsumedOriginWait } from '../boardingWait';
+import { hasConsumedOriginWait, isInTripByEvidence } from '../boardingWait';
 import type { BoardingLock } from '../../types/boardingLock';
 
 const baseLock: BoardingLock = {
@@ -49,5 +49,31 @@ describe('hasConsumedOriginWait', () => {
   it('boardingEvidence=true이고 initialEtaSeconds가 없어도 true를 반환한다', () => {
     const lock: BoardingLock = { ...baseLock, boardingEvidence: true };
     expect(hasConsumedOriginWait(lock, lock.boardedAt)).toBe(true);
+  });
+});
+
+// #2393 — isInTripByEvidence: HomeScreen/stationPipeline 공통 in-trip 판정 헬퍼.
+// 4 입력 조합(lock/legAdvance/firedAlarms 각 신호 단독 true, 전부 false) 단위 테스트.
+describe('isInTripByEvidence', () => {
+  const now = 1_700_000_100_000;
+
+  it('세 신호 모두 false/null이면 false를 반환한다', () => {
+    expect(isInTripByEvidence(null, now, null, false)).toBe(false);
+  });
+
+  it('hasConsumedOriginWait만 true이면 true를 반환한다', () => {
+    const lock: BoardingLock = { ...baseLock, boardingEvidence: true };
+    expect(isInTripByEvidence(lock, now, null, false)).toBe(true);
+  });
+
+  it('legAdvanceLine만 non-null이면 true를 반환한다', () => {
+    expect(isInTripByEvidence(null, now, '2', false)).toBe(true);
+  });
+
+  // RED(수정 전 실패) → GREEN(수정 후 통과): lockless + legAdvance 없음 + firedAlarms만 있는
+  // 조합이 이 이슈(#2393)의 핵심 신규 신호다. 성수→뚝섬 evidence(2026-08-27): device가 이미
+  // station-passed/도착 알람을 발사했다면 lock/legAdvance가 둘 다 없어도 in-trip이어야 한다.
+  it('hasFiredThisTrip만 true이면 true를 반환한다(lockless + legAdvance 없음)', () => {
+    expect(isInTripByEvidence(null, now, null, true)).toBe(true);
   });
 });

--- a/src/shared/utils/boardingWait.ts
+++ b/src/shared/utils/boardingWait.ts
@@ -1,4 +1,5 @@
 import type { BoardingLock } from '../types/boardingLock';
+import type { LineNumber } from '../types/station';
 
 /**
  * #2290 P1-1 — 출발 leg의 boarding 대기(다음 열차 대기)가 이미 소진됐는지 판정.
@@ -24,4 +25,34 @@ export function hasConsumedOriginWait(lock: BoardingLock | null, now: number): b
   if (lock.boardingEvidence) return true;
   if (lock.initialEtaSeconds == null) return false;
   return now - lock.boardedAt >= lock.initialEtaSeconds * 1000;
+}
+
+/**
+ * #2393 — in-trip 판정 공통 헬퍼. HomeScreen(FG 표시 ETA)과 stationPipeline(BG 알림 body ETA)이
+ * 동일 판정을 쓰도록 추출 — 중복/드리프트 방지(이슈 스펙 "주의" 항목).
+ *
+ * RCA: lockless(boardingLock 없음) + legAdvance stamp 없음(하차 응답 미발생) 조합에서는
+ * 기존 두 신호(`hasConsumedOriginWait`, `legAdvanceLine`)가 모두 false로 떨어져, 이미 device가
+ * station-passed/도착 알람을 발사(주행 중 evidence)한 뒤에도 ETA가 출발 대기를 계속 합산했다
+ * (2026-08-27 성수→뚝섬 evidence: 실제 1분 hop인데 "6분"으로 표시).
+ *
+ * 신호 3개는 대체가 아니라 OR — 하나라도 "이미 탑승/주행 중" evidence면 in-trip.
+ * - `hasConsumedOriginWait(lock, now)` — #2290, lock 기반 탑승 evidence.
+ * - `legAdvanceLine !== null` — #2278, 사용자 하차 응답(다음 leg 진입 확정).
+ * - `hasFiredThisTrip` — #2393, 이 trip에 station-passed/도착 알람이 이미 발사됨
+ *   (`getFiredAlarms(destination.id)` non-empty). 발사됐다 = 주행 중이다(device-authority 정합).
+ *   #2154 준수 — 기존 firedAlarms 원장만 재사용, 새 감지 경로 신설 아님.
+ *
+ * @param lock - 현재 활성 BoardingLock.
+ * @param now - 판정 시각(ms epoch).
+ * @param legAdvanceLine - `useLegAdvanceStore`의 `nextLine`(하차 응답 stamp).
+ * @param hasFiredThisTrip - 이 trip destination에 대해 firedAlarms 원장이 non-empty인지 여부.
+ */
+export function isInTripByEvidence(
+  lock: BoardingLock | null,
+  now: number,
+  legAdvanceLine: LineNumber | null,
+  hasFiredThisTrip: boolean,
+): boolean {
+  return hasConsumedOriginWait(lock, now) || legAdvanceLine !== null || hasFiredThisTrip;
 }


### PR DESCRIPTION
Closes #2393

## 요약
2026-08-27 실탑승 evidence: lockless trip(boardingLock 없음)에서 device가 "성수 → 뚝섬 · 1정거장" 도착 알람을 발사했는데 표시 ETA가 6분(실제 1분 hop). 원인은 `isInTrip` 판정이 `hasConsumedOriginWait`(lock 기반)과 `legAdvanceLine`(하차 응답) 두 신호만 사용해, lockless + legAdvance stamp 없음 조합에서 항상 false로 떨어져 출발 대기(~5분)가 계속 합산된 것.

## 변경
- `src/shared/utils/boardingWait.ts` — `isInTripByEvidence(lock, now, legAdvanceLine, hasFiredThisTrip)` 공통 헬퍼 추가. 기존 `hasConsumedOriginWait` OR `legAdvanceLine !== null` OR `hasFiredThisTrip`(이 trip destination에 대해 firedAlarms 원장 non-empty). 기존 두 신호는 무변경, 신호 추가만(#2290 비역행).
- `src/screens/HomeScreen.tsx` — FG 표시 ETA. `getFiredAlarms`가 async라 `useEffect`+`useState`로 `hasFiredThisTrip` 도출(destination.id / effectiveOrigin.id 변경 시 재조회), `isInTripByEvidence`로 교체.
- `src/features/alarm/utils/stationPipeline.ts` — BG 알림 body ETA. 이미 입력으로 갖고 있는 `firedAlarms`(신규 read 없음)를 재사용해 `isInTripByEvidence`로 교체.
- 새 감지 알고리즘 신설 없음(#2154 준수) — 기존 `getFiredAlarms` 원장만 재사용.

## 테스트 (TDD red→green)
- `boardingWait.test.ts`: `isInTripByEvidence` 4 입력 조합(각 신호 단독 true / 전부 false) 단위 테스트.
- `stationPipeline.test.ts`: lockless + legAdvance 없음 + firedAlarms non-empty → `excludeOriginWait: true`(RED였던 케이스, 현재 GREEN). firedAlarms empty(출발 대기 중) → 기존대로 `excludeOriginWait: false` 유지(회귀 없음).
- 기존 #2290 lock/legAdvance 테스트 전부 유지.
- `npm test` — 455 suites / 9695 tests pass, 커버리지 100%(lines/functions/branches/statements).
- `npm run type-check` — pass.
- `npm run lint:orphan` — 0 orphan (공통 헬퍼 `isInTripByEvidence`는 HomeScreen.tsx / stationPipeline.ts 2 caller 존재).

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` pass. `isInTripByEvidence` export는 2 caller(HomeScreen.tsx, stationPipeline.ts) 존재.
2. **V/X** — 알림 body etaSuffix + HomeScreen displayEta. DebugModal에서 ETA 관측 가능.
3. **의존 PR** — N/A(독립).
4. **측정 plan** — 다음 실탑승 destination 알림 ETA vs 실소요(1정거장≈1~2분) 비교. 특히 성수→뚝섬류 1-hop 재현.
5. **Device verify** — 실기기 검증 필요. 탑승 번들 마지막에 1회(1정거장 ETA가 대기 미포함 값으로 표시되는지 확인). 코드-only CI는 type+unit만 커버.

## 알려진 edge (허용, 이슈 명시)
1-hop 초단거리 trip에서 첫 발사 시점엔 firedAlarms가 아직 비어 그 순간만 대기가 표시될 수 있음 — #2290이 tolerable로 둔 transient 범위, multi-hop(본 evidence)은 완전 커버.

관련: #2290, #2278, #2154, ADR-035