### PR TITLE
chore(#2403): BG 지하 실시간성 계측 — 위치 task 발화 heartbeat 덤프 가시화

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -87,6 +87,7 @@ import {
   logCategoryRegistrationSucceeded,
   logCategoryRegistrationFailed,
   logBoardingPromptCategoryReceived,
+  logBgTaskHeartbeat,
   logBoardingPromptResponded,
   logCompanionAlarmFired,
   logLastTrainAlarmFired,
@@ -1568,6 +1569,34 @@ describe('alarmLog', () => {
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
       const matching = saved.filter((e) => e.reason === 'gate-accuracy');
       expect(matching).toHaveLength(1);
+    });
+
+    it('#2403 logBgTaskHeartbeat: source=bg-task-heartbeat, outcome=received로 location과 함께 적재한다', async () => {
+      const location = { lat: 37.5, lng: 127.0, accuracy: 12, ageMs: 500 };
+      logBgTaskHeartbeat(location);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg-task-heartbeat',
+        outcome: 'received',
+        location,
+      });
+    });
+
+    it('#2403 logBgTaskHeartbeat: burst dedup 없이 연속 호출마다 개별 entry를 적재한다 (발화 간격 측정 목적)', async () => {
+      _resetBurstSuppressWindowForTests();
+      const location = { lat: 37.5, lng: 127.0, accuracy: 12, ageMs: 500 };
+      logBgTaskHeartbeat(location);
+      logBgTaskHeartbeat(location);
+      logBgTaskHeartbeat(location);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.source === 'bg-task-heartbeat');
+      expect(matching).toHaveLength(3);
     });
 
     it('#2339 logSuppressedGate: different reasons are NOT deduped against each other', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -134,7 +134,13 @@ export type AlarmLogSource =
   // #2398 — boardingPrompt 알림 수신 시 실제 categoryIdentifier 값 계측. `useBoardingPromptDisplayLogger`
   // `tryLogDisplayed`가 early-return(categoryIdentifier 미스매치) 직전 매 수신 건마다 적재 —
   // "backend push에 aps.category가 실제로 실렸는가"를 device 덤프로 판정한다.
-  | 'boarding-prompt-category-received';
+  | 'boarding-prompt-category-received'
+  // #2403 — BG 지하 실시간성 계측. `BACKGROUND_LOCATION_TASK`가 매 tick `latest` fix를 확보한
+  // 직후, 기존 gate(gate-age/gate-accuracy)/발사 로직보다 먼저 1건 적재한다. gate에 걸려 조기
+  // return하거나 position-train 경로로 fire하는 tick도 이 heartbeat는 남으므로, 덤프에서
+  // "BG task가 실제로 몇 초/분 간격으로 깨어났는지"(starvation 여부)와 fix staleness(ageMs)를
+  // 직접 측정할 수 있다. 순수 진단 stamp — behavior 무변경.
+  | 'bg-task-heartbeat';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1450,6 +1456,8 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'category-registration': null,
   // #2398 — 수신 categoryIdentifier 진단 stamp도 silent push outcome과 무관.
   'boarding-prompt-category-received': null,
+  // #2403 — BG task heartbeat는 silent push와 무관한 순수 진단 stamp.
+  'bg-task-heartbeat': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1515,6 +1523,8 @@ const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
   'category-registration': false,
   // #2398 — 수신 categoryIdentifier 진단 stamp(outcome='received')도 fire 분모 제외.
   'boarding-prompt-category-received': false,
+  // #2403 — BG task heartbeat(outcome='received')는 사용자 노출 알람이 아닌 진단 stamp. fire 분모 제외.
+  'bg-task-heartbeat': false,
 };
 
 /**
@@ -1631,6 +1641,26 @@ export function logSuppressedGate(
     source: 'bg',
     outcome: 'suppressed',
     reason,
+    location,
+  });
+}
+
+/**
+ * #2403 — BG task 발화 heartbeat 1건 적재. 순수 진단 계측 — behavior 무변경.
+ *
+ * `BACKGROUND_LOCATION_TASK`가 `latest` fix를 확보한 직후, 기존 gate-age/gate-accuracy 게이트나
+ * position-train-lock 발사 경로보다 먼저 호출한다. 그 아래 경로가 조기 return하거나 fire하는
+ * tick도 이 heartbeat는 남으므로, 덤프에서 BG task 발화 간격(starvation vs O1 threshold 병목
+ * 확정)과 fix staleness(ageMs)/accuracy를 직접 측정할 수 있다.
+ *
+ * 다른 suppress 계열 helper와 달리 burst dedup을 적용하지 않는다 — 이 stamp 자체가 "발화
+ * 간격"의 측정 대상이므로 연속 tick을 하나로 합치면 간격 측정이 불가능해진다.
+ */
+export function logBgTaskHeartbeat(location: AlarmLogLocation): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg-task-heartbeat',
+    outcome: 'received',
     location,
   });
 }

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -42,8 +42,11 @@ jest.mock('../../../alarm/utils/notificationState', () => ({
 
 // ── alarmLog 모킹 ──
 const mockLogSuppressedGate = jest.fn();
+// #2403 — BG task 발화 heartbeat 모킹.
+const mockLogBgTaskHeartbeat = jest.fn();
 jest.mock('../../../alarm/utils/alarmLog', () => ({
   logSuppressedGate: (...args: unknown[]) => mockLogSuppressedGate(...args),
+  logBgTaskHeartbeat: (...args: unknown[]) => mockLogBgTaskHeartbeat(...args),
 }));
 
 // ── positionUpload 모킹 (#819) ──
@@ -595,6 +598,70 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       'gate-accuracy',
       expect.objectContaining({ accuracy }),
     );
+  });
+
+  // #2403 — BG task 발화 heartbeat. 순수 진단 계측 — 아래 gate/발사 로직에 영향 없이 매 tick
+  // logBgTaskHeartbeat가 fix ageMs/accuracy와 함께 호출되는지만 검증한다.
+  describe('#2403 — BG task 발화 heartbeat (진단 계측)', () => {
+    it('정상 fix 수신 시 logBgTaskHeartbeat가 lat/lng/accuracy/ageMs와 함께 호출된다', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: 12 }));
+
+      expect(mockLogBgTaskHeartbeat).toHaveBeenCalledWith(
+        expect.objectContaining({ lat: 37.498, lng: 127.028, accuracy: 12 }),
+      );
+      const [[heartbeatArg]] = mockLogBgTaskHeartbeat.mock.calls;
+      expect(typeof heartbeatArg.ageMs).toBe('number');
+      expect(heartbeatArg.ageMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('gate-age drop tick에서도 logBgTaskHeartbeat가 호출된다(게이트 로직보다 먼저 적재)', async () => {
+      const ageMs = MAX_LOCATION_AGE_MS + 1_000;
+      await runWithLocation(makeLocation(37.498, 127.028, { ageMs }));
+
+      expect(mockLogBgTaskHeartbeat).toHaveBeenCalledWith(
+        expect.objectContaining({ ageMs: expect.any(Number) }),
+      );
+      const [[heartbeatArg]] = mockLogBgTaskHeartbeat.mock.calls;
+      expect(heartbeatArg.ageMs).toBeGreaterThanOrEqual(ageMs);
+    });
+
+    it('gate-accuracy drop tick에서도 logBgTaskHeartbeat가 호출된다', async () => {
+      const accuracy = MAX_ACCURACY_M + 50;
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy }));
+
+      expect(mockLogBgTaskHeartbeat).toHaveBeenCalledWith(
+        expect.objectContaining({ accuracy }),
+      );
+    });
+
+    it('position-train-lock이 채택(fired=true)한 tick에서도 logBgTaskHeartbeat가 먼저 호출된다', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockEvaluatePositionTrainFire.mockResolvedValueOnce(true);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: 12 }));
+
+      expect(mockLogBgTaskHeartbeat).toHaveBeenCalledTimes(1);
+      // position-train fire 채택 시 이후 GPS 파이프라인은 건너뛴다 (기존 동작 무변경 확인).
+      expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+
+    it('error 분기에서는 logBgTaskHeartbeat를 호출하지 않는다', async () => {
+      await taskCallback({ data: null, error: { message: '위치 오류' } });
+      expect(mockLogBgTaskHeartbeat).not.toHaveBeenCalled();
+    });
+
+    it('data가 null이면 logBgTaskHeartbeat를 호출하지 않는다', async () => {
+      await taskCallback({ data: null, error: null });
+      expect(mockLogBgTaskHeartbeat).not.toHaveBeenCalled();
+    });
+
+    it('locations가 빈 배열이면 logBgTaskHeartbeat를 호출하지 않는다', async () => {
+      await taskCallback({ data: { locations: [] }, error: null });
+      expect(mockLogBgTaskHeartbeat).not.toHaveBeenCalled();
+    });
   });
 
   // #2345 — 지하 accuracy 강등 gate. isAccuracyAcceptable early-return 직전에 카운터를 올린다.

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -15,7 +15,7 @@ import { createLogger } from '../../../shared/utils/logger';
 import { APNS_TOKEN_KEY, DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import { getFiredAlarms, setFiredAlarms } from '../../alarm/utils/notificationState';
 import { isAccuracyAcceptable, isLocationFresh, isPlausibleJump, type FixSample } from '../utils/locationGates';
-import { logSuppressedGate } from '../../alarm/utils/alarmLog';
+import { logSuppressedGate, logBgTaskHeartbeat } from '../../alarm/utils/alarmLog';
 import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY, BG_LAST_POSITION_UPLOAD_AT_KEY } from '../../../shared/constants/storageKeys';
 import { uploadPosition, type PositionMotion } from '../api/positionUpload';
 import { POSITION_UPLOAD_MIN_INTERVAL_MS } from '../../../shared/constants/location';
@@ -138,6 +138,17 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const { locations } = data as { locations: Location.LocationObject[] };
   const latest = locations[locations.length - 1];
   if (!latest) return;
+
+  // #2403 — BG task 발화 heartbeat. behavior 무변경 순수 진단 계측: 이 tick이 실제로 깨어났다는
+  // 사실 자체와 fix staleness(ageMs)/accuracy를 덤프에 남겨 지하 발화 간격 측정을 가능하게 한다.
+  // 아래 gate/position-train/consensus 발사 로직보다 먼저 fire-and-forget으로 적재 — 그 경로가
+  // 조기 return하거나 fire해도 이 heartbeat는 항상 남는다.
+  logBgTaskHeartbeat({
+    lat: latest.coords.latitude,
+    lng: latest.coords.longitude,
+    accuracy: latest.coords.accuracy,
+    ageMs: Date.now() - (latest.timestamp ?? 0),
+  });
 
   // #2178 — pull 기반 trip 死 backstop. GPS fix 품질(age/accuracy)과 무관하게 "BG task가
   // 깨어났다"는 사실 자체가 backend 생존 확인 기회다. fire-and-forget — 아래 알람 파이프라인의


### PR DESCRIPTION
Closes #2403

## 요약
**behavior 무변경 순수 진단 계측.** `BACKGROUND_LOCATION_TASK`가 `latest` fix를 확보한 직후(기존 gate-age/gate-accuracy/position-train-lock 로직보다 먼저) 덤프-가시 heartbeat 1건을 fire-and-forget으로 적재한다. 이 tick이 gate에 걸려 조기 return하든, position-train 경로로 fire하든 상관없이 항상 남으므로, 다음 탑승 덤프에서 BG 발화 간격(초/분)과 fix staleness(ageMs)/accuracy를 직접 측정할 수 있다.

## 변경
- `src/features/nearest-station/tasks/backgroundLocationTask.ts`: `if (!latest) return;` 직후 `logBgTaskHeartbeat({ lat, lng, accuracy, ageMs })` 호출 추가. 기존 pull backstop / position-train-lock / gate-age / gate-accuracy / consensus / 발사 로직은 전혀 건드리지 않음.
- `src/features/alarm/utils/alarmLog.ts`: 신규 source `'bg-task-heartbeat'` 추가 (`AlarmLogSource` union + `SILENT_PUSH_OUTCOME_SOURCES`/`FIRED_ALARM_SOURCES` exhaustive Record 갱신, #2398과 동일 패턴) + `logBgTaskHeartbeat` helper. 다른 suppress 계열과 달리 burst dedup을 적용하지 않음 — 이 stamp 자체가 "발화 간격" 측정 대상이라 연속 tick을 합치면 측정이 불가능해지기 때문.

## Wire-completion 5단
1. **Orphan** — pass (`npm run lint:orphan` → No orphan exports detected).
2. **V/X dashboard** — 🔴 BG task 발화가 DebugModal Alarm log(`getAlarmLog` → `source='bg-task-heartbeat'`, `outcome='received'`)에서 ts+location(lat/lng/accuracy/ageMs)과 함께 시각화됨.
3. **의존 PR** — N/A.
4. **측정 plan** — 다음 탑승 후 덤프에서 `source='bg-task-heartbeat'` 엔트리의 ts 간격 분포를 직접 계산해 지하 BG 발화 간격(starvation 여부)을 산출. ageMs로 fix staleness를, 인접 position-train/consensus 엔트리 유무로 발사 성공 여부를 교차 확인. silent push 도달은 기존 `silent-push-received` receivedAt으로, backend 자율전진은 D1로 별도 교차확인(계측 인프라 자체는 무변경).
5. **Device verify** — 🔴 다음 지하 BG 탑승 번들에 합류해 캡처.

## 관측 요건 (ring buffer 용량 노트)
`alarmLog` ring buffer cap은 `ALARM_LOG_BUFFER_SIZE=200`이며 heartbeat 전용이 아닌 **모든 source 공유** 버퍼다. heartbeat는 burst dedup 없이 매 BG tick마다 1건씩 적재되므로, 같은 trip 동안 다른 gate/발사 엔트리와 경합해 버퍼를 점유한다. 지하 구간은 원래 발화가 희박한 게 측정 대상이라 flood 문제는 없지만, 지상 구간이 길게 이어지는 trip에서는 heartbeat가 버퍼 다수를 차지해 오래된 다른 진단 엔트리(gate suppress 등)를 먼저 밀어낼 수 있다 — evict는 최신 우선이므로 정작 측정 대상인 "최근 지하 구간" 관측에는 무해하다. 별도 채널 분리는 하지 않음(이슈 스펙대로 `appendAlarmLog` 단일 채널 유지) — 용량 부족이 실측으로 확인되면 후속 이슈로 분리 검토.

## 검증
- `npm test` — 전체 스위트(453 suites / 9686 tests) pass, coverage 100%.
- `npm run type-check` — pass.
- `npm run lint:orphan` — No orphan exports detected.

## 금지사항 준수
- 위치 task 게이트/발사/쿨다운 로직 무변경 — heartbeat 로그 1건 추가만.
- FG(#2402)·backend 변경 없음.