### PR TITLE
feat(#2395): FG phase(transfer/destination) 발사 봉인 해제 — device 로컬 발사 + 이중배너 방어

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -6,9 +6,17 @@
 // #2122 (FG 보조 발사) — 로컬 station-passed 배너 발사. 실제 expo-notifications 왕복 없이
 // 호출 여부/인자만 검증하기 위해 mock으로 격리.
 const mockFireFgAuxStationPassedNotification = jest.fn().mockResolvedValue(undefined);
+// #2395 (ADR-035 Phase1① — #2067 봉인 해제) — FG phase(transfer/destination) device 로컬 발사.
+const mockFireLocalAlarmNotification = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/stationNotification', () => ({
   fireFgAuxStationPassedNotification: (...args: unknown[]) =>
     mockFireFgAuxStationPassedNotification(...args),
+  fireLocalAlarmNotification: (...args: unknown[]) => mockFireLocalAlarmNotification(...args),
+}));
+
+const mockMarkLocalStationFired = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/recentLocalStationFires', () => ({
+  markLocalStationFired: (...args: unknown[]) => mockMarkLocalStationFired(...args),
 }));
 
 import { AppState } from 'react-native';
@@ -257,6 +265,10 @@ describe('useStationAlarm', () => {
     jest.clearAllMocks();
     setAppState('background');
     mockFireFgAuxStationPassedNotification.mockResolvedValue(undefined);
+    mockFireLocalAlarmNotification.mockResolvedValue(undefined);
+    mockMarkLocalStationFired.mockResolvedValue(undefined);
+    // #2395 — 기본 flag OFF(회귀 보존). 개별 describe에서 ON으로 재설정.
+    delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
     useSettingsStore.setState({ sleepMode: false, allowSpeaker: true });
     useAlarmEventStore.setState({ alarmEvent: null, dismissSilence: null });
     useUserIntentStore.setState({ infoModeEnabled: false });
@@ -1666,6 +1678,117 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => {
         expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta');
+      });
+    });
+
+    // #2395 (ADR-035 Phase1① — #2067 봉인 해제) — EXPO_PUBLIC_MINIMAL_ALARM 플래그로 FG도
+    // BG(stationPipeline #2379)와 동일하게 device 로컬 배너를 즉시 발사한다. markLocalStationFired
+    // 동반은 뒤늦게 도착하는 backend transfer/destination push의 이중배너를 억제하는 핵심 방어선
+    // (setupNotificationHandler의 isRecentLocalAuxFireDuplicate가 참조) — 빠뜨리면 acceptance 위반.
+    describe('#2395 EXPO_PUBLIC_MINIMAL_ALARM — FG phase device 로컬 발사', () => {
+      const originalEnv = process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+
+      afterEach(() => {
+        if (originalEnv === undefined) {
+          delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+        } else {
+          process.env.EXPO_PUBLIC_MINIMAL_ALARM = originalEnv;
+        }
+      });
+
+      describe('플래그 OFF (기본) — 회귀 가드: #2067 봉인 유지, device 로컬 발사 없음', () => {
+        beforeEach(() => {
+          delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+        });
+
+        it('destination phase 발사 시에도 fireLocalAlarmNotification을 호출하지 않는다', async () => {
+          mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+          renderHook(() =>
+            useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+          );
+
+          await waitFor(() => {
+            expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta');
+          });
+          expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+          expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+        });
+
+        it('transfer phase 발사 시에도 fireLocalAlarmNotification을 호출하지 않는다', async () => {
+          mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+
+          renderHook(() =>
+            useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+          );
+
+          await waitFor(() => {
+            expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyTransfer, 'eta');
+          });
+          expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+          expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('플래그 ON — device 로컬 발사 + markLocalStationFired 이중배너 방어', () => {
+        beforeEach(() => {
+          process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+        });
+
+        it('destination phase 발사 시 fireLocalAlarmNotification + markLocalStationFired("강남", "destination")를 호출한다', async () => {
+          mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+          renderHook(() =>
+            useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+          );
+
+          await waitFor(() => {
+            expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta');
+          });
+          await waitFor(() => {
+            expect(mockFireLocalAlarmNotification).toHaveBeenCalledWith(earlyDest, undefined);
+          });
+          expect(mockMarkLocalStationFired).toHaveBeenCalledWith('강남', 'destination');
+        });
+
+        it('transfer phase 발사 시 fireLocalAlarmNotification + markLocalStationFired("시청", "transfer")를 호출한다', async () => {
+          mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
+
+          renderHook(() =>
+            useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+          );
+
+          await waitFor(() => {
+            expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyTransfer, 'eta');
+          });
+          await waitFor(() => {
+            expect(mockFireLocalAlarmNotification).toHaveBeenCalledWith(earlyTransfer, undefined);
+          });
+          expect(mockMarkLocalStationFired).toHaveBeenCalledWith('시청', 'transfer');
+        });
+
+        it('fusionSource 전달 시 resolveNotificationSource 결과를 source로 전달한다', async () => {
+          mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+          renderHook(() =>
+            useStationAlarm(
+              defaultInputs({
+                route,
+                destination,
+                nearestStation: station,
+                fusionSource: 'position-train',
+                locationUncertain: false,
+              }),
+            ),
+          );
+
+          await waitFor(() => {
+            expect(mockFireLocalAlarmNotification).toHaveBeenCalledWith(
+              earlyDest,
+              'positionTrain',
+            );
+          });
+        });
       });
     });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -91,8 +91,12 @@ import { isStrongFusionSource } from '../../../shared/constants/fusionSourceStre
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import {
   fireFgAuxStationPassedNotification,
+  fireLocalAlarmNotification,
   type StationPassedTargetKind,
 } from '../utils/stationNotification';
+import { markLocalStationFired } from '../utils/recentLocalStationFires';
+import { resolveNotificationSource } from '../utils/notificationSource';
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 
 const logger = createLogger('StationAlarm');
 
@@ -1026,6 +1030,18 @@ export function useStationAlarm({
     // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거. 알람 배너는 원격 visible push가
     // 담당(Phase 2-backend). FG는 이제 dedup ledger 기록 + in-app store stamp만 수행한다.
     logFiredAlarm('fg', event, trigger);
+    // #2395 (ADR-035 Phase1① — #2067 봉인 해제) — EXPO_PUBLIC_MINIMAL_ALARM ON이면 FG도
+    // BG(stationPipeline #2379)와 동일하게 device 로컬 배너를 즉시 발사한다. markLocalStationFired
+    // 동반 필수 — 뒤늦게 도착하는 backend transfer/destination push(APNs 지연 실측 35~51s)를
+    // setupNotificationHandler의 isRecentLocalAuxFireDuplicate가 (station, kind) 매칭으로 억제해
+    // 이중배너를 막는다(#2122와 동일 방어 패턴).
+    if (isMinimalAlarmEnabled()) {
+      const notificationSource = fusionSource
+        ? resolveNotificationSource(fusionSource, locationUncertain)
+        : undefined;
+      await fireLocalAlarmNotification(event, notificationSource);
+      await markLocalStationFired(rawEvent.stationName, rawEvent.type);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- ADR-035 Phase1① — `useStationAlarm.ts`의 `fireAndLog` 내 #2067 봉인 지점에 `isMinimalAlarmEnabled()` 게이트로 device 로컬 FG phase(transfer/destination) 발사를 복원했습니다.
- `fireLocalAlarmNotification(event, notificationSource)` + `markLocalStationFired(rawEvent.stationName, rawEvent.type)`를 함께 호출합니다(BG `stationPipeline.ts`(#2379)와 동일 패턴).
- `notificationSource`는 hook의 `fusionSource`/`locationUncertain`을 `resolveNotificationSource`로 변환해 BG와 동일 SSoT를 재사용합니다.

## 이중배너 방어 (핵심 acceptance)
`markLocalStationFired` 동반 호출이 필수입니다 — device가 FG phase 배너를 먼저 쏜 뒤 뒤늦게 도착하는 backend transfer/destination push(APNs 지연 실측 35~51s)를 `setupNotificationHandler`의 `isRecentLocalAuxFireDuplicate`가 `(station, kind)` 매칭으로 억제합니다(`BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND`가 transfer→'transfer', destination→'destination'로 이미 매핑됨, #2122와 동일 방어 패턴).

## 변경 파일
- `src/features/alarm/hooks/useStationAlarm.ts` — `fireAndLog` 배선만 추가. SSoT gate/`markStationFired`/legAdvance/기존 dedup 로직 무변경.
- `src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` — flag OFF 회귀 가드 2건 + flag ON 발사/markLocalStationFired 검증 3건 추가.

## 금지사항 준수
- `MINIMAL_ALARM` 기본값 변경 없음(여전히 flag 뒤 배선만).
- station-passed FG aux(#2122)·BG 경로(#2379) 무변경.
- 새 감지/발사 아키텍처 신설 없음.

## 검증
- `npm test` — 9655 passed, coverage 100%(lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단
1. **Orphan** — pass. 신규 import(`fireLocalAlarmNotification`, `markLocalStationFired`, `resolveNotificationSource`, `isMinimalAlarmEnabled`)는 모두 `fireAndLog` 내부에서 호출되는 실제 caller 존재.
2. **V/X** — FG 알림 배너(실기기) + DebugModal fire 로그(`logFiredAlarm('fg', ...)`, `addDomainBreadcrumb('alarm', 'fire-local', ...)`). 이중배너 발생 여부는 device 관측 필요.
3. **의존 PR** — N/A(독립). 단 Phase2(backend 퇴역) 전까지는 `markLocalStationFired` 이중배너 방어에 의존.
4. **측정 plan** — 다음 실탑승 FG에서 transfer/destination 배너가 device 즉시 발사 후 뒤늦은 backend push가 collapse(단일 배너만 표시)되는지 확인. 회귀 시 두 배너가 모두 뜨는지 로그로 확인.
5. **Device verify** — 🔴 필수, 탑승 번들 마지막. 시나리오: FG 활성 상태로 환승/도착 접근 → 배너 1개만(이중 아님) + backend push 35~51s 후 collapse. 코드-only CI는 type+unit만 커버.

Closes #2395