### PR TITLE
chore(#2398): boardingPrompt 버튼 미표시 근본 계측

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
@@ -19,6 +19,7 @@ jest.mock('expo-notifications', () => ({
 }));
 jest.mock('../../utils/alarmLog', () => ({
   logBoardingPromptFired: jest.fn(),
+  logBoardingPromptCategoryReceived: jest.fn(),
 }));
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -29,7 +30,9 @@ jest.mock('../../../../shared/utils/logger', () => ({
   }),
 }));
 
-const { logBoardingPromptFired } = jest.requireMock('../../utils/alarmLog');
+const { logBoardingPromptFired, logBoardingPromptCategoryReceived } = jest.requireMock(
+  '../../utils/alarmLog',
+);
 
 const VALID_DATA = {
   kind: 'boarding-prompt',
@@ -146,6 +149,51 @@ describe('useBoardingPromptDisplayLogger (#1385 / #1419)', () => {
     renderHook(() => useBoardingPromptDisplayLogger());
     registeredHandler!(makeNotification({ categoryIdentifier: null }));
     expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  // #2398 — early-return 직전 진단 계측 3케이스: null / 미스매치 / 정상.
+  describe('진단 계측 — logBoardingPromptCategoryReceived (#2398)', () => {
+    it('categoryIdentifier null → categoryIdentifier=null + payloadMatched 기록 (기존 동작 무변경)', () => {
+      renderHook(() => useBoardingPromptDisplayLogger());
+      registeredHandler!(makeNotification({ categoryIdentifier: null }));
+      expect(logBoardingPromptCategoryReceived).toHaveBeenCalledWith({
+        categoryIdentifier: null,
+        payloadMatched: true,
+      });
+      expect(logBoardingPromptFired).not.toHaveBeenCalled();
+    });
+
+    it('categoryIdentifier 미스매치 → 수신값 그대로 기록 (기존 동작 무변경)', () => {
+      renderHook(() => useBoardingPromptDisplayLogger());
+      registeredHandler!(makeNotification({ categoryIdentifier: 'OTHER_CATEGORY' }));
+      expect(logBoardingPromptCategoryReceived).toHaveBeenCalledWith({
+        categoryIdentifier: 'OTHER_CATEGORY',
+        payloadMatched: true,
+      });
+      expect(logBoardingPromptFired).not.toHaveBeenCalled();
+    });
+
+    it('categoryIdentifier 정상 매칭 → 매칭값 + payloadMatched=true 기록 (기존 동작 무변경)', () => {
+      renderHook(() => useBoardingPromptDisplayLogger());
+      registeredHandler!(makeNotification({ identifier: 'n-diag' }));
+      expect(logBoardingPromptCategoryReceived).toHaveBeenCalledWith({
+        categoryIdentifier: BOARDING_PROMPT_CATEGORY,
+        payloadMatched: true,
+      });
+      expect(logBoardingPromptFired).toHaveBeenCalledWith({
+        originStation: '강남',
+        line: '2',
+      });
+    });
+
+    it('payload schema 미일치 → payloadMatched=false 기록', () => {
+      renderHook(() => useBoardingPromptDisplayLogger());
+      registeredHandler!(makeNotification({ data: { kind: 'reschedule' } }));
+      expect(logBoardingPromptCategoryReceived).toHaveBeenCalledWith({
+        categoryIdentifier: BOARDING_PROMPT_CATEGORY,
+        payloadMatched: false,
+      });
+    });
   });
 
   it('payload schema 미일치(kind 다름) → no-op', () => {

--- a/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
+++ b/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
@@ -29,7 +29,7 @@ import { useEffect } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import { BOARDING_PROMPT_CATEGORY, DISEMBARK_PROMPT_CATEGORY } from '../utils/notificationCategory';
-import { logBoardingPromptFired } from '../utils/alarmLog';
+import { logBoardingPromptFired, logBoardingPromptCategoryReceived } from '../utils/alarmLog';
 import { extractBoardingPromptPayload } from './useBoardingPromptResponder';
 import { createLogger } from '../../../shared/utils/logger';
 
@@ -74,13 +74,19 @@ function tryLogDisplayed(notification: Notifications.Notification): void {
   try {
     const request = notification.request;
     const content = request.content;
+    const payload = extractBoardingPromptPayload(content.data);
+    // #2398 — 진단 계측: early-return 판정 직전, 수신한 categoryIdentifier 실제 값(null 포함)
+    // + payload 매칭 여부를 매 수신 건마다 device 덤프로 가시화. behavior 무변경.
+    logBoardingPromptCategoryReceived({
+      categoryIdentifier: content.categoryIdentifier ?? null,
+      payloadMatched: payload !== null,
+    });
     // #2282 — hop-end 는 DISEMBARK_PROMPT_CATEGORY로 분리 발사되므로 두 category 모두 displayed 적재.
     if (
       content.categoryIdentifier !== BOARDING_PROMPT_CATEGORY &&
       content.categoryIdentifier !== DISEMBARK_PROMPT_CATEGORY
     )
       return;
-    const payload = extractBoardingPromptPayload(content.data);
     if (!payload) return;
     const identifier = request.identifier;
     if (typeof identifier !== 'string' || identifier.length === 0) return;

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -84,6 +84,9 @@ import {
   countAlarmLogReasonsByWindow,
   lastNReasons,
   logBoardingPromptFired,
+  logCategoryRegistrationSucceeded,
+  logCategoryRegistrationFailed,
+  logBoardingPromptCategoryReceived,
   logBoardingPromptResponded,
   logCompanionAlarmFired,
   logLastTrainAlarmFired,
@@ -2502,6 +2505,54 @@ describe('alarmLog', () => {
       expect(saved[0].source).toBe('companion');
       expect(saved[0].outcome).toBe('fired');
       expect(saved[0].stationName).toBe('2·뚝섬');
+    });
+
+    it('#2398: logCategoryRegistrationSucceeded가 category-registration entry(outcome=fired)를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logCategoryRegistrationSucceeded({
+        categoryId: 'BOARDING_PROMPT',
+        buttonTitles: ['탑승', '아직이요'],
+      });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('category-registration');
+      expect(saved[0].outcome).toBe('fired');
+      expect(saved[0].stationName).toBe('BOARDING_PROMPT:buttons=2:[탑승|아직이요]');
+    });
+
+    it('#2398: logCategoryRegistrationFailed가 category-registration entry(outcome=suppressed)를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logCategoryRegistrationFailed({
+        categoryId: 'BOARDING_PROMPT',
+        errorMessage: 'not supported',
+      });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('category-registration');
+      expect(saved[0].outcome).toBe('suppressed');
+      expect(saved[0].reason).toBe('category-registration-failed');
+      expect(saved[0].stationName).toBe('BOARDING_PROMPT:not supported');
+    });
+
+    it('#2398: logBoardingPromptCategoryReceived가 boarding-prompt-category-received entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardingPromptCategoryReceived({ categoryIdentifier: 'BOARDING_PROMPT', payloadMatched: true });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('boarding-prompt-category-received');
+      expect(saved[0].outcome).toBe('received');
+      expect(saved[0].stationName).toBe('category=BOARDING_PROMPT:payloadMatched=true');
+    });
+
+    it('#2398: logBoardingPromptCategoryReceived — categoryIdentifier null은 "null" 문자열로 인코딩', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardingPromptCategoryReceived({ categoryIdentifier: null, payloadMatched: false });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved[0].stationName).toBe('category=null:payloadMatched=false');
     });
 
     it('#2284 (P1 wire matrix gap): logLastTrainAlarmFired가 last-train-alarm entry를 적재한다', async () => {

--- a/src/features/alarm/utils/__tests__/notificationCategory.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationCategory.test.ts
@@ -22,6 +22,14 @@ import {
 jest.mock('expo-notifications', () => ({
   setNotificationCategoryAsync: jest.fn(),
 }));
+jest.mock('../alarmLog', () => ({
+  logCategoryRegistrationSucceeded: jest.fn(),
+  logCategoryRegistrationFailed: jest.fn(),
+}));
+
+const { logCategoryRegistrationSucceeded, logCategoryRegistrationFailed } = jest.requireMock(
+  '../alarmLog',
+);
 
 installLanguageRestoreHook();
 
@@ -66,6 +74,40 @@ describe('setupBoardingPromptCategory (#819)', () => {
     );
     await expect(setupBoardingPromptCategory()).resolves.toBeUndefined();
   });
+
+  // #2398 — 진단 계측: 등록 성공/실패 로그 호출 검증.
+  it('등록 성공 시 logCategoryRegistrationSucceeded 호출 (#2398)', async () => {
+    await setupBoardingPromptCategory();
+    expect(logCategoryRegistrationSucceeded).toHaveBeenCalledWith({
+      categoryId: BOARDING_PROMPT_CATEGORY,
+      buttonTitles: [
+        i18next.t('notifications.actions.boardingConfirm'),
+        i18next.t('notifications.actions.notYet'),
+      ],
+    });
+    expect(logCategoryRegistrationFailed).not.toHaveBeenCalled();
+  });
+
+  it('등록 실패 시 logCategoryRegistrationFailed 호출 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await setupBoardingPromptCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: BOARDING_PROMPT_CATEGORY,
+      errorMessage: 'not supported',
+    });
+    expect(logCategoryRegistrationSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('non-Error throw도 문자열로 변환해 기록 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce('boom');
+    await setupBoardingPromptCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: BOARDING_PROMPT_CATEGORY,
+      errorMessage: 'boom',
+    });
+  });
 });
 
 describe('setupDisembarkPromptCategory (#2282)', () => {
@@ -97,6 +139,38 @@ describe('setupDisembarkPromptCategory (#2282)', () => {
       new Error('not supported'),
     );
     await expect(setupDisembarkPromptCategory()).resolves.toBeUndefined();
+  });
+
+  // #2398 — 진단 계측: 등록 성공/실패 로그 호출 검증.
+  it('등록 성공 시 logCategoryRegistrationSucceeded 호출 (#2398)', async () => {
+    await setupDisembarkPromptCategory();
+    expect(logCategoryRegistrationSucceeded).toHaveBeenCalledWith({
+      categoryId: DISEMBARK_PROMPT_CATEGORY,
+      buttonTitles: [
+        i18next.t('notifications.actions.disembarkConfirm'),
+        i18next.t('notifications.actions.notYet'),
+      ],
+    });
+  });
+
+  it('등록 실패 시 logCategoryRegistrationFailed 호출 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await setupDisembarkPromptCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: DISEMBARK_PROMPT_CATEGORY,
+      errorMessage: 'not supported',
+    });
+  });
+
+  it('non-Error throw도 문자열로 변환해 기록 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce('boom');
+    await setupDisembarkPromptCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: DISEMBARK_PROMPT_CATEGORY,
+      errorMessage: 'boom',
+    });
   });
 });
 
@@ -140,6 +214,38 @@ describe('setupAlarmCategory (#1798 P2)', () => {
     );
     await expect(setupAlarmCategory()).resolves.toBeUndefined();
   });
+
+  // #2398 — 진단 계측: 등록 성공/실패 로그 호출 검증.
+  it('등록 성공 시 logCategoryRegistrationSucceeded 호출 (#2398)', async () => {
+    await setupAlarmCategory();
+    expect(logCategoryRegistrationSucceeded).toHaveBeenCalledWith({
+      categoryId: ALARM_CATEGORY,
+      buttonTitles: [
+        i18next.t('notifications.actions.acknowledge'),
+        i18next.t('notifications.actions.endTrip'),
+      ],
+    });
+  });
+
+  it('등록 실패 시 logCategoryRegistrationFailed 호출 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await setupAlarmCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: ALARM_CATEGORY,
+      errorMessage: 'not supported',
+    });
+  });
+
+  it('non-Error throw도 문자열로 변환해 기록 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce('boom');
+    await setupAlarmCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: ALARM_CATEGORY,
+      errorMessage: 'boom',
+    });
+  });
 });
 
 describe('setupTripEndedCategory (#1798 P2)', () => {
@@ -175,5 +281,34 @@ describe('setupTripEndedCategory (#1798 P2)', () => {
       new Error('not supported'),
     );
     await expect(setupTripEndedCategory()).resolves.toBeUndefined();
+  });
+
+  // #2398 — 진단 계측: 등록 성공/실패 로그 호출 검증.
+  it('등록 성공 시 logCategoryRegistrationSucceeded 호출 (#2398)', async () => {
+    await setupTripEndedCategory();
+    expect(logCategoryRegistrationSucceeded).toHaveBeenCalledWith({
+      categoryId: TRIP_ENDED_CATEGORY,
+      buttonTitles: [i18next.t('notifications.actions.nextTrip')],
+    });
+  });
+
+  it('등록 실패 시 logCategoryRegistrationFailed 호출 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await setupTripEndedCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: TRIP_ENDED_CATEGORY,
+      errorMessage: 'not supported',
+    });
+  });
+
+  it('non-Error throw도 문자열로 변환해 기록 (#2398)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce('boom');
+    await setupTripEndedCategory();
+    expect(logCategoryRegistrationFailed).toHaveBeenCalledWith({
+      categoryId: TRIP_ENDED_CATEGORY,
+      errorMessage: 'boom',
+    });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -125,7 +125,16 @@ export type AlarmLogSource =
   // 발사 stamp. `expo-notifications`에 `trigger: null`로 예약하므로 스케줄 호출 자체가 곧
   // 사용자 노출 확정 시점 — bg-scheduled(OS DATE trigger, 취소 가능한 미래 예약)와 달리
   // "예약≠발사" 갭이 없는 확정 발사다.
-  | 'last-train-alarm';
+  | 'last-train-alarm'
+  // #2398 — boardingPrompt 버튼 미표시 근본 계측. UNNotificationCategory 등록 성공/실패 stamp.
+  // `setup*Category`(notificationCategory.ts) 4종이 앱 부팅 시 이 source로 outcome='fired'
+  // (등록 성공, id+버튼 개수/타이틀 기록) 또는 outcome='suppressed'(등록 실패, catch 삼킨 에러
+  // 가시화)를 적재한다. 순수 진단 — 등록 로직/graceful catch는 무변경.
+  | 'category-registration'
+  // #2398 — boardingPrompt 알림 수신 시 실제 categoryIdentifier 값 계측. `useBoardingPromptDisplayLogger`
+  // `tryLogDisplayed`가 early-return(categoryIdentifier 미스매치) 직전 매 수신 건마다 적재 —
+  // "backend push에 aps.category가 실제로 실렸는가"를 device 덤프로 판정한다.
+  | 'boarding-prompt-category-received';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -135,6 +144,8 @@ export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'lock-line-mismatch'는 BoardingLock 활성 시 nextWaypoint가 lock.boardingLine에 정차하지
 // 않는 다른 leg/노선의 silent push로 판정돼 차단된 케이스 (#707).
 export type AlarmLogReason =
+  // #2398 — UNNotificationCategory 등록 실패(setNotificationCategoryAsync reject/throw) stamp.
+  | 'category-registration-failed'
   | 'dedup-station'
   | 'dedup-alarm'
   // #1515 — station-level cross-category dedup. firedAlarms(phase) + lastNotifiedStationId(station-passed)
@@ -1435,6 +1446,10 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'push-contract-skew': null,
   // #2284 — 막차 알람은 silent push와 무관한 device 로컬 채널이므로 이 counter 제외.
   'last-train-alarm': null,
+  // #2398 — category 등록 성공/실패는 silent push와 무관한 진단 stamp.
+  'category-registration': null,
+  // #2398 — 수신 categoryIdentifier 진단 stamp도 silent push outcome과 무관.
+  'boarding-prompt-category-received': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1496,6 +1511,10 @@ const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
   'push-contract-skew': true,
   // #2284 (P1) — 즉시 발사(trigger: null) 확정 알람. 실제 사용자 노출이므로 fire 분모 포함.
   'last-train-alarm': true,
+  // #2398 — category 등록 성공(outcome='fired')은 사용자 노출 알람이 아닌 진단 stamp. fire 분모 제외.
+  'category-registration': false,
+  // #2398 — 수신 categoryIdentifier 진단 stamp(outcome='received')도 fire 분모 제외.
+  'boarding-prompt-category-received': false,
 };
 
 /**
@@ -2037,6 +2056,58 @@ export function logBoardingPromptFired(input: { originStation: string; line: str
     source: 'boarding-prompt',
     outcome: 'fired',
     stationName: `${input.line}·${input.originStation}`,
+  });
+}
+
+/**
+ * #2398 — UNNotificationCategory 등록 성공 1건 적재. `setup*Category`(notificationCategory.ts)가
+ * `setNotificationCategoryAsync` 성공 직후 호출. categoryId + 버튼 개수/타이틀을 stationName
+ * 슬롯에 인코딩 — 기존 schema 확장 없이 DebugModal 가시화(logBoardingPromptFired 패턴 재사용).
+ */
+export function logCategoryRegistrationSucceeded(input: {
+  categoryId: string;
+  buttonTitles: string[];
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'category-registration',
+    outcome: 'fired',
+    stationName: `${input.categoryId}:buttons=${input.buttonTitles.length}:[${input.buttonTitles.join('|')}]`,
+  });
+}
+
+/**
+ * #2398 — UNNotificationCategory 등록 실패 1건 적재. `setup*Category`의 삼킨 `catch {}`에서
+ * 호출 — graceful 유지(throw 재전파 없음)한 채 실패 흔적만 device 덤프로 가시화.
+ */
+export function logCategoryRegistrationFailed(input: {
+  categoryId: string;
+  errorMessage: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'category-registration',
+    outcome: 'suppressed',
+    reason: 'category-registration-failed',
+    stationName: `${input.categoryId}:${input.errorMessage}`,
+  });
+}
+
+/**
+ * #2398 — boardingPrompt 알림 수신 시 실제 categoryIdentifier 값 1건 적재.
+ * `useBoardingPromptDisplayLogger.tryLogDisplayed`가 early-return 여부 판정 직전, 매 수신
+ * notification마다 호출한다. categoryIdentifier가 null이면 문자열 'null'로 인코딩(AlarmLogEntry
+ * stationName은 string만 허용).
+ */
+export function logBoardingPromptCategoryReceived(input: {
+  categoryIdentifier: string | null;
+  payloadMatched: boolean;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'boarding-prompt-category-received',
+    outcome: 'received',
+    stationName: `category=${input.categoryIdentifier ?? 'null'}:payloadMatched=${input.payloadMatched}`,
   });
 }
 

--- a/src/features/alarm/utils/notificationCategory.ts
+++ b/src/features/alarm/utils/notificationCategory.ts
@@ -20,6 +20,10 @@
 
 import * as Notifications from 'expo-notifications';
 import i18next from 'i18next';
+import {
+  logCategoryRegistrationSucceeded,
+  logCategoryRegistrationFailed,
+} from './alarmLog';
 
 /** APNs payload `aps.category`와 1:1 매칭. backend `BOARDING_PROMPT_CATEGORY`와 동기. */
 export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
@@ -58,27 +62,37 @@ export const TRIP_ENDED_ACTION_NEXT_TRIP = 'TRIP_ENDED_ACTION_NEXT_TRIP';
  * 같은 listener가 default action으로 호출되니 trainCode 자동 lock은 계속 동작.
  */
 export async function setupBoardingPromptCategory(): Promise<void> {
+  const actions = [
+    {
+      identifier: BOARDING_PROMPT_ACTION_BOARDED,
+      buttonTitle: i18next.t('notifications.actions.boardingConfirm'),
+      options: {
+        opensAppToForeground: true,
+      },
+    },
+    {
+      identifier: BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      buttonTitle: i18next.t('notifications.actions.notYet'),
+      options: {
+        // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
+        opensAppToForeground: false,
+        isDestructive: true,
+      },
+    },
+  ];
   try {
-    await Notifications.setNotificationCategoryAsync(BOARDING_PROMPT_CATEGORY, [
-      {
-        identifier: BOARDING_PROMPT_ACTION_BOARDED,
-        buttonTitle: i18next.t('notifications.actions.boardingConfirm'),
-        options: {
-          opensAppToForeground: true,
-        },
-      },
-      {
-        identifier: BOARDING_PROMPT_ACTION_NOT_BOARDED,
-        buttonTitle: i18next.t('notifications.actions.notYet'),
-        options: {
-          // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
-          opensAppToForeground: false,
-          isDestructive: true,
-        },
-      },
-    ]);
-  } catch {
-    // graceful — Android/예외 시 기본 동작으로 폴백.
+    await Notifications.setNotificationCategoryAsync(BOARDING_PROMPT_CATEGORY, actions);
+    // #2398 — 등록 성공 진단 계측.
+    logCategoryRegistrationSucceeded({
+      categoryId: BOARDING_PROMPT_CATEGORY,
+      buttonTitles: actions.map((a) => a.buttonTitle),
+    });
+  } catch (err) {
+    // graceful — Android/예외 시 기본 동작으로 폴백. #2398 — 삼킨 에러를 device 덤프로 가시화.
+    logCategoryRegistrationFailed({
+      categoryId: BOARDING_PROMPT_CATEGORY,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
@@ -88,27 +102,37 @@ export async function setupBoardingPromptCategory(): Promise<void> {
  * 같은 listener가 default action으로 호출되니 `handleHopEndResponse`는 계속 동작.
  */
 export async function setupDisembarkPromptCategory(): Promise<void> {
+  const actions = [
+    {
+      identifier: DISEMBARK_ACTION_DISEMBARKED,
+      buttonTitle: i18next.t('notifications.actions.disembarkConfirm'),
+      options: {
+        opensAppToForeground: true,
+      },
+    },
+    {
+      identifier: DISEMBARK_ACTION_NOT_YET,
+      buttonTitle: i18next.t('notifications.actions.notYet'),
+      options: {
+        // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
+        opensAppToForeground: false,
+        isDestructive: true,
+      },
+    },
+  ];
   try {
-    await Notifications.setNotificationCategoryAsync(DISEMBARK_PROMPT_CATEGORY, [
-      {
-        identifier: DISEMBARK_ACTION_DISEMBARKED,
-        buttonTitle: i18next.t('notifications.actions.disembarkConfirm'),
-        options: {
-          opensAppToForeground: true,
-        },
-      },
-      {
-        identifier: DISEMBARK_ACTION_NOT_YET,
-        buttonTitle: i18next.t('notifications.actions.notYet'),
-        options: {
-          // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
-          opensAppToForeground: false,
-          isDestructive: true,
-        },
-      },
-    ]);
-  } catch {
-    // graceful — Android/예외 시 기본 동작으로 폴백.
+    await Notifications.setNotificationCategoryAsync(DISEMBARK_PROMPT_CATEGORY, actions);
+    // #2398 — 등록 성공 진단 계측.
+    logCategoryRegistrationSucceeded({
+      categoryId: DISEMBARK_PROMPT_CATEGORY,
+      buttonTitles: actions.map((a) => a.buttonTitle),
+    });
+  } catch (err) {
+    // graceful — Android/예외 시 기본 동작으로 폴백. #2398 — 삼킨 에러를 device 덤프로 가시화.
+    logCategoryRegistrationFailed({
+      categoryId: DISEMBARK_PROMPT_CATEGORY,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
@@ -117,26 +141,36 @@ export async function setupDisembarkPromptCategory(): Promise<void> {
  * 앱 부팅 시 1회 호출. 실패는 graceful — 미등록 시 액션 없는 alert로 폴백.
  */
 export async function setupAlarmCategory(): Promise<void> {
+  const actions = [
+    {
+      identifier: ALARM_ACTION_ACKNOWLEDGE,
+      buttonTitle: i18next.t('notifications.actions.acknowledge'),
+      options: {
+        opensAppToForeground: false,
+      },
+    },
+    {
+      identifier: ALARM_ACTION_END_TRIP,
+      buttonTitle: i18next.t('notifications.actions.endTrip'),
+      options: {
+        opensAppToForeground: false,
+        isDestructive: true,
+      },
+    },
+  ];
   try {
-    await Notifications.setNotificationCategoryAsync(ALARM_CATEGORY, [
-      {
-        identifier: ALARM_ACTION_ACKNOWLEDGE,
-        buttonTitle: i18next.t('notifications.actions.acknowledge'),
-        options: {
-          opensAppToForeground: false,
-        },
-      },
-      {
-        identifier: ALARM_ACTION_END_TRIP,
-        buttonTitle: i18next.t('notifications.actions.endTrip'),
-        options: {
-          opensAppToForeground: false,
-          isDestructive: true,
-        },
-      },
-    ]);
-  } catch {
-    // graceful — Android/예외 시 기본 동작으로 폴백.
+    await Notifications.setNotificationCategoryAsync(ALARM_CATEGORY, actions);
+    // #2398 — 등록 성공 진단 계측.
+    logCategoryRegistrationSucceeded({
+      categoryId: ALARM_CATEGORY,
+      buttonTitles: actions.map((a) => a.buttonTitle),
+    });
+  } catch (err) {
+    // graceful — Android/예외 시 기본 동작으로 폴백. #2398 — 삼킨 에러를 device 덤프로 가시화.
+    logCategoryRegistrationFailed({
+      categoryId: ALARM_CATEGORY,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
@@ -145,17 +179,27 @@ export async function setupAlarmCategory(): Promise<void> {
  * 앱 부팅 시 1회 호출. 실패는 graceful — 미등록 시 액션 없는 alert로 폴백.
  */
 export async function setupTripEndedCategory(): Promise<void> {
-  try {
-    await Notifications.setNotificationCategoryAsync(TRIP_ENDED_CATEGORY, [
-      {
-        identifier: TRIP_ENDED_ACTION_NEXT_TRIP,
-        buttonTitle: i18next.t('notifications.actions.nextTrip'),
-        options: {
-          opensAppToForeground: true,
-        },
+  const actions = [
+    {
+      identifier: TRIP_ENDED_ACTION_NEXT_TRIP,
+      buttonTitle: i18next.t('notifications.actions.nextTrip'),
+      options: {
+        opensAppToForeground: true,
       },
-    ]);
-  } catch {
-    // graceful — Android/예외 시 기본 동작으로 폴백.
+    },
+  ];
+  try {
+    await Notifications.setNotificationCategoryAsync(TRIP_ENDED_CATEGORY, actions);
+    // #2398 — 등록 성공 진단 계측.
+    logCategoryRegistrationSucceeded({
+      categoryId: TRIP_ENDED_CATEGORY,
+      buttonTitles: actions.map((a) => a.buttonTitle),
+    });
+  } catch (err) {
+    // graceful — Android/예외 시 기본 동작으로 폴백. #2398 — 삼킨 에러를 device 덤프로 가시화.
+    logCategoryRegistrationFailed({
+      categoryId: TRIP_ENDED_CATEGORY,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
   }
 }


### PR DESCRIPTION
Closes #2398

## 배경
boardingPrompt 알림은 뜨는데 탑승/미탑승 액션 버튼이 잠금화면 포함 한 번도 안 나오는 증상. 정적 코드 검증으로는 category 등록 코드/backend payload/i18n 키 모두 정상 — 런타임 원인 2개(device category 등록 실패 vs 도착 push의 aps.category 실제 누락)만 남았고, 둘 다 흔적이 없어 계측 없이는 확정 불가.

**본 PR은 순수 진단 계측**. behavior 무변경.

## 변경
1. `src/features/alarm/utils/notificationCategory.ts` — 4개 `setup*Category` 함수:
   - `setNotificationCategoryAsync` 성공 직후 `logCategoryRegistrationSucceeded`(categoryId + 버튼 개수/타이틀) 호출
   - 삼킨 `catch {}`에 `logCategoryRegistrationFailed`(categoryId + 에러 메시지) 호출 — graceful 유지, throw 재전파 없음
2. `src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts` `tryLogDisplayed` — early-return(categoryIdentifier 미스매치) 판정 직전, 매 수신 notification마다 `logBoardingPromptCategoryReceived`(수신 categoryIdentifier 실제 값, null 포함 + payload 매칭 여부) 호출
3. `src/features/alarm/utils/alarmLog.ts` — 새 `AlarmLogSource` 2종(`category-registration`, `boarding-prompt-category-received`) + reason(`category-registration-failed`) + 3개 헬퍼 함수 추가. 기존 `SILENT_PUSH_OUTCOME_SOURCES`/`FIRED_ALARM_SOURCES` Record에도 두 source를 `null`/`false`로 명시 등록(진단 stamp이므로 silent push 통계·fire 분모 모두 제외).

## 관측 요건 확인 — 사용된 덤프 채널
`appendAlarmLog()` → `getAlarmLog()`가 DebugModal(`src/features/debug/components/DebugModal.tsx:2311`, `setLogs(await getAlarmLog())`)이 실제로 읽는 채널임을 코드에서 확인. 기존 `logBoardingPromptFired`와 동일한 SSoT 패턴(alarmLog ring buffer)을 그대로 재사용했다 — `logger.warn`만으로는 덤프에 안 뜨는 문제를 원천 차단.

## 금지사항 준수
- 알림 발사/등록 동작 무변경 — category 등록 로직/타이밍/순서 무변경(단, 성공 로그를 위해 `setNotificationCategoryAsync` 호출 인자를 인라인 배열에서 `const actions = [...]` 변수로 추출했을 뿐 — 전달되는 값·순서 동일).
- 삼킨 catch는 로그만 추가, graceful 유지(throw 재전파 없음).
- `tryLogDisplayed`의 payload 추출(`extractBoardingPromptPayload`)을 진단 로그를 위해 카테고리 체크보다 앞으로 옮겼으나, 이 함수는 순수/무부수효과 검증 함수라 이후 실제 early-return 분기·dedup·적재 로직의 순서/결과는 완전히 동일 — 응답 처리/dedup 무변경.

## Wire-completion 5단
1. **Orphan** — pass (`npm run lint:orphan` → No orphan exports detected).
2. **V/X dashboard** — 🔴 DebugModal이 `getAlarmLog()`로 alarmLog ring buffer를 읽어 표시 → 등록 성공/실패(`category-registration` source) + 수신 categoryIdentifier(`boarding-prompt-category-received` source)가 device 덤프에 그대로 노출.
3. **의존 PR** — N/A.
4. **측정 plan** — 다음 탑승 후 device 덤프에서 (A) `category-registration` source의 outcome이 전부 `fired`인지(등록 실패 없음 확인), (B) `boarding-prompt-category-received` source의 stationName에 실제 수신된 categoryIdentifier 값이 `BOARDING_PROMPT`/`DISEMBARK_PROMPT`로 찍히는지 확인 — 둘 중 하나라도 이상하면 root 확정(A=device 등록 실패, B=backend category 누락).
5. **Device verify** — 🔴 필요. 다음 탑승 번들에 합류 — boardingPrompt 발사 시 DebugModal 덤프 캡처 필요.

## 테스트
- `npm test` — 9675개 전체 통과, 커버리지 100% (lines/branches/functions/statements) 유지.
- `npm run type-check` — 통과.
- `npm run lint:orphan` — 0 orphan.
- setup 함수 성공/실패 경로(Error/non-Error 둘 다) 로그 호출 검증 — `notificationCategory.test.ts`.
- `tryLogDisplayed` null/미스매치/정상/payload 미일치 4케이스 진단 로그 호출 + 기존 동작(early-return/적재/dedup) 무변경 검증 — `useBoardingPromptDisplayLogger.test.ts`.
- alarmLog 헬퍼 3종 직접 단위 테스트(entry 필드 검증) — `alarmLog.test.ts`.

