### PR TITLE
fix(#2407): 탭 시 fallback lock 생성 — trainCode 확정 실패해도 lock 생성 (root fix)

### DIFF
--- a/src/features/alarm/__tests__/replay_20260828_boarding_wire_red.test.ts
+++ b/src/features/alarm/__tests__/replay_20260828_boarding_wire_red.test.ts
@@ -1,11 +1,12 @@
 /**
- * #2405 — 2026-08-28 실탑승 whole-trip wire RED fixture (honest verification spike).
+ * #2405/#2406 — 2026-08-28 실탑승 whole-trip wire fixture (honest verification spike).
+ * #2407 — root fix 적용 후 Assertion 1(가설 A/B)을 GREEN으로 flip.
  *
- * 배경: 2026-08-28 실탑승(용마산(7)→중곡→군자→어린이대공원→건대입구(환승 7→2)→성수→뚝섬(2))에서
- * 8개 증상이 발생했는데 CI(type+unit+fixture)는 전부 green이었다. 원인: 기존 unit 테스트가
- * `tryAutoLock`을 부분 격리(`fetchArrivalsForStation`을 train 반환 mock)해 오늘 실패 모드를
- * 재현하지 못했고, fixture replay(#2401 계열)도 fire 로직만 재생해 boardingPrompt→lock→estimator
- * wire 자체는 replay하지 않았다.
+ * 배경: #2405/#2406 — 2026-08-28 실탑승(용마산(7)→중곡→군자→어린이대공원→건대입구(환승
+ * 7→2)→성수→뚝섬(2))에서 8개 증상이 발생했는데 CI(type+unit+fixture)는 전부 green이었다.
+ * 원인: 기존 unit 테스트가 `tryAutoLock`을 부분 격리(`fetchArrivalsForStation`을 train 반환
+ * mock)해 오늘 실패 모드를 재현하지 못했고, fixture replay(#2401 계열)도 fire 로직만 재생해
+ * boardingPrompt→lock→estimator wire 자체는 replay하지 않았다.
  *
  * 덤프: `/Users/kimdohan/.claude/uploads/b4fc2a33-498b-4c58-ab8b-14d959d807e5/4dd126ab-827.txt`
  *   - `BoardingLock active=no` — trip 내내 lockless.
@@ -24,7 +25,10 @@
  * `fetchArrivalsForStation`(오늘 지하 조건 재현 — null 또는 line 매칭 0건), AsyncStorage,
  * `expo-notifications`, `dismissBoardingPrompt`(네트워크 POST 경계).
  *
- * 🔴 production 코드는 이 이슈에서 수정하지 않는다. 아래 assertion이 RED(버그 재현)면 정상이다.
+ * #2407 root fix: `tryAutoLock`(useBoardingPromptResponder.ts)이 arrivals null / line 매칭 0건
+ * 이어도 더 이상 조기 return하지 않고, trainCode=`PENDING_TRAIN_CODE` sentinel + evidence=false로
+ * fallback lock을 생성한다(ADR-014 "명시 탭 = lock 활성과 동급"). 아래 가설 A/B assertion을
+ * "lock이 생성되지 않는다"에서 "pending lock이 생성된다"로 flip해 root fix를 실체인으로 증명한다.
  */
 
 const storage = new Map<string, string>();
@@ -80,6 +84,7 @@ import { findNearestStation } from '../../nearest-station/utils/findNearestStati
 import { resolveCurrentLine } from '../utils/resolveCurrentLine';
 import type { StationArrival } from '../../../shared/types/arrival';
 import { canonicalStationName } from '../../../testUtils/canonicalStationName';
+import { PENDING_TRAIN_CODE } from '../../../shared/constants/boardingLock';
 
 describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoLock → lock', () => {
   const ORIGIN_STATION = '용마산';
@@ -116,19 +121,24 @@ describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoL
   }
 
   it(
-    '가설 A(arrivals-null): fetchArrivalsForStation이 null 반환 시 실 tryAutoLock이 lock을 ' +
-      '생성하지 않는다 (RED — #2405 root 재현)',
+    '가설 A(arrivals-null): fetchArrivalsForStation이 null 반환 시 실 tryAutoLock이 pending ' +
+      'fallback lock을 생성한다 (GREEN — #2407 root fix 증명)',
     async () => {
       const fetchArrivalsForStation = jest.fn().mockResolvedValue(null);
 
       await driveBoardedTap(fetchArrivalsForStation);
 
       expect(fetchArrivalsForStation).toHaveBeenCalledWith(ORIGIN_STATION);
-      // 🔴 RED 기대: lock이 생성되지 않는다.
-      expect(useBoardingLockStore.getState().lock).toBeNull();
-      // 사용자 명시 의향은 그대로 stamp됨 — lock 실패와 무관하게 infoMode/navigationActive는 켜진다
-      // (ADR-014 §X, useBoardingPromptResponder.ts:217-228). 덤프의 `lockless-trip-end 1:intent`와
-      // 정합 — "응답은 있었는데 lock만 안 생겼다"는 이슈 서술을 코드로 확인.
+      // 🟢 GREEN 기대(#2407 root fix): train 확정 실패해도 lock은 생성된다 — trainCode는
+      // pending sentinel, evidence=false, destinationId/boardingLine은 payload 기반 확정값.
+      const { lock } = useBoardingLockStore.getState();
+      expect(lock).not.toBeNull();
+      expect(lock?.trainCode).toBe(PENDING_TRAIN_CODE);
+      expect(lock?.boardingLine).toBe(LINE);
+      expect(lock?.destinationId).toBe(DESTINATION_ID);
+      expect(lock?.boardingEvidence).toBe(false);
+      // 사용자 명시 의향은 그대로 stamp됨 (ADR-014 §X, useBoardingPromptResponder.ts:217-228).
+      // 덤프의 `lockless-trip-end 1:intent`와 정합.
       expect(useUserIntentStore.getState().infoModeEnabled).toBe(true);
       expect(useNavigationStore.getState().navigationActive).toBe(true);
     },
@@ -136,7 +146,7 @@ describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoL
 
   it(
     '가설 B(line-filtered-empty): fetchArrivalsForStation이 다른 노선 후보만 반환 시(7호선 ' +
-      '매칭 0건) 실 tryAutoLock이 lock을 생성하지 않는다 (RED — #2405 root 재현)',
+      '매칭 0건) 실 tryAutoLock이 pending fallback lock을 생성한다 (GREEN — #2407 root fix 증명)',
     async () => {
       // 지하 환경에서 7호선 열차 정보만 API 응답 지연/누락되고 나머지 노선은 응답하는 케이스
       // (환승역 아님에도 payload.line !== 응답 line인 상황을 최소 재현).
@@ -161,7 +171,12 @@ describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoL
 
       await driveBoardedTap(fetchArrivalsForStation);
 
-      expect(useBoardingLockStore.getState().lock).toBeNull();
+      // 🟢 GREEN 기대(#2407 root fix): 7호선 매칭 0건이어도 pending fallback lock이 생성된다.
+      const { lock } = useBoardingLockStore.getState();
+      expect(lock).not.toBeNull();
+      expect(lock?.trainCode).toBe(PENDING_TRAIN_CODE);
+      expect(lock?.boardingLine).toBe(LINE);
+      expect(lock?.boardingEvidence).toBe(false);
     },
   );
 

--- a/src/features/alarm/__tests__/replay_20260828_boarding_wire_red.test.ts
+++ b/src/features/alarm/__tests__/replay_20260828_boarding_wire_red.test.ts
@@ -120,6 +120,19 @@ describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoL
     });
   }
 
+  // #2407 root fix 공통 assertion — train 확정 실패(가설 A/B)해도 pending sentinel lock이
+  // 생성됨을 검증. destinationId 검증은 가설 A에서만 필요(가설 B는 별도 관심사 없음).
+  function expectPendingFallbackLock(opts: { checkDestinationId?: boolean } = {}) {
+    const { lock } = useBoardingLockStore.getState();
+    expect(lock).not.toBeNull();
+    expect(lock?.trainCode).toBe(PENDING_TRAIN_CODE);
+    expect(lock?.boardingLine).toBe(LINE);
+    expect(lock?.boardingEvidence).toBe(false);
+    if (opts.checkDestinationId) {
+      expect(lock?.destinationId).toBe(DESTINATION_ID);
+    }
+  }
+
   it(
     '가설 A(arrivals-null): fetchArrivalsForStation이 null 반환 시 실 tryAutoLock이 pending ' +
       'fallback lock을 생성한다 (GREEN — #2407 root fix 증명)',
@@ -131,12 +144,7 @@ describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoL
       expect(fetchArrivalsForStation).toHaveBeenCalledWith(ORIGIN_STATION);
       // 🟢 GREEN 기대(#2407 root fix): train 확정 실패해도 lock은 생성된다 — trainCode는
       // pending sentinel, evidence=false, destinationId/boardingLine은 payload 기반 확정값.
-      const { lock } = useBoardingLockStore.getState();
-      expect(lock).not.toBeNull();
-      expect(lock?.trainCode).toBe(PENDING_TRAIN_CODE);
-      expect(lock?.boardingLine).toBe(LINE);
-      expect(lock?.destinationId).toBe(DESTINATION_ID);
-      expect(lock?.boardingEvidence).toBe(false);
+      expectPendingFallbackLock({ checkDestinationId: true });
       // 사용자 명시 의향은 그대로 stamp됨 (ADR-014 §X, useBoardingPromptResponder.ts:217-228).
       // 덤프의 `lockless-trip-end 1:intent`와 정합.
       expect(useUserIntentStore.getState().infoModeEnabled).toBe(true);
@@ -172,11 +180,7 @@ describe('#2405 whole-trip wire RED — 용마산(7) boardingPrompt → tryAutoL
       await driveBoardedTap(fetchArrivalsForStation);
 
       // 🟢 GREEN 기대(#2407 root fix): 7호선 매칭 0건이어도 pending fallback lock이 생성된다.
-      const { lock } = useBoardingLockStore.getState();
-      expect(lock).not.toBeNull();
-      expect(lock?.trainCode).toBe(PENDING_TRAIN_CODE);
-      expect(lock?.boardingLine).toBe(LINE);
-      expect(lock?.boardingEvidence).toBe(false);
+      expectPendingFallbackLock();
     },
   );
 

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -1205,6 +1205,18 @@ describe('useBoardingLockController', () => {
       return createLockMock;
     }
 
+    // suggestion 채택 시나리오 공용 assertion — createLock(arg, evidence) 호출부의
+    // trainCode/boardingLine/evidence를 검증. #2407 pending-lock upgrade 테스트도 공유.
+    function expectCreateLockCall(
+      createLockMock: jest.Mock,
+      expected: { trainCode: string; boardingLine: string; evidence: boolean },
+    ) {
+      const arg = createLockMock.mock.calls[0][0];
+      expect(arg.trainCode).toBe(expected.trainCode);
+      expect(arg.boardingLine).toBe(expected.boardingLine);
+      expect(createLockMock.mock.calls[0][1]).toBe(expected.evidence);
+    }
+
     beforeEach(() => {
       jest.useFakeTimers();
       // jest.requireActual로 module을 가져오고 readBackendSsotMirror만 spy.
@@ -1232,16 +1244,12 @@ describe('useBoardingLockController', () => {
       await waitFor(() => {
         expect(createLockMock).toHaveBeenCalled();
       });
-      const arg = createLockMock.mock.calls[0][0];
-      expect(arg.trainCode).toBe('AUTO-1');
-      expect(arg.boardingLine).toBe('2');
       // motion gate / directionalArrivals 검증 X (suggestion 채택은 우회)
       // #2290 P1 (RCA 재현): lockSuggestion은 backend(#1534)가 arvlcd-confirmed evidence로 이미
       // 합의한 뒤 통보한 결과라 생성 시점 자체가 탑승 evidence다. evidence=false로 stamp되면
       // (수정 전 버그) `hasConsumedOriginWait`가 initialEtaSeconds도 없는 이 lock 타입에서 trip
       // 내내 false로 고착돼 출발 대기가 과다 합산된다.
-      const evidence = createLockMock.mock.calls[0][1];
-      expect(evidence).toBe(true);
+      expectCreateLockCall(createLockMock, { trainCode: 'AUTO-1', boardingLine: '2', evidence: true });
     });
 
     it('이미 lock 존재 → suggestion 채택 skip (idempotent)', async () => {
@@ -1277,11 +1285,7 @@ describe('useBoardingLockController', () => {
       await waitFor(() => {
         expect(createLockMock).toHaveBeenCalled();
       });
-      const arg = createLockMock.mock.calls[0][0];
-      expect(arg.trainCode).toBe('AUTO-1');
-      expect(arg.boardingLine).toBe('2');
-      const evidence = createLockMock.mock.calls[0][1];
-      expect(evidence).toBe(true);
+      expectCreateLockCall(createLockMock, { trainCode: 'AUTO-1', boardingLine: '2', evidence: true });
     });
 
     // #2407 — 다른 leg(boardingLine 불일치)의 suggestion이 pending fallback lock을 clobber하지

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -101,6 +101,21 @@ function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   };
 }
 
+// #2407 — pending fallback lock(trainCode 미확정) fixture. upgrade 시나리오 2개(같은/다른
+// boardingLine suggestion)가 공유.
+function makePendingLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'dest-1',
+    trainCode: PENDING_TRAIN_CODE,
+    boardingStationId: 'stn-A',
+    boardingLine: '2',
+    boardedAt: Date.now(),
+    expectedDurationMs: 30 * 60_000,
+    boardingEvidence: false,
+    ...overrides,
+  };
+}
+
 const stationA: Station = {
   id: 'stn-A',
   name: '강남',
@@ -1254,15 +1269,7 @@ describe('useBoardingLockController', () => {
     it('#2407 — pending lock(trainCode 미확정) + 같은 boardingLine suggestion → 실 trainCode로 upgrade', async () => {
       readSpy.mockResolvedValue(MIRROR);
       const createLockMock = jest.fn().mockResolvedValue(undefined);
-      const pending: BoardingLock = {
-        destinationId: 'dest-1',
-        trainCode: PENDING_TRAIN_CODE,
-        boardingStationId: 'stn-A',
-        boardingLine: '2',
-        boardedAt: Date.now(),
-        expectedDurationMs: 30 * 60_000,
-        boardingEvidence: false,
-      };
+      const pending = makePendingLock();
       mockGetBoardingLock.mockResolvedValue(pending);
       useBoardingLockStore.setState({ lock: pending, createLock: createLockMock });
       renderHook(() => useBoardingLockController(defaultInputs));
@@ -1285,15 +1292,7 @@ describe('useBoardingLockController', () => {
         lockSuggestion: { ...SUGGESTION, lineId: '7' },
       });
       const createLockMock = jest.fn().mockResolvedValue(undefined);
-      const pending: BoardingLock = {
-        destinationId: 'dest-1',
-        trainCode: PENDING_TRAIN_CODE,
-        boardingStationId: 'stn-A',
-        boardingLine: '2',
-        boardedAt: Date.now(),
-        expectedDurationMs: 30 * 60_000,
-        boardingEvidence: false,
-      };
+      const pending = makePendingLock();
       mockGetBoardingLock.mockResolvedValue(pending);
       useBoardingLockStore.setState({ lock: pending, createLock: createLockMock });
       renderHook(() => useBoardingLockController(defaultInputs));

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -14,6 +14,7 @@ import {
   makeDirectRoute,
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
 
 jest.mock('expo-haptics', () => ({
   impactAsync: jest.fn().mockResolvedValue(undefined),
@@ -1242,6 +1243,59 @@ describe('useBoardingLockController', () => {
       // loadLock effect도 같은 lock을 반환하도록 모킹 — selector가 hydrate한 후에도 lock 유지.
       mockGetBoardingLock.mockResolvedValue(existing);
       useBoardingLockStore.setState({ lock: existing, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await tickAndSettleCycle();
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    // #2407 — pending fallback lock(trainCode 미확정)은 lockSuggestion(backend
+    // arvlcd-confirmed evidence)이 도착하면 async로 실 trainCode를 확정해야 한다. 같은 leg
+    // (boardingLine 일치)이면 upgrade 허용.
+    it('#2407 — pending lock(trainCode 미확정) + 같은 boardingLine suggestion → 실 trainCode로 upgrade', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      const pending: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: PENDING_TRAIN_CODE,
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 30 * 60_000,
+        boardingEvidence: false,
+      };
+      mockGetBoardingLock.mockResolvedValue(pending);
+      useBoardingLockStore.setState({ lock: pending, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await tickAndSettleCycle();
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      const arg = createLockMock.mock.calls[0][0];
+      expect(arg.trainCode).toBe('AUTO-1');
+      expect(arg.boardingLine).toBe('2');
+      const evidence = createLockMock.mock.calls[0][1];
+      expect(evidence).toBe(true);
+    });
+
+    // #2407 — 다른 leg(boardingLine 불일치)의 suggestion이 pending fallback lock을 clobber하지
+    // 않도록 방어.
+    it('#2407 — pending lock + 다른 boardingLine suggestion → upgrade 안 함 (clobber 방지)', async () => {
+      readSpy.mockResolvedValue({
+        ...MIRROR,
+        lockSuggestion: { ...SUGGESTION, lineId: '7' },
+      });
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      const pending: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: PENDING_TRAIN_CODE,
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 30 * 60_000,
+        boardingEvidence: false,
+      };
+      mockGetBoardingLock.mockResolvedValue(pending);
+      useBoardingLockStore.setState({ lock: pending, createLock: createLockMock });
       renderHook(() => useBoardingLockController(defaultInputs));
       await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -204,6 +204,17 @@ function makeHandleResponseDeps(
   };
 }
 
+// #2407 — pending fallback lock(trainCode=PENDING_TRAIN_CODE) 생성 assertion 공통 헬퍼.
+function expectPendingFallbackLockCalled(boardingLine?: string): void {
+  expect(createLockMock).toHaveBeenCalledWith(
+    boardingLine === undefined
+      ? expect.objectContaining({ trainCode: PENDING_TRAIN_CODE })
+      : expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine }),
+    false,
+    'boarding-prompt-response',
+  );
+}
+
 describe('extractBoardingPromptPayload', () => {
   it('valid payload → 보존', () => {
     expect(
@@ -347,11 +358,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).toHaveBeenCalledWith(
-      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-      false,
-      'boarding-prompt-response',
-    );
+    expectPendingFallbackLockCalled('2');
     expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
   });
 
@@ -362,11 +369,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
       fetchArrivalsForStation: jest.fn(async () => makeArrivalWithUp(AMBIGUOUS_TRAINS)),
     });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).toHaveBeenCalledWith(
-      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-      false,
-      'boarding-prompt-response',
-    );
+    expectPendingFallbackLockCalled('2');
   });
 
   // #2407 — pending fallback lock도 payload.line이 유효 LineNumber가 아니면 생성 불가(극히
@@ -441,11 +444,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     mockBgLastStation('2', 0);
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).toHaveBeenCalledWith(
-      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-      false,
-      'boarding-prompt-response',
-    );
+    expectPendingFallbackLockCalled('2');
     expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
       reason: 'autolock-fallback-pending',
       originStation: '강남',
@@ -458,11 +457,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     (AsyncStorage.getItem as jest.Mock).mockImplementationOnce(async () => null);
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).toHaveBeenCalledWith(
-      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-      false,
-      'boarding-prompt-response',
-    );
+    expectPendingFallbackLockCalled('2');
   });
 
   it('#2408 — BG_LAST_STATION stale(신선도 초과) → 검증 불가, 기존대로 lock 생성', async () => {
@@ -471,11 +466,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     mockBgLastStation('7', 5 * 60_000 + 1);
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).toHaveBeenCalledWith(
-      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-      false,
-      'boarding-prompt-response',
-    );
+    expectPendingFallbackLockCalled('2');
   });
 
   it('#2408 — BG_LAST_STATION read 예외 → guard skip, 기존대로 lock 생성(graceful)', async () => {
@@ -485,11 +476,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     });
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).toHaveBeenCalledWith(
-      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-      false,
-      'boarding-prompt-response',
-    );
+    expectPendingFallbackLockCalled('2');
   });
 
   it('station lookup 실패 → manual fallback (createLock 안 함)', async () => {
@@ -563,11 +550,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
       });
       const payload = { ...PAYLOAD, destinationDirection: 'up' as const };
       await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, payload, deps);
-      expect(createLockMock).toHaveBeenCalledWith(
-        expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
-        false,
-        'boarding-prompt-response',
-      );
+      expectPendingFallbackLockCalled('2');
     },
   );
 
@@ -1037,11 +1020,7 @@ describe('handleResponse — #1888 RC-13 onBannerTap navigation', () => {
       await handleResponse(Notifications.DEFAULT_ACTION_IDENTIFIER, HANDLE_RESPONSE_PAYLOAD, deps);
       expect(onBannerTap).toHaveBeenCalledTimes(1);
       // #2407 root fix — train 미확정이어도 lock 자체는 생성된다 (trainCode=pending sentinel).
-      expect(createLockMock).toHaveBeenCalledWith(
-        expect.objectContaining({ trainCode: PENDING_TRAIN_CODE }),
-        false,
-        'boarding-prompt-response',
-      );
+      expectPendingFallbackLockCalled();
     },
   );
 

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -215,6 +215,16 @@ function expectPendingFallbackLockCalled(boardingLine?: string): void {
   );
 }
 
+// #2407/#2408 — logBoardingPromptAutoLock({ reason, originStation, line }) 호출 assertion
+// 공통 헬퍼. originStation/line은 이 describe 전역에서 '강남'/'2'로 고정된 케이스가 대부분.
+function expectAutoLockLogged(
+  reason: string,
+  originStation: string = '강남',
+  line: string = '2',
+): void {
+  expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({ reason, originStation, line });
+}
+
 describe('extractBoardingPromptPayload', () => {
   it('valid payload → 보존', () => {
     expect(
@@ -379,11 +389,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, invalidPayload, deps);
     expect(createLockMock).not.toHaveBeenCalled();
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-station-lookup',
-      originStation: '강남',
-      line: '99',
-    });
+    expectAutoLockLogged('autolock-station-lookup', '강남', '99');
   });
 
   // #2407 — pending fallback: station lookup 자체가 실패하면 lock 없이 graceful skip.
@@ -392,11 +398,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).not.toHaveBeenCalled();
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-station-lookup',
-      originStation: '강남',
-      line: '2',
-    });
+    expectAutoLockLogged('autolock-station-lookup');
   });
 
   // #2407 — pending fallback createLock이 실패해도(storage/network 예외) 응답 처리는 graceful.
@@ -408,11 +410,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
       createLock: failingCreateLock,
     });
     await expect(handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps)).resolves.toBeUndefined();
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-lock-failed',
-      originStation: '강남',
-      line: '2',
-    });
+    expectAutoLockLogged('autolock-lock-failed');
   });
 
   // #2408 — 위험1 guard: stale prompt → 잘못된 lock 방지. BG_LAST_STATION mock helper.
@@ -432,11 +430,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).not.toHaveBeenCalled();
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'fallback-skipped-position-contradiction',
-      originStation: '강남',
-      line: '2',
-    });
+    expectAutoLockLogged('fallback-skipped-position-contradiction');
   });
 
   it('#2408 — BG_LAST_STATION line이 payload.line과 일치 → 기존대로 pending fallback lock 생성', async () => {
@@ -445,11 +439,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expectPendingFallbackLockCalled('2');
-    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
-      reason: 'autolock-fallback-pending',
-      originStation: '강남',
-      line: '2',
-    });
+    expectAutoLockLogged('autolock-fallback-pending');
   });
 
   it('#2408 — BG_LAST_STATION 부재(null) → 검증 불가, 기존대로 lock 생성(탭 신뢰)', async () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -19,6 +19,7 @@ import {
   DISEMBARK_ACTION_NOT_YET,
 } from '../../utils/notificationCategory';
 import * as positionUpload from '../../../nearest-station/api/positionUpload';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { renderHook } from '@testing-library/react-native';
 import type { StationArrival } from '../../../../shared/types/arrival';
 import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
@@ -26,6 +27,10 @@ import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
 jest.mock('expo-notifications', () => ({
   addNotificationResponseReceivedListener: jest.fn(),
   DEFAULT_ACTION_IDENTIFIER: '$default',
+}));
+// #2408 — 위험1 guard: BG_LAST_STATION_KEY read. 기본값은 부재(null) → guard 미작동(기존 동작).
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(async () => null),
 }));
 jest.mock('../../../nearest-station/api/positionUpload', () => ({
   dismissBoardingPrompt: jest.fn(),
@@ -405,6 +410,86 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
       originStation: '강남',
       line: '2',
     });
+  });
+
+  // #2408 — 위험1 guard: stale prompt → 잘못된 lock 방지. BG_LAST_STATION mock helper.
+  function mockBgLastStation(line: string, ageMs: number): void {
+    (AsyncStorage.getItem as jest.Mock).mockImplementationOnce(async () =>
+      JSON.stringify({
+        station: { id: 'BG1', line, name: '용마산' },
+        distanceKm: 0.1,
+        timestamp: Date.now() - ageMs,
+      }),
+    );
+  }
+
+  it('#2408 — fresh BG_LAST_STATION이 payload.line과 모순 → createLock 미호출(skip)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    mockBgLastStation('7', 0); // 7호선(용마산)에 있는데 payload.line='2'(강남) — 모순.
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'fallback-skipped-position-contradiction',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('#2408 — BG_LAST_STATION line이 payload.line과 일치 → 기존대로 pending fallback lock 생성', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    mockBgLastStation('2', 0);
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+      false,
+      'boarding-prompt-response',
+    );
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-fallback-pending',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  it('#2408 — BG_LAST_STATION 부재(null) → 검증 불가, 기존대로 lock 생성(탭 신뢰)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    (AsyncStorage.getItem as jest.Mock).mockImplementationOnce(async () => null);
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+      false,
+      'boarding-prompt-response',
+    );
+  });
+
+  it('#2408 — BG_LAST_STATION stale(신선도 초과) → 검증 불가, 기존대로 lock 생성', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    // line 모순('7')이어도 신선도 초과(5분+1ms)면 guard 미작동 — 검증 불가로 간주.
+    mockBgLastStation('7', 5 * 60_000 + 1);
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+      false,
+      'boarding-prompt-response',
+    );
+  });
+
+  it('#2408 — BG_LAST_STATION read 예외 → guard skip, 기존대로 lock 생성(graceful)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    (AsyncStorage.getItem as jest.Mock).mockImplementationOnce(async () => {
+      throw new Error('IO error');
+    });
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+      false,
+      'boarding-prompt-response',
+    );
   });
 
   it('station lookup 실패 → manual fallback (createLock 안 함)', async () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -21,6 +21,7 @@ import {
 import * as positionUpload from '../../../nearest-station/api/positionUpload';
 import { renderHook } from '@testing-library/react-native';
 import type { StationArrival } from '../../../../shared/types/arrival';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
 
 jest.mock('expo-notifications', () => ({
   addNotificationResponseReceivedListener: jest.fn(),
@@ -336,19 +337,74 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     expect(createLockMock).not.toHaveBeenCalled();
   });
 
-  it('arrivals null → fallback to manual (createLock/dismiss 없음)', async () => {
+  // #2407 (root fix) — train 확정 실패해도 lock은 생성한다(ADR-014 명시 탭=lock 동급).
+  it('arrivals null → pending fallback lock 생성 (#2407, dismiss는 발사 안 함)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
     const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
-    expect(createLockMock).not.toHaveBeenCalled();
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+      false,
+      'boarding-prompt-response',
+    );
     expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
   });
 
-  it('ambiguity (같은 priority 후보 2+) → manual fallback, lock 안 함', async () => {
+  // #2407 — ambiguity도 "탭했는데 train을 못 골랐다"는 동일 실패 모드라 pending fallback lock 대상.
+  it('ambiguity (같은 priority 후보 2+) → pending fallback lock 생성 (#2407)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
     const deps = makeDeps({
       fetchArrivalsForStation: jest.fn(async () => makeArrivalWithUp(AMBIGUOUS_TRAINS)),
     });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+      false,
+      'boarding-prompt-response',
+    );
+  });
+
+  // #2407 — pending fallback lock도 payload.line이 유효 LineNumber가 아니면 생성 불가(극히
+  // 드문 데이터 이상). manual fallback graceful skip.
+  it('#2407 — pending fallback: payload.line이 유효하지 않으면 createLock 안 함', async () => {
+    const invalidPayload = { ...PAYLOAD, line: '99' };
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, invalidPayload, deps);
     expect(createLockMock).not.toHaveBeenCalled();
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-station-lookup',
+      originStation: '강남',
+      line: '99',
+    });
+  });
+
+  // #2407 — pending fallback: station lookup 자체가 실패하면 lock 없이 graceful skip.
+  it('#2407 — pending fallback: station lookup 실패 → createLock 안 함', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue(null);
+    const deps = makeDeps({ fetchArrivalsForStation: jest.fn(async () => null) });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-station-lookup',
+      originStation: '강남',
+      line: '2',
+    });
+  });
+
+  // #2407 — pending fallback createLock이 실패해도(storage/network 예외) 응답 처리는 graceful.
+  it('#2407 — pending fallback: createLock 예외 시 graceful (autolock-lock-failed telemetry)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const failingCreateLock = jest.fn().mockRejectedValue(new Error('storage full'));
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () => null),
+      createLock: failingCreateLock,
+    });
+    await expect(handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps)).resolves.toBeUndefined();
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-lock-failed',
+      originStation: '강남',
+      line: '2',
+    });
   });
 
   it('station lookup 실패 → manual fallback (createLock 안 함)', async () => {
@@ -408,17 +464,27 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     );
   });
 
-  it('#1740 — destinationDirection "up" 지정 + up 후보 없음 → lock 안 함 (반대 방향만 존재)', async () => {
-    const downTrain = { trainCode: 'DOWN1', arrivalCode: 2, line: '2' as const };
-    const deps = makeDeps({
-      fetchArrivalsForStation: jest.fn(async () =>
-        makeArrivalBothDirections([], [downTrain]),
-      ),
-    });
-    const payload = { ...PAYLOAD, destinationDirection: 'up' as const };
-    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, payload, deps);
-    expect(createLockMock).not.toHaveBeenCalled();
-  });
+  // #2407 — up 후보 0건은 "line 매칭 0건" 실패 모드와 동일 — pending fallback lock 대상.
+  it(
+    '#1740 — destinationDirection "up" 지정 + up 후보 없음 → pending fallback lock 생성 ' +
+      '(#2407, 반대 방향만 존재)',
+    async () => {
+      (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+      const downTrain = { trainCode: 'DOWN1', arrivalCode: 2, line: '2' as const };
+      const deps = makeDeps({
+        fetchArrivalsForStation: jest.fn(async () =>
+          makeArrivalBothDirections([], [downTrain]),
+        ),
+      });
+      const payload = { ...PAYLOAD, destinationDirection: 'up' as const };
+      await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, payload, deps);
+      expect(createLockMock).toHaveBeenCalledWith(
+        expect.objectContaining({ trainCode: PENDING_TRAIN_CODE, boardingLine: '2' }),
+        false,
+        'boarding-prompt-response',
+      );
+    },
+  );
 
   it('#1740 — destinationDirection undefined → 양방향 모두 후보 (backward compat)', async () => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
@@ -873,18 +939,26 @@ describe('handleResponse — #1888 RC-13 onBannerTap navigation', () => {
     expect(onBannerTap).toHaveBeenCalledTimes(1);
   });
 
-  it('$default action → onBannerTap 호출 (autolock 실패 케이스도 navigation)', async () => {
-    // arrivals 0건 → autolock empty fallback path. 사용자는 여전히 list를 보고 싶다.
-    const onBannerTap = jest.fn();
-    const deps = makeHandleResponseDeps({
-      fetchArrivalsForStation: jest.fn(async () => null),
-      onBannerTap,
-    });
-    await handleResponse(Notifications.DEFAULT_ACTION_IDENTIFIER, HANDLE_RESPONSE_PAYLOAD, deps);
-    expect(onBannerTap).toHaveBeenCalledTimes(1);
-    // 추가 확인 — lock은 생성 안 됨 (fallback path).
-    expect(createLockMock).not.toHaveBeenCalled();
-  });
+  it(
+    '$default action → onBannerTap 호출 (train 확정 실패해도 pending fallback lock 생성, #2407)',
+    async () => {
+      // arrivals 0건 → #2407 pending fallback lock 경로. 사용자는 여전히 list를 보고 싶다.
+      (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+      const onBannerTap = jest.fn();
+      const deps = makeHandleResponseDeps({
+        fetchArrivalsForStation: jest.fn(async () => null),
+        onBannerTap,
+      });
+      await handleResponse(Notifications.DEFAULT_ACTION_IDENTIFIER, HANDLE_RESPONSE_PAYLOAD, deps);
+      expect(onBannerTap).toHaveBeenCalledTimes(1);
+      // #2407 root fix — train 미확정이어도 lock 자체는 생성된다 (trainCode=pending sentinel).
+      expect(createLockMock).toHaveBeenCalledWith(
+        expect.objectContaining({ trainCode: PENDING_TRAIN_CODE }),
+        false,
+        'boarding-prompt-response',
+      );
+    },
+  );
 
   it('[탑승] action → onBannerTap 호출 안 함 (action button은 silent autolock)', async () => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -25,6 +25,7 @@ import type { BoardingLock } from '../../../shared/types/boardingLock';
 import {
   FALLBACK_BOARDING_DURATION_MINUTES,
   FREE_TRIP_DESTINATION_SENTINEL,
+  isPendingTrainCode,
 } from '../../../shared/constants/boardingLock';
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 import { useLockSuggestion } from '../api/useLockSuggestion';
@@ -205,13 +206,22 @@ export function useBoardingLockController({
   //     stamp가 없으면(nextLine=null) 가드 미개입 — 기존 동작 그대로.
   useEffect(() => {
     if (!lockSuggestion) return;
-    if (lock) return;
+    // #2407 — pending lock(#2407 fallback lock, trainCode 미확정)은 lockSuggestion(backend
+    // arvlcd-confirmed evidence, arrival/realtimePosition 기반)이 도착하면 async로 실 trainCode를
+    // 확정해야 한다("기존 메커니즘 재사용, 신규 감지 신설 금지" — 이 effect가 이미 하는 backend
+    // suggestion → createLock 채택 로직을 pending 케이스까지 확장). 이미 trainCode가 확정된
+    // 일반 lock은 기존대로 완전 no-op(사용자 명시 탭 lock 보호 정책 불변).
+    const isPendingUpgrade = lock !== null && isPendingTrainCode(lock.trainCode);
+    if (lock && !isPendingUpgrade) return;
     // #2330 (consensus-D, 설계 SSoT #2323 (3)) — confidence='consensus'는 lock 승격 금지.
     // legConsensus는 UI 표시(배지/하이라이트)/floor 힌트 전용 forward라 high/medium/low(9-AND
     // gate 기반 evidence)와 달리 자동 hydrate 대상이 아니다. "오토락 부활" 오해를 구조적으로 차단.
     if (lockSuggestion.confidence === 'consensus') return;
     const boardingLine = asLineNumber(lockSuggestion.lineId);
     if (!boardingLine) return;
+    // pending lock upgrade는 같은 leg(boardingLine 일치)일 때만 허용 — 다른 leg의 suggestion이
+    // fallback lock을 clobber하지 않도록 방어.
+    if (isPendingUpgrade && lock && boardingLine !== lock.boardingLine) return;
     if (legAdvanceLine !== null) {
       const isStale =
         legAdvanceStampedAt !== null && lockSuggestion.decidedAt < legAdvanceStampedAt;

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -115,6 +115,43 @@ function asLineNumber(raw: string): LineNumber | null {
 const isReachable = (train: ArrivalInfo): boolean => train.arrivalSeconds >= 0;
 
 /**
+ * #2407 — lock이 이미 확정된(pending 아닌) trainCode로 존재하면 lockSuggestion 채택을 skip.
+ * pending fallback lock(trainCode 미확정)은 upgrade 대상이라 skip하지 않는다.
+ */
+function shouldSkipExistingLock(lock: BoardingLock | null): boolean {
+  return lock !== null && !isPendingTrainCode(lock.trainCode);
+}
+
+/**
+ * #2407 — pending fallback lock upgrade는 같은 leg(boardingLine 일치)일 때만 허용한다.
+ * 다른 leg의 suggestion이 fallback lock을 clobber하지 않도록 방어.
+ */
+function isPendingUpgradeLineMismatch(lock: BoardingLock | null, boardingLine: LineNumber): boolean {
+  return lock !== null && isPendingTrainCode(lock.trainCode) && boardingLine !== lock.boardingLine;
+}
+
+/**
+ * #2278 (PR #2287 리뷰 P1-1) — legAdvance stamp(사용자 명시 하차 응답)가 살아있는 동안 stale/
+ * 불일치 lockSuggestion으로 재-hydrate해 그 stamp를 무력화하지 않도록 판정한다:
+ *   (a) suggestion.decidedAt < stamp.stampedAt — 사용자가 하차를 확인한 시점 *이전에* backend가
+ *       결정한 stale suggestion. 그 사이의 최신 상황을 반영하지 못했으므로 신뢰 X.
+ *   (b) suggestion.boardingLine !== stamp.nextLine — 사용자가 확인한 다음 leg와 다른 노선을
+ *       제안 — stale mirror(이전 leg) 재생성 회귀(#2278 RCA)를 여기서 직접 차단.
+ * stamp가 없으면(legAdvanceLine=null) conflict 없음 — 기존 동작 그대로.
+ */
+function isLegAdvanceConflict(
+  legAdvanceLine: LineNumber | null,
+  legAdvanceStampedAt: number | null,
+  decidedAt: number,
+  boardingLine: LineNumber,
+): boolean {
+  if (legAdvanceLine === null) return false;
+  const isStale = legAdvanceStampedAt !== null && decidedAt < legAdvanceStampedAt;
+  const disagrees = boardingLine !== legAdvanceLine;
+  return isStale || disagrees;
+}
+
+/**
  * BoardingLock 제어 hook (#584 PR B).
  *
  * 책임:
@@ -211,22 +248,16 @@ export function useBoardingLockController({
     // 확정해야 한다("기존 메커니즘 재사용, 신규 감지 신설 금지" — 이 effect가 이미 하는 backend
     // suggestion → createLock 채택 로직을 pending 케이스까지 확장). 이미 trainCode가 확정된
     // 일반 lock은 기존대로 완전 no-op(사용자 명시 탭 lock 보호 정책 불변).
-    const isPendingUpgrade = lock !== null && isPendingTrainCode(lock.trainCode);
-    if (lock && !isPendingUpgrade) return;
+    if (shouldSkipExistingLock(lock)) return;
     // #2330 (consensus-D, 설계 SSoT #2323 (3)) — confidence='consensus'는 lock 승격 금지.
     // legConsensus는 UI 표시(배지/하이라이트)/floor 힌트 전용 forward라 high/medium/low(9-AND
     // gate 기반 evidence)와 달리 자동 hydrate 대상이 아니다. "오토락 부활" 오해를 구조적으로 차단.
     if (lockSuggestion.confidence === 'consensus') return;
     const boardingLine = asLineNumber(lockSuggestion.lineId);
     if (!boardingLine) return;
-    // pending lock upgrade는 같은 leg(boardingLine 일치)일 때만 허용 — 다른 leg의 suggestion이
-    // fallback lock을 clobber하지 않도록 방어.
-    if (isPendingUpgrade && lock && boardingLine !== lock.boardingLine) return;
-    if (legAdvanceLine !== null) {
-      const isStale =
-        legAdvanceStampedAt !== null && lockSuggestion.decidedAt < legAdvanceStampedAt;
-      const disagrees = boardingLine !== legAdvanceLine;
-      if (isStale || disagrees) return;
+    if (isPendingUpgradeLineMismatch(lock, boardingLine)) return;
+    if (isLegAdvanceConflict(legAdvanceLine, legAdvanceStampedAt, lockSuggestion.decidedAt, boardingLine)) {
+      return;
     }
     const allowed = allowedLinesFromRoute(route);
     if (allowed && !allowed.has(boardingLine)) return;

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -45,6 +45,7 @@ import {
   DISEMBARK_PROMPT_CATEGORY,
 } from '../utils/notificationCategory';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { PENDING_TRAIN_CODE } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 import {
@@ -322,10 +323,12 @@ async function tryAutoLock(
     await dismissBoardingPrompt(payload.tripToken);
     return;
   }
+  // await 경계를 넘어도 non-null narrowing이 유지되도록 local const로 고정.
+  const destinationId = deps.destinationId;
 
   const arrival = await deps.fetchArrivalsForStation(payload.originStation);
   if (!arrival) {
-    log.info('arrivals fetch returned null — falling back to manual');
+    log.info('arrivals fetch returned null — creating pending fallback lock');
     logBoardingPromptAutoLock({ reason: 'autolock-arrivals-empty', ...telemetry });
     // #1888 (RC-13) — 빈 후보 graceful skip evidence. arrivals null = API fetch 실패 또는 응답 빈 케이스.
     // BoardingTrainList도 동시에 empty state로 진입하므로 사용자는 manual list에서 0건만 본다.
@@ -334,6 +337,10 @@ async function tryAutoLock(
       reason: 'arrivals-null',
       ...telemetry,
     });
+    // #2407 (root fix) — train 확정 실패해도 사용자 명시 탭 = lock 활성과 동급(ADR-014).
+    // trainCode는 PENDING sentinel로, downstream consumer가 arrival/realtimePosition 도착 시
+    // 기존 lockSuggestion 채널(useBoardingLockController)로 async 확정한다.
+    await createPendingFallbackLock(payload, deps, destinationId);
     return;
   }
 
@@ -349,7 +356,7 @@ async function tryAutoLock(
   );
   const chosen = pickAutoTrainCodeFromArrivals(sameLine, destinationDirection);
   if (!chosen) {
-    log.info('ambiguity or empty — auto lock skipped');
+    log.info('ambiguity or empty — creating pending fallback lock');
     // 빈 후보와 ambiguity 구분: sameLine이 1개 이상인데 chosen이 null이면 ambiguity.
     const reason = sameLine.length === 0 ? 'autolock-arrivals-empty' : 'autolock-ambiguity';
     logBoardingPromptAutoLock({ reason, ...telemetry });
@@ -361,6 +368,9 @@ async function tryAutoLock(
         ...telemetry,
       });
     }
+    // #2407 (root fix) — 무매칭/ambiguity 둘 다 "탭했는데 train을 못 골랐다"는 동일 실패 모드.
+    // 두 경우 모두 lock 자체는 생성해 lockless cascade를 막는다 (async 확정은 후속 신호에 위임).
+    await createPendingFallbackLock(payload, deps, destinationId);
     return;
   }
 
@@ -374,7 +384,7 @@ async function tryAutoLock(
 
   try {
     await deps.createLock({
-      destinationId: deps.destinationId,
+      destinationId,
       trainCode: chosen.trainCode,
       boardingStationId: station.id,
       boardingLine: chosen.line,
@@ -393,6 +403,58 @@ async function tryAutoLock(
     // #1167 — lock 실패 시 fallback 경로. createLock는 storage/network 예외 가능.
     // 사용자는 manual BoardingTrainList에서 재선택. 예외는 swallow — autoLock은 best-effort.
     log.warn('createLock failed — falling back to manual', err as Error);
+    logBoardingPromptAutoLock({ reason: 'autolock-lock-failed', ...telemetry });
+  }
+}
+
+/**
+ * #2407 (root fix) — train 확정 실패(arrivals null / line 매칭 0건 / ambiguity)에서도 사용자가
+ * 방금 [탑승] 응답했다는 사실 자체는 확정 evidence다(ADR-014 "명시 탭 = lock 활성과 동급").
+ * trainCode만 `PENDING_TRAIN_CODE` sentinel로 채워 lock을 생성 — GPS/route 기반 저정밀도라도
+ * lockless보다 낫다(설계 문서 "지하 완벽감지"와 동일 철학). `evidence=false` — 탑승 확정이 아니라
+ * "탑승 의향 표명 + train 미확정" 상태이므로 #2290 P1 정책과 정합.
+ *
+ * boardingStationId 조회 실패(원 payload.line이 유효 LineNumber가 아니거나 역명 매칭 실패)는
+ * 극히 드문 데이터 이상 케이스 — lock 없이 manual fallback으로 graceful skip.
+ */
+async function createPendingFallbackLock(
+  payload: BoardingPromptPayload,
+  deps: HandleDeps,
+  destinationId: string,
+): Promise<void> {
+  const telemetry = { originStation: payload.originStation, line: payload.line };
+
+  if (!isValidLineNumber(payload.line)) {
+    log.warn('pending fallback lock skipped — invalid line', payload.line);
+    logBoardingPromptAutoLock({ reason: 'autolock-station-lookup', ...telemetry });
+    return;
+  }
+  const station = findStationByNameAndLine(payload.originStation, payload.line);
+  if (!station) {
+    log.info('pending fallback lock skipped — station lookup failed');
+    logBoardingPromptAutoLock({ reason: 'autolock-station-lookup', ...telemetry });
+    return;
+  }
+
+  try {
+    await deps.createLock(
+      {
+        destinationId,
+        trainCode: PENDING_TRAIN_CODE,
+        boardingStationId: station.id,
+        boardingLine: payload.line,
+        boardedAt: Date.now(),
+        expectedDurationMs: deps.expectedDurationMs,
+        // train 미확정 — Seam A 지연 칩 기준치가 없다. undefined는 기존 legacy lock과 동일하게
+        // graceful(지연 라벨 미노출).
+        initialEtaSeconds: undefined,
+      },
+      false,
+      'boarding-prompt-response',
+    );
+    logBoardingPromptAutoLock({ reason: 'autolock-fallback-pending', ...telemetry });
+  } catch (err) {
+    log.warn('pending fallback createLock failed', err as Error);
     logBoardingPromptAutoLock({ reason: 'autolock-lock-failed', ...telemetry });
   }
 }

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -24,6 +24,7 @@
 
 import { useEffect } from 'react';
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
@@ -45,9 +46,14 @@ import {
   DISEMBARK_PROMPT_CATEGORY,
 } from '../utils/notificationCategory';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
-import { PENDING_TRAIN_CODE } from '../../../shared/constants/boardingLock';
+import {
+  FALLBACK_LOCK_POSITION_GUARD_FRESHNESS_MS,
+  PENDING_TRAIN_CODE,
+} from '../../../shared/constants/boardingLock';
+import { BG_LAST_STATION_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import { parseBgLastStation } from '../utils/widgetRefreshContext';
 import {
   markBoardingPromptDisplayed,
   wasBoardingPromptDisplayed,
@@ -408,6 +414,26 @@ async function tryAutoLock(
 }
 
 /**
+ * #2408 (위험1 guard) — BG_LAST_STATION_KEY를 읽어 신선도 기준(FALLBACK_LOCK_POSITION_GUARD_
+ * FRESHNESS_MS) 안의 관측치만 반환. stale(오래된 timestamp)이거나 부재/파싱 실패면 null —
+ * 검증 불가 케이스는 guard가 작동하지 않고 기존 fallback lock 생성 경로로 흐른다.
+ *
+ * read/parse 실패는 swallow — guard는 best-effort이며 실패 시 사용자 탭을 그대로 신뢰한다.
+ */
+async function readFreshBgLastStationForGuard() {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LAST_STATION_KEY);
+    const bgContext = parseBgLastStation(raw);
+    if (!bgContext) return null;
+    if (Date.now() - bgContext.timestamp > FALLBACK_LOCK_POSITION_GUARD_FRESHNESS_MS) return null;
+    return bgContext;
+  } catch (err) {
+    log.warn('BG_LAST_STATION read failed — position guard skipped', err as Error);
+    return null;
+  }
+}
+
+/**
  * #2407 (root fix) — train 확정 실패(arrivals null / line 매칭 0건 / ambiguity)에서도 사용자가
  * 방금 [탑승] 응답했다는 사실 자체는 확정 evidence다(ADR-014 "명시 탭 = lock 활성과 동급").
  * trainCode만 `PENDING_TRAIN_CODE` sentinel로 채워 lock을 생성 — GPS/route 기반 저정밀도라도
@@ -423,6 +449,21 @@ async function createPendingFallbackLock(
   destinationId: string,
 ): Promise<void> {
   const telemetry = { originStation: payload.originStation, line: payload.line };
+
+  // #2408 (위험1 guard) — stale prompt → 잘못된 lock 방지. device가 최근에 관측한
+  // BG_LAST_STATION(현재 위치)이 payload.line과 다른 노선이면, 이 prompt가 사용자의 실제 현재
+  // 위치와 모순되는 오래된(stale) 알림이라고 판단해 lock 생성을 skip한다. BG_LAST_STATION이
+  // 없거나(WhileInUse 등) 신선도 기준을 넘었거나(검증 불가) line이 일치하면 기존대로 진행 —
+  // 사용자의 명시 탭을 신뢰한다(ADR-014).
+  const bgContext = await readFreshBgLastStationForGuard();
+  if (bgContext && bgContext.station.line !== payload.line) {
+    log.info('pending fallback lock skipped — position contradiction with fresh BG context');
+    logBoardingPromptAutoLock({
+      reason: 'fallback-skipped-position-contradiction',
+      ...telemetry,
+    });
+    return;
+  }
 
   if (!isValidLineNumber(payload.line)) {
     log.warn('pending fallback lock skipped — invalid line', payload.line);

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -2757,6 +2757,8 @@ describe('alarmLog', () => {
       ['autolock-ambiguity', 'suppressed'],
       ['autolock-station-lookup', 'suppressed'],
       ['autolock-lock-failed', 'suppressed'],
+      // #2407 — root fix fallback lock reason.
+      ['autolock-fallback-pending', 'suppressed'],
     ] as const)('reason=%s → outcome=%s + stationName 합성', async (reason, expectedOutcome) => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
       logBoardingPromptAutoLock({ reason, originStation: '강남', line: '2' });
@@ -2780,6 +2782,8 @@ describe('alarmLog', () => {
         { ts: 5, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
         { ts: 6, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-station-lookup' },
         { ts: 7, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+        // #2407 — root fix fallback lock reason도 분포에 포함되어야 한다.
+        { ts: 10, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-fallback-pending' },
         // reason 없는 #1021 발사 entry는 제외
         { ts: 8, source: 'boarding-prompt', outcome: 'fired' },
         // 다른 source는 제외
@@ -2793,6 +2797,7 @@ describe('alarmLog', () => {
         'autolock-ambiguity': 1,
         'autolock-station-lookup': 1,
         'autolock-lock-failed': 1,
+        'autolock-fallback-pending': 1,
       });
     });
 
@@ -2837,6 +2842,8 @@ describe('alarmLog', () => {
         { ts: 99_003, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-no-trip' },
         { ts: 99_004, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-station-lookup' },
         { ts: 99_005, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+        // #2407 — root fix fallback lock reason도 분포에 포함되어야 한다.
+        { ts: 99_006, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-fallback-pending' },
       ];
       const counts = countAutoLockReasonsByWindow(entries, 10_000, now);
       expect(counts).toEqual({
@@ -2846,6 +2853,7 @@ describe('alarmLog', () => {
         'autolock-no-trip': 1,
         'autolock-station-lookup': 1,
         'autolock-lock-failed': 1,
+        'autolock-fallback-pending': 1,
       });
     });
 
@@ -2867,6 +2875,7 @@ describe('alarmLog', () => {
       expect(counts['autolock-no-trip']).toBe(0);
       expect(counts['autolock-station-lookup']).toBe(0);
       expect(counts['autolock-lock-failed']).toBe(0);
+      expect(counts['autolock-fallback-pending']).toBe(0);
     });
 
     it('reason 없는 entry(발사 빈도 #1021)는 집계에서 제외한다', () => {

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -2759,6 +2759,8 @@ describe('alarmLog', () => {
       ['autolock-lock-failed', 'suppressed'],
       // #2407 — root fix fallback lock reason.
       ['autolock-fallback-pending', 'suppressed'],
+      // #2408 — 위험1 guard skip reason.
+      ['fallback-skipped-position-contradiction', 'suppressed'],
     ] as const)('reason=%s → outcome=%s + stationName 합성', async (reason, expectedOutcome) => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
       logBoardingPromptAutoLock({ reason, originStation: '강남', line: '2' });
@@ -2784,6 +2786,13 @@ describe('alarmLog', () => {
         { ts: 7, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
         // #2407 — root fix fallback lock reason도 분포에 포함되어야 한다.
         { ts: 10, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-fallback-pending' },
+        // #2408 — 위험1 guard skip reason도 분포에 포함되어야 한다.
+        {
+          ts: 11,
+          source: 'boarding-prompt',
+          outcome: 'suppressed',
+          reason: 'fallback-skipped-position-contradiction',
+        },
         // reason 없는 #1021 발사 entry는 제외
         { ts: 8, source: 'boarding-prompt', outcome: 'fired' },
         // 다른 source는 제외
@@ -2798,6 +2807,7 @@ describe('alarmLog', () => {
         'autolock-station-lookup': 1,
         'autolock-lock-failed': 1,
         'autolock-fallback-pending': 1,
+        'fallback-skipped-position-contradiction': 1,
       });
     });
 
@@ -2844,6 +2854,13 @@ describe('alarmLog', () => {
         { ts: 99_005, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
         // #2407 — root fix fallback lock reason도 분포에 포함되어야 한다.
         { ts: 99_006, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-fallback-pending' },
+        // #2408 — 위험1 guard skip reason도 분포에 포함되어야 한다.
+        {
+          ts: 99_007,
+          source: 'boarding-prompt',
+          outcome: 'suppressed',
+          reason: 'fallback-skipped-position-contradiction',
+        },
       ];
       const counts = countAutoLockReasonsByWindow(entries, 10_000, now);
       expect(counts).toEqual({
@@ -2854,6 +2871,7 @@ describe('alarmLog', () => {
         'autolock-station-lookup': 1,
         'autolock-lock-failed': 1,
         'autolock-fallback-pending': 1,
+        'fallback-skipped-position-contradiction': 1,
       });
     });
 
@@ -2876,6 +2894,7 @@ describe('alarmLog', () => {
       expect(counts['autolock-station-lookup']).toBe(0);
       expect(counts['autolock-lock-failed']).toBe(0);
       expect(counts['autolock-fallback-pending']).toBe(0);
+      expect(counts['fallback-skipped-position-contradiction']).toBe(0);
     });
 
     it('reason 없는 entry(발사 빈도 #1021)는 집계에서 제외한다', () => {

--- a/src/features/alarm/utils/__tests__/bgPositionTrainFire.test.ts
+++ b/src/features/alarm/utils/__tests__/bgPositionTrainFire.test.ts
@@ -89,6 +89,7 @@ import {
   ALARM_EVENT_KEY,
   BG_LAST_STATION_KEY,
 } from '../../../../shared/constants/storageKeys';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
 
 const ORIGIN = { id: 'S0', name: '탑승역', line: '2', lat: 37.0, lng: 127.0 };
 const WAYPOINT = { id: 'S1', name: '다음역', line: '2', lat: 37.1, lng: 127.1 };
@@ -166,6 +167,17 @@ describe('evaluatePositionTrainFire', () => {
 
   it('lock.trainCode가 없으면 false를 반환한다', async () => {
     mockGetBoardingLock.mockResolvedValue({ ...LOCK, trainCode: '' });
+
+    const result = await evaluatePositionTrainFire();
+
+    expect(result).toBe(false);
+    expect(mockPollTrainPositionsIfDue).not.toHaveBeenCalled();
+  });
+
+  // #2407 — pending lock(fallback lock, trainCode 미확정)은 이 정밀추적 경로를 skip해야
+  // 한다. sentinel을 실 trainCode처럼 넣으면 어떤 열차와도 매칭되지 않아 false negative만 쌓인다.
+  it('lock.trainCode가 pending sentinel이면 false를 반환한다 (#2407)', async () => {
+    mockGetBoardingLock.mockResolvedValue({ ...LOCK, trainCode: PENDING_TRAIN_CODE });
 
     const result = await evaluatePositionTrainFire();
 

--- a/src/features/alarm/utils/__tests__/buildBoardingLockMeta.test.ts
+++ b/src/features/alarm/utils/__tests__/buildBoardingLockMeta.test.ts
@@ -80,34 +80,17 @@ describe('buildBoardingLockMeta', () => {
     expect(result).toBeNull();
   });
 
-  it('#865 — 시간표 fallback trainCode(SCHED-*)면 null (backend 누설 차단)', () => {
-    const route = makeDirectRoute(1, '7');
-    const result = buildBoardingLockMeta({
-      lock: { ...baseLock, trainCode: 'SCHED-UP-1', boardingLine: '7' },
-      route,
-      destinationName: '용마산',
-      boardingStationName: '면목',
-    });
-    expect(result).toBeNull();
-  });
-
-  it('#865 — SCHED-DN-* 같은 다른 suffix도 동일하게 null', () => {
-    const route = makeDirectRoute(1, '7');
-    const result = buildBoardingLockMeta({
-      lock: { ...baseLock, trainCode: 'SCHED-DN-2', boardingLine: '7' },
-      route,
-      destinationName: '용마산',
-      boardingStationName: '면목',
-    });
-    expect(result).toBeNull();
-  });
-
-  // #2407 — pending fallback lock(trainCode 미확정)은 backend reschedule의 anchor로 쓸 수
+  // #865 — 시간표 fallback trainCode(SCHED-*)는 backend 누설 차단.
+  // #2407 — pending fallback lock(trainCode 미확정)도 backend reschedule의 anchor로 쓸 수
   // 없다. schedule fallback과 동일하게 등록을 보류해 anchor waypoint 폴링으로 fallback해야 한다.
-  it('#2407 — trainCode가 pending sentinel이면 null (backend 등록 보류)', () => {
+  it.each([
+    ['#865 — 시간표 fallback trainCode(SCHED-*)면 null (backend 누설 차단)', 'SCHED-UP-1'],
+    ['#865 — SCHED-DN-* 같은 다른 suffix도 동일하게 null', 'SCHED-DN-2'],
+    ['#2407 — trainCode가 pending sentinel이면 null (backend 등록 보류)', 'PENDING-TRAIN-CODE'],
+  ])('%s', (_description, trainCode) => {
     const route = makeDirectRoute(1, '7');
     const result = buildBoardingLockMeta({
-      lock: { ...baseLock, trainCode: 'PENDING-TRAIN-CODE', boardingLine: '7' },
+      lock: { ...baseLock, trainCode: trainCode as never, boardingLine: '7' },
       route,
       destinationName: '용마산',
       boardingStationName: '면목',

--- a/src/features/alarm/utils/__tests__/buildBoardingLockMeta.test.ts
+++ b/src/features/alarm/utils/__tests__/buildBoardingLockMeta.test.ts
@@ -102,6 +102,19 @@ describe('buildBoardingLockMeta', () => {
     expect(result).toBeNull();
   });
 
+  // #2407 — pending fallback lock(trainCode 미확정)은 backend reschedule의 anchor로 쓸 수
+  // 없다. schedule fallback과 동일하게 등록을 보류해 anchor waypoint 폴링으로 fallback해야 한다.
+  it('#2407 — trainCode가 pending sentinel이면 null (backend 등록 보류)', () => {
+    const route = makeDirectRoute(1, '7');
+    const result = buildBoardingLockMeta({
+      lock: { ...baseLock, trainCode: 'PENDING-TRAIN-CODE', boardingLine: '7' },
+      route,
+      destinationName: '용마산',
+      boardingStationName: '면목',
+    });
+    expect(result).toBeNull();
+  });
+
   it('segmentStations 추론 불가하면 (boardingLine ≠ route segment) null', () => {
     const route = makeTransferRoute({
       transferName: '교대',

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -263,10 +263,12 @@ export type AlarmLogReason =
   //   'autolock-ambiguity': 같은 priority 후보 2+ → manual fallback.
   //   'autolock-station-lookup': originStation/line 매칭 실패.
   //   'autolock-lock-failed': createLock 예외 (저장/네트워크 등) → manual fallback.
+  //   'autolock-fallback-pending': #2407 root fix — train 확정 실패해도 pending trainCode로 lock 생성.
   | 'autolock-success'
   | 'autolock-no-trip'
   | 'autolock-arrivals-empty'
   | 'autolock-ambiguity'
+  | 'autolock-fallback-pending'
   | 'autolock-station-lookup'
   | 'autolock-lock-failed'
   // #1170 — boarding-prompt 사용자 응답 측정. 9단 게이트 통과 후 발사된 prompt에 대한 응답.
@@ -2224,7 +2226,9 @@ export type BoardingPromptAutoLockReason =
   | 'autolock-arrivals-empty'
   | 'autolock-ambiguity'
   | 'autolock-station-lookup'
-  | 'autolock-lock-failed';
+  | 'autolock-lock-failed'
+  // #2407 — train 확정 실패해도 lock은 생성한 root-fix fallback 경로. trainCode=pending sentinel.
+  | 'autolock-fallback-pending';
 
 export function logBoardingPromptAutoLock(input: {
   reason: BoardingPromptAutoLockReason;
@@ -2251,6 +2255,7 @@ export function countBoardingPromptAutoLockOutcomes(
     'autolock-ambiguity': 0,
     'autolock-station-lookup': 0,
     'autolock-lock-failed': 0,
+    'autolock-fallback-pending': 0,
   };
   for (const entry of entries) {
     if (entry.source !== 'boarding-prompt') continue;
@@ -2284,6 +2289,7 @@ export function countAutoLockReasonsByWindow(
     'autolock-ambiguity': 0,
     'autolock-station-lookup': 0,
     'autolock-lock-failed': 0,
+    'autolock-fallback-pending': 0,
   };
   for (const entry of entries) {
     if (entry.ts <= cutoff) continue;

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -2250,11 +2250,9 @@ export function logBoardingPromptAutoLock(input: {
   });
 }
 
-/** #1167 — 최근 N건의 autolock outcome 분포 (운영 측정용). */
-export function countBoardingPromptAutoLockOutcomes(
-  entries: readonly AlarmLogEntry[],
-): Record<BoardingPromptAutoLockReason, number> {
-  const counts: Record<BoardingPromptAutoLockReason, number> = {
+/** #2408 — `countBoardingPromptAutoLockOutcomes`/`countAutoLockReasonsByWindow`가 공유하는 0값 초기 분포. */
+function createEmptyAutoLockReasonCounts(): Record<BoardingPromptAutoLockReason, number> {
+  return {
     'autolock-success': 0,
     'autolock-no-trip': 0,
     'autolock-arrivals-empty': 0,
@@ -2264,6 +2262,13 @@ export function countBoardingPromptAutoLockOutcomes(
     'autolock-fallback-pending': 0,
     'fallback-skipped-position-contradiction': 0,
   };
+}
+
+/** #1167 — 최근 N건의 autolock outcome 분포 (운영 측정용). */
+export function countBoardingPromptAutoLockOutcomes(
+  entries: readonly AlarmLogEntry[],
+): Record<BoardingPromptAutoLockReason, number> {
+  const counts = createEmptyAutoLockReasonCounts();
   for (const entry of entries) {
     if (entry.source !== 'boarding-prompt') continue;
     const reason = entry.reason;
@@ -2289,16 +2294,7 @@ export function countAutoLockReasonsByWindow(
   now: number = Date.now(),
 ): Record<BoardingPromptAutoLockReason, number> {
   const cutoff = now - windowMs;
-  const counts: Record<BoardingPromptAutoLockReason, number> = {
-    'autolock-success': 0,
-    'autolock-no-trip': 0,
-    'autolock-arrivals-empty': 0,
-    'autolock-ambiguity': 0,
-    'autolock-station-lookup': 0,
-    'autolock-lock-failed': 0,
-    'autolock-fallback-pending': 0,
-    'fallback-skipped-position-contradiction': 0,
-  };
+  const counts = createEmptyAutoLockReasonCounts();
   for (const entry of entries) {
     if (entry.ts <= cutoff) continue;
     if (entry.source !== 'boarding-prompt') continue;

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -264,11 +264,14 @@ export type AlarmLogReason =
   //   'autolock-station-lookup': originStation/line 매칭 실패.
   //   'autolock-lock-failed': createLock 예외 (저장/네트워크 등) → manual fallback.
   //   'autolock-fallback-pending': #2407 root fix — train 확정 실패해도 pending trainCode로 lock 생성.
+  //   'fallback-skipped-position-contradiction': #2408 위험1 guard — fresh BG_LAST_STATION이
+  //     payload.line과 모순(다른 노선에 위치)돼 stale prompt로 판단, pending fallback lock을 skip.
   | 'autolock-success'
   | 'autolock-no-trip'
   | 'autolock-arrivals-empty'
   | 'autolock-ambiguity'
   | 'autolock-fallback-pending'
+  | 'fallback-skipped-position-contradiction'
   | 'autolock-station-lookup'
   | 'autolock-lock-failed'
   // #1170 — boarding-prompt 사용자 응답 측정. 9단 게이트 통과 후 발사된 prompt에 대한 응답.
@@ -2228,7 +2231,10 @@ export type BoardingPromptAutoLockReason =
   | 'autolock-station-lookup'
   | 'autolock-lock-failed'
   // #2407 — train 확정 실패해도 lock은 생성한 root-fix fallback 경로. trainCode=pending sentinel.
-  | 'autolock-fallback-pending';
+  | 'autolock-fallback-pending'
+  // #2408 — 위험1 guard: fresh BG_LAST_STATION이 payload.line과 모순돼 stale prompt로 판단,
+  // pending fallback lock 생성을 skip.
+  | 'fallback-skipped-position-contradiction';
 
 export function logBoardingPromptAutoLock(input: {
   reason: BoardingPromptAutoLockReason;
@@ -2256,6 +2262,7 @@ export function countBoardingPromptAutoLockOutcomes(
     'autolock-station-lookup': 0,
     'autolock-lock-failed': 0,
     'autolock-fallback-pending': 0,
+    'fallback-skipped-position-contradiction': 0,
   };
   for (const entry of entries) {
     if (entry.source !== 'boarding-prompt') continue;
@@ -2290,6 +2297,7 @@ export function countAutoLockReasonsByWindow(
     'autolock-station-lookup': 0,
     'autolock-lock-failed': 0,
     'autolock-fallback-pending': 0,
+    'fallback-skipped-position-contradiction': 0,
   };
   for (const entry of entries) {
     if (entry.ts <= cutoff) continue;

--- a/src/features/alarm/utils/bgFirePersist.ts
+++ b/src/features/alarm/utils/bgFirePersist.ts
@@ -1,0 +1,62 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: `bgPositionTrainFire.ts` / `undergroundConsensusFire.ts`와 동일하게
+ * widget feature의 util을 조합하는 orchestrator다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { alarmKey } from './stationAlarm';
+import { setFiredAlarms } from './notificationState';
+import { saveStationToWidget } from '../../widget/api/widgetStorage';
+import { buildWidgetTripContext } from '../../widget/utils/buildTripContext';
+import { ALARM_EVENT_KEY, BG_LAST_STATION_KEY } from '../../../shared/constants/storageKeys';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import type { PipelineResult } from './stationPipeline';
+
+export interface PersistBgFireResultInputs extends PipelineResult {
+  destination: Station;
+  firedAlarms: Set<string>;
+  storedRoute: Route;
+}
+
+/**
+ * BG 자가감지 발사 경로(`bgPositionTrainFire.ts` / `undergroundConsensusFire.ts`)가 공유하는
+ * `processLocationUpdate` 후처리 — firedAlarms bookkeeping, `ALARM_EVENT_KEY` 저장,
+ * `BG_LAST_STATION_KEY` 저장, 위젯 forward. 두 경로 모두 GPS 좌표 없이(train/consensus 좌표로)
+ * 완결된 독립 경로라 `backgroundLocationTask.ts`의 GPS 경로 후처리와 별도로 이 후처리를
+ * 각자 수행했는데, 그 후처리 로직 자체가 완전히 동일해 SonarCloud 신규 중복으로 추출했다.
+ */
+export async function persistBgFireResult({
+  alarmEvent,
+  nearest,
+  destination,
+  firedAlarms,
+  storedRoute,
+}: PersistBgFireResultInputs): Promise<void> {
+  if (alarmEvent) {
+    firedAlarms.add(alarmKey(alarmEvent));
+    await Promise.all([
+      setFiredAlarms(destination.id, firedAlarms),
+      AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
+    ]);
+  }
+
+  if (nearest) {
+    await AsyncStorage.setItem(
+      BG_LAST_STATION_KEY,
+      JSON.stringify({
+        station: nearest.station,
+        distanceKm: nearest.distanceKm,
+        timestamp: Date.now(),
+      }),
+    );
+    const tripContext = buildWidgetTripContext({
+      destination,
+      currentStation: nearest.station,
+      route: storedRoute,
+    });
+    await saveStationToWidget(nearest.station, nearest.distanceKm, undefined, undefined, tripContext);
+  }
+}

--- a/src/features/alarm/utils/bgPositionTrainFire.ts
+++ b/src/features/alarm/utils/bgPositionTrainFire.ts
@@ -9,6 +9,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from './stationPipeline';
 import { alarmKey } from './stationAlarm';
 import { getBoardingLock } from './boardingLockStorage';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 import { getFiredAlarms, setFiredAlarms } from './notificationState';
 import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 import { passesLockedStationGate } from '../../nearest-station/utils/lockedStationGate';
@@ -61,7 +62,10 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
   if (!isMinimalAlarmEnabled()) return false;
 
   const lock = await getBoardingLock();
-  if (!lock || !lock.trainCode) return false;
+  // #2407 — trainCode pending(fallback lock, 미확정) 상태에서는 이 경로(realtimePosition 정밀추적)를
+  // skip한다. pending sentinel을 실 trainCode처럼 매칭에 넣으면 항상 미매칭이라 false negative만
+  // 쌓인다 — 호출자(backgroundLocationTask)가 기존 GPS/route 파이프라인으로 graceful degrade.
+  if (!lock || !lock.trainCode || isPendingTrainCode(lock.trainCode)) return false;
 
   const destJson = await AsyncStorage.getItem(DESTINATION_KEY);
   if (!destJson) return false;

--- a/src/features/alarm/utils/bgPositionTrainFire.ts
+++ b/src/features/alarm/utils/bgPositionTrainFire.ts
@@ -7,26 +7,18 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from './stationPipeline';
-import { alarmKey } from './stationAlarm';
 import { getBoardingLock } from './boardingLockStorage';
 import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
-import { getFiredAlarms, setFiredAlarms } from './notificationState';
+import { getFiredAlarms } from './notificationState';
+import { persistBgFireResult } from './bgFirePersist';
 import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 import { passesLockedStationGate } from '../../nearest-station/utils/lockedStationGate';
 import { pollTrainPositionsIfDue } from '../../nearest-station/tasks/bgPositionTrainPoll';
 import { pickCandidateTrains } from '../../arrival/utils/pickCandidateTrains';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
-import { saveStationToWidget } from '../../widget/api/widgetStorage';
-import { buildWidgetTripContext } from '../../widget/utils/buildTripContext';
 import { getStationById, type Route } from '../../../shared/utils/stationRoute';
-import {
-  DESTINATION_KEY,
-  SLEEP_MODE_KEY,
-  ROUTE_KEY,
-  ALARM_EVENT_KEY,
-  BG_LAST_STATION_KEY,
-} from '../../../shared/constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, ROUTE_KEY, BG_LAST_STATION_KEY } from '../../../shared/constants/storageKeys';
 import type { Station } from '../../../shared/types/station';
 import { createLogger } from '../../../shared/utils/logger';
 
@@ -149,30 +141,7 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
     fusionSource: 'position-train',
   });
 
-  if (alarmEvent) {
-    firedAlarms.add(alarmKey(alarmEvent));
-    await Promise.all([
-      setFiredAlarms(destination.id, firedAlarms),
-      AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
-    ]);
-  }
-
-  if (nearest) {
-    await AsyncStorage.setItem(
-      BG_LAST_STATION_KEY,
-      JSON.stringify({
-        station: nearest.station,
-        distanceKm: nearest.distanceKm,
-        timestamp: Date.now(),
-      }),
-    );
-    const tripContext = buildWidgetTripContext({
-      destination,
-      currentStation: nearest.station,
-      route: storedRoute,
-    });
-    await saveStationToWidget(nearest.station, nearest.distanceKm, undefined, undefined, tripContext);
-  }
+  await persistBgFireResult({ alarmEvent, nearest, destination, firedAlarms, storedRoute });
 
   return true;
 }

--- a/src/features/alarm/utils/bgPositionTrainFire.ts
+++ b/src/features/alarm/utils/bgPositionTrainFire.ts
@@ -65,7 +65,7 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
   // #2407 — trainCode pending(fallback lock, 미확정) 상태에서는 이 경로(realtimePosition 정밀추적)를
   // skip한다. pending sentinel을 실 trainCode처럼 매칭에 넣으면 항상 미매칭이라 false negative만
   // 쌓인다 — 호출자(backgroundLocationTask)가 기존 GPS/route 파이프라인으로 graceful degrade.
-  if (!lock || !lock.trainCode || isPendingTrainCode(lock.trainCode)) return false;
+  if (!lock?.trainCode || isPendingTrainCode(lock.trainCode)) return false;
 
   const destJson = await AsyncStorage.getItem(DESTINATION_KEY);
   if (!destJson) return false;

--- a/src/features/alarm/utils/buildBoardingLockMeta.ts
+++ b/src/features/alarm/utils/buildBoardingLockMeta.ts
@@ -8,6 +8,7 @@ import type { Station } from '../../../shared/types/station';
 import type { LineNumber } from '../../../shared/types/station';
 import type { AlarmBoardingLock } from '../api/alarmBackend';
 import { isScheduleFallbackTrainCode } from './scheduleFallback';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('buildBoardingLockMeta');
@@ -100,6 +101,17 @@ export function buildBoardingLockMeta({
   if (isScheduleFallbackTrainCode(lock.trainCode)) {
     logger.warn(
       `skip backend register — schedule fallback trainCode=${lock.trainCode} (line=${lock.boardingLine})`,
+    );
+    return null;
+  }
+
+  // #2407 — trainCode pending(fallback lock, train 미확정)은 backend reschedule의 정정 anchor로
+  // 쓸 수 없다 — backend가 이 sentinel로 실시간 API를 조회하면 절대 못 찾아 schedule fallback과
+  // 동일하게 anchor waypoint 폴링으로 fallback해야 한다. 등록 자체를 보류하고, 다음 effect
+  // cycle에서 trainCode가 확정되면(useBoardingLockController lockSuggestion upgrade) 정상 등록된다.
+  if (isPendingTrainCode(lock.trainCode)) {
+    logger.warn(
+      `skip backend register — pending trainCode (line=${lock.boardingLine})`,
     );
     return null;
   }

--- a/src/features/alarm/utils/undergroundConsensusFire.ts
+++ b/src/features/alarm/utils/undergroundConsensusFire.ts
@@ -7,9 +7,9 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from './stationPipeline';
-import { alarmKey } from './stationAlarm';
 import { getBoardingLock } from './boardingLockStorage';
-import { getFiredAlarms, setFiredAlarms } from './notificationState';
+import { getFiredAlarms } from './notificationState';
+import { persistBgFireResult } from './bgFirePersist';
 import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 import { isUndergroundProfile } from '../../nearest-station/utils/bgLocationProfile';
 import { undergroundSSOTConsensus } from '../../nearest-station/utils/undergroundSSotConsensus';
@@ -25,15 +25,7 @@ import {
   startCellularTechUpdates,
   classifyCellularEnvironment,
 } from '../../nearest-station/utils/cellularTech';
-import { saveStationToWidget } from '../../widget/api/widgetStorage';
-import { buildWidgetTripContext } from '../../widget/utils/buildTripContext';
-import {
-  DESTINATION_KEY,
-  SLEEP_MODE_KEY,
-  ROUTE_KEY,
-  ALARM_EVENT_KEY,
-  BG_LAST_STATION_KEY,
-} from '../../../shared/constants/storageKeys';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
 import { createLogger } from '../../../shared/utils/logger';
@@ -142,28 +134,5 @@ export async function evaluateUndergroundConsensusFire(): Promise<void> {
     fusionSource: 'position-train',
   });
 
-  if (alarmEvent) {
-    firedAlarms.add(alarmKey(alarmEvent));
-    await Promise.all([
-      setFiredAlarms(destination.id, firedAlarms),
-      AsyncStorage.setItem(ALARM_EVENT_KEY, JSON.stringify(alarmEvent)),
-    ]);
-  }
-
-  if (nearest) {
-    await AsyncStorage.setItem(
-      BG_LAST_STATION_KEY,
-      JSON.stringify({
-        station: nearest.station,
-        distanceKm: nearest.distanceKm,
-        timestamp: Date.now(),
-      }),
-    );
-    const tripContext = buildWidgetTripContext({
-      destination,
-      currentStation: nearest.station,
-      route: storedRoute,
-    });
-    await saveStationToWidget(nearest.station, nearest.distanceKm, undefined, undefined, tripContext);
-  }
+  await persistBgFireResult({ alarmEvent, nearest, destination, firedAlarms, storedRoute });
 }

--- a/src/features/alarm/utils/widgetRefreshContext.ts
+++ b/src/features/alarm/utils/widgetRefreshContext.ts
@@ -49,8 +49,11 @@ function parseDestination(raw: string | null): Station | null {
  * (`refreshLiveActivityFromBackgroundContext`의 `BgLastStation`과 동일 shape).
  *
  * - parsed가 null / 비-object / distanceKm 비-number / station 부재 → null.
+ *
+ * #2408 — useBoardingPromptResponder의 stale-prompt position guard도 동일 parse 로직이 필요해
+ * export. 중복 구현 대신 이 단일 narrow 함수를 공유한다.
  */
-function parseBgLastStation(raw: string | null): BgLastStationContext | null {
+export function parseBgLastStation(raw: string | null): BgLastStationContext | null {
   const parsed = safeParse<unknown>(raw);
   if (
     !parsed ||

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1370,6 +1370,14 @@ function buildBackendCallsSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #2407 — pending sentinel(fallback lock, 실 trainCode 미확정)을 dump/UI 양쪽에 동일하게
+ * "(pending)" suffix로 명시 표기. 두 표시 지점(dump text, BoardingLockSection UI)의 SSOT.
+ */
+function formatTrainCodeDisplay(trainCode: string): string {
+  return isPendingTrainCode(trainCode) ? `${trainCode} (pending)` : trainCode;
+}
+
+/**
  * #1413 — BoardingLock 섹션. UI BoardingLockSection과 동일 필드를 dump key=value 형태로.
  * lock 없으면 `active=no` 1줄만.
  */
@@ -1380,8 +1388,7 @@ function buildBoardingLockSection(args: BuildDumpArgs): string[] {
   const lines: string[] = [`active=${active ? 'yes' : 'no'}`];
   if (lock) {
     lines.push(
-      // #2407 — pending sentinel(fallback lock, 실 trainCode 미확정)을 dump에도 명시 표기.
-      `trainCode=${isPendingTrainCode(lock.trainCode) ? `${lock.trainCode} (pending)` : lock.trainCode}`,
+      `trainCode=${formatTrainCodeDisplay(lock.trainCode)}`,
       `line=${lock.boardingLine}`,
       `expiresAt=${formatAt(lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR)}`,
       `boardedAt=${formatAt(lock.boardedAt)}`,
@@ -3385,8 +3392,7 @@ function BoardingLockSection({
         <>
           <KeyValue
             label="trainCode"
-            // #2407 — pending sentinel(fallback lock, 실 trainCode 미확정)을 명시 표기.
-            value={isPendingTrainCode(lock.trainCode) ? `${lock.trainCode} (pending)` : lock.trainCode}
+            value={formatTrainCodeDisplay(lock.trainCode)}
             colors={colors}
           />
           <KeyValue label="line" value={String(lock.boardingLine)} colors={colors} />

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -81,6 +81,7 @@ import {
   isBoardingLockExpired,
   type BoardingLock,
 } from '../../../shared/types/boardingLock';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 import {
   clearEstimatorEntries,
   getEstimatorEntries,
@@ -1379,7 +1380,8 @@ function buildBoardingLockSection(args: BuildDumpArgs): string[] {
   const lines: string[] = [`active=${active ? 'yes' : 'no'}`];
   if (lock) {
     lines.push(
-      `trainCode=${lock.trainCode}`,
+      // #2407 — pending sentinel(fallback lock, 실 trainCode 미확정)을 dump에도 명시 표기.
+      `trainCode=${isPendingTrainCode(lock.trainCode) ? `${lock.trainCode} (pending)` : lock.trainCode}`,
       `line=${lock.boardingLine}`,
       `expiresAt=${formatAt(lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR)}`,
       `boardedAt=${formatAt(lock.boardedAt)}`,
@@ -3381,7 +3383,12 @@ function BoardingLockSection({
       <KeyValue label="active" value={active ? 'yes' : 'no'} colors={colors} />
       {lock && (
         <>
-          <KeyValue label="trainCode" value={lock.trainCode} colors={colors} />
+          <KeyValue
+            label="trainCode"
+            // #2407 — pending sentinel(fallback lock, 실 trainCode 미확정)을 명시 표기.
+            value={isPendingTrainCode(lock.trainCode) ? `${lock.trainCode} (pending)` : lock.trainCode}
+            colors={colors}
+          />
           <KeyValue label="line" value={String(lock.boardingLine)} colors={colors} />
           <KeyValue
             label="expiresAt"
@@ -3566,11 +3573,13 @@ function AutoLockTelemetryRow({
     counts['autolock-arrivals-empty'] +
     counts['autolock-no-trip'] +
     counts['autolock-station-lookup'] +
-    counts['autolock-lock-failed'];
+    counts['autolock-lock-failed'] +
+    counts['autolock-fallback-pending'];
   const value =
     total === 0
       ? '—'
-      : `ok=${counts['autolock-success']} amb=${counts['autolock-ambiguity']} empty=${counts['autolock-arrivals-empty']} fail=${counts['autolock-lock-failed']}`;
+      // #2407 — pending: root-fix fallback lock 카운트(train 미확정이어도 lock은 생성됨).
+      : `ok=${counts['autolock-success']} amb=${counts['autolock-ambiguity']} empty=${counts['autolock-arrivals-empty']} fail=${counts['autolock-lock-failed']} pending=${counts['autolock-fallback-pending']}`;
   return (
     <KeyValue
       label="autoLock(1h)"

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -876,13 +876,15 @@ describe('DebugModal', () => {
     expect(screen.getByTestId('debug-autolock-telemetry-1h').props.children).toBe('—');
   });
 
-  it('#1687: autoLock(1h) row — success/ambiguous/empty/failed 분포 표기', async () => {
+  it('#1687: autoLock(1h) row — success/ambiguous/empty/failed/pending 분포 표기', async () => {
     const now = Date.now();
     mockGetAlarmLog.mockResolvedValue([
       { ts: now - 1_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
       { ts: now - 2_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
       { ts: now - 3_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
       { ts: now - 4_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+      // #2407 — root fix fallback lock 카운트.
+      { ts: now - 5_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-fallback-pending' },
     ]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
@@ -892,6 +894,7 @@ describe('DebugModal', () => {
     expect(el.props.children).toContain('amb=1');
     expect(el.props.children).toContain('empty=1');
     expect(el.props.children).toContain('fail=1');
+    expect(el.props.children).toContain('pending=1');
   });
 
   it('#1693/#1706: Fusion Tier (1h) 섹션이 별 ring tier 분포를 표시한다', async () => {
@@ -3246,6 +3249,25 @@ describe('DebugModal — BoardingLock 섹션 (#1025)', () => {
     expect(screen.getByText('yes')).toBeTruthy();
   });
 
+  // #2407 — root fix fallback lock의 trainCode가 pending sentinel이면 UI KeyValue에도
+  // "(pending)" suffix를 명시(V/X dashboard 관측성).
+  it('lock.trainCode가 pending sentinel이면 "(pending)" suffix를 표시한다', async () => {
+    act(() => {
+      useBoardingLockStore.setState({
+        lock: {
+          ...activeLockBase(),
+          destinationId: 'dest-1',
+          trainCode: 'PENDING-TRAIN-CODE',
+          boardingStationId: 'stn-1',
+          boardingLine: '2',
+          boardingEvidence: false,
+        },
+      });
+    });
+    await renderAndWait();
+    expect(screen.getByText('PENDING-TRAIN-CODE (pending)')).toBeTruthy();
+  });
+
   it('lock이 sentinel이면 sentinel=yes를 표시한다', async () => {
     act(() => {
       useBoardingLockStore.setState({
@@ -3576,6 +3598,30 @@ describe('DebugModal share SSOT (#1346)', () => {
       expect(section).toContain('expiresAt=');
       expect(section).toContain('boardedAt=');
       expect(section).not.toContain('sentinel=yes');
+    });
+
+    // #2407 — trainCode가 pending sentinel(fallback lock, 실 trainCode 미확정)이면 dump에도
+    // 명시 표기(V/X dashboard 관측성).
+    it('BoardingLock: trainCode가 pending sentinel이면 "(pending)" suffix 표기', () => {
+      const boardedAt = new Date('2026-06-17T13:00:00Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: boardedAt + 60_000,
+          boardingLock: {
+            trainCode: 'PENDING-TRAIN-CODE',
+            boardingLine: '7',
+            boardedAt,
+            expectedDurationMs: 30 * 60 * 1000,
+            boardingStationId: '728',
+            destinationId: '2-022',
+          },
+        }),
+      );
+      const section = dump.slice(
+        dump.indexOf('## BoardingLock'),
+        dump.indexOf('## Estimator State'),
+      );
+      expect(section).toContain('trainCode=PENDING-TRAIN-CODE (pending)');
     });
 
     it('BoardingLock: hydratedFromSentinel=true면 sentinel=yes 라인 추가', () => {

--- a/src/features/route/hooks/__tests__/useTrainCodeMismatchDetector.test.ts
+++ b/src/features/route/hooks/__tests__/useTrainCodeMismatchDetector.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../useTrainCodeMismatchDetector';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
 
 const baseLock: BoardingLock = {
   destinationId: 'd',
@@ -237,6 +238,20 @@ describe('useTrainCodeMismatchDetector', () => {
       rerender,
       { lock: refreshedLock, positions: mismatchPositions, now: stillInGrace },
       TRAIN_CODE_MISMATCH_THRESHOLD + 2,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  // #2407 — pending lock(fallback lock, trainCode 미확정)은 mismatch 판정을 보류해야 한다.
+  // sentinel을 실 trainCode처럼 매칭에 넣으면 항상 mismatch 후보로 잘못 카운트돼 정당한
+  // pending lock을 90s 후 오탐 release할 위험이 있다.
+  it('lock.trainCode가 pending sentinel이면 mismatch 카운터가 증가하지 않는다 (#2407)', () => {
+    const pendingLock: BoardingLock = { ...baseLock, trainCode: PENDING_TRAIN_CODE };
+    const { result, rerender } = mount({ lock: pendingLock, positions: mismatchPositions });
+    rerenderTimes(
+      rerender,
+      { lock: pendingLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 5,
     );
     expect(result.current.detected).toBe(false);
   });

--- a/src/features/route/hooks/useTrainCodeMismatchDetector.ts
+++ b/src/features/route/hooks/useTrainCodeMismatchDetector.ts
@@ -1,6 +1,7 @@
 import { type MutableRefObject, useEffect, useRef, useState } from 'react';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LinePositions } from '../../../shared/types/position';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 
 /**
  * ref + state 이중관리 helper — stale closure 없이 ref는 effect 분기에, state는 외부 노출에 쓴다.
@@ -91,6 +92,10 @@ export function useTrainCodeMismatchDetector({
     if (!lock || !positions) return;
     if (positions.isMock) return;
     if (positions.line !== lock.boardingLine) return;
+    // #2407 — lock.trainCode가 pending sentinel(train 미확정)이면 mismatch 판정을 보류한다.
+    // pending은 실 trainCode가 아니므로 어떤 열차와도 매칭되지 않아 항상 'mismatch 후보'로
+    // 잘못 카운트되고, 90s 후 정당한 pending lock을 오탐 release할 위험이 있다(오탐 금지 원칙).
+    if (isPendingTrainCode(lock.trainCode)) return;
 
     // lock.trainCode가 현재 positions에 present → 정상 탑승, 카운터 reset.
     const isPresent = positions.trains.some((t) => t.trainNo === lock.trainCode);

--- a/src/features/route/utils/__tests__/detectMisBoarding.test.ts
+++ b/src/features/route/utils/__tests__/detectMisBoarding.test.ts
@@ -1,6 +1,7 @@
 import { detectMisBoarding } from '../detectMisBoarding';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
 
 const lock: BoardingLock = {
   destinationId: 'd',
@@ -62,5 +63,15 @@ describe('detectMisBoarding', () => {
 
   it('positions에 trains 빈 배열 → absent (관측은 됐지만 lock train 없음)', () => {
     expect(detectMisBoarding(lock, positions({ trains: [] }))).toBe('absent');
+  });
+
+  // #2407 — pending lock(fallback lock, trainCode 미확정)은 오탐 방지를 위해 no-signal로
+  // 판정을 보류해야 한다. sentinel을 실 trainCode처럼 매칭에 넣으면 항상 'absent'로 잘못 확정된다.
+  it('lock.trainCode가 pending sentinel이면 no-signal (오탐 금지, #2407)', () => {
+    const pendingLock: BoardingLock = { ...lock, trainCode: PENDING_TRAIN_CODE };
+    expect(
+      detectMisBoarding(pendingLock, positions({ trains: [train({ trainNo: 'T-OTHER' })] })),
+    ).toBe('no-signal');
+    expect(detectMisBoarding(pendingLock, positions({ trains: [] }))).toBe('no-signal');
   });
 });

--- a/src/features/route/utils/detectMisBoarding.ts
+++ b/src/features/route/utils/detectMisBoarding.ts
@@ -1,11 +1,14 @@
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LinePositions } from '../../../shared/types/position';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 
 /**
  * BoardingLock의 trainCode가 lock.boardingLine의 위치 데이터에서 관측되는지 검사 (#584 PR D3).
  *
  * - lock 또는 positions 없음 → 'no-signal' (탐지 보류 — 호출자가 카운터 미증가)
  * - positions.line이 lock.boardingLine과 다름 → 'no-signal' (관측 불가)
+ * - lock.trainCode가 #2407 pending sentinel(train 미확정) → 'no-signal' (오탐 금지 — pending을
+ *   실 trainCode처럼 매칭에 넣으면 항상 'absent'로 잘못 확정된다)
  * - positions에 trainNo == lock.trainCode 존재 → 'present'
  * - positions는 있고 trainNo 부재 → 'absent'
  *
@@ -20,6 +23,7 @@ export function detectMisBoarding(
   if (!lock || !positions) return 'no-signal';
   if (positions.isMock) return 'no-signal';
   if (positions.line !== lock.boardingLine) return 'no-signal';
+  if (isPendingTrainCode(lock.trainCode)) return 'no-signal';
   const found = positions.trains.some((t) => t.trainNo === lock.trainCode);
   return found ? 'present' : 'absent';
 }

--- a/src/shared/constants/__tests__/boardingLock.test.ts
+++ b/src/shared/constants/__tests__/boardingLock.test.ts
@@ -1,0 +1,15 @@
+import { PENDING_TRAIN_CODE, isPendingTrainCode } from '../boardingLock';
+
+describe('isPendingTrainCode (#2407)', () => {
+  it('PENDING_TRAIN_CODE sentinel → true', () => {
+    expect(isPendingTrainCode(PENDING_TRAIN_CODE)).toBe(true);
+  });
+
+  it('실 trainCode → false', () => {
+    expect(isPendingTrainCode('2026082601')).toBe(false);
+  });
+
+  it('빈 문자열 → false (sentinel은 명시 상수만 인정, falsy coercion에 의존하지 않음)', () => {
+    expect(isPendingTrainCode('')).toBe(false);
+  });
+});

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -186,6 +186,37 @@ export const REGISTER_RETRY_HEAL_BUSY_RECHECK_MS = 2_000;
 export const REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES = 5;
 
 /**
+ * #2407 (root fix, 08-28 lockless cascade) — trainCode 확정 실패(arrivals null / line 매칭 0건)
+ * 상태에서도 사용자 탑 탭 = lock 생성을 보장하기 위한 pending trainCode sentinel.
+ *
+ * 배경: `tryAutoLock`(useBoardingPromptResponder)이 arrivals 조회 실패/무매칭이면 `createLock`을
+ * 아예 호출하지 않고 return해, 사용자가 명시 탭했는데도 lock이 하나도 생기지 않는 회귀가
+ * 실탑승에서 확인됐다(#2405/#2406 RED fixture). ADR-014 "명시 탭 = lock 활성과 동급" 정합을
+ * 지키려면 train 확정 실패해도 lock 자체는 생성해야 한다 — trainCode만 이 sentinel로 채운다.
+ *
+ * 설계(빈 문자열 vs sentinel 상수 — sentinel 채택 이유):
+ *   - `BoardingLock.trainCode: string`은 이미 여러 소비처가 `.length > 0`/`.startsWith(...)`
+ *     같은 명시적 predicate로 검사한다(`isScheduleFallbackTrainCode`의 `SCHED-` prefix가 동일
+ *     선례). 빈 문자열('')은 일부 falsy-check(`!lock.trainCode`) 소비처에서는 우연히 안전하게
+ *     걸러지지만, 값 비교(`row.trainCode === lock.trainCode`)나 `.startsWith()` 호출부에서는
+ *     예외/오탐 가능성이 있어 암묵적 falsy coercion에 의존하는 게 더 위험하다.
+ *   - 명시적 sentinel 상수 + `isPendingTrainCode()` predicate가 "이 값이 왜 특별한가"를 grep
+ *     한 번으로 드러내고, 향후 코드 리뷰에서 실수로 빠뜨린 consumer를 찾기 쉽다(blast radius
+ *     추적 용이).
+ *   - `string` 타입을 `string | undefined`로 optional化하는 대안은 BoardingLock을 참조하는
+ *     전 소비처(수십 곳, 위 grep 결과)의 타입 가드를 전수 추가해야 해 blast radius가 훨씬 크다.
+ *
+ * 🔴 소비처는 `lock.trainCode`를 실 trainCode처럼 매칭에 사용하기 전에 반드시
+ * `isPendingTrainCode(lock.trainCode)`로 pending 여부를 먼저 판별해야 한다(오탐 금지).
+ */
+export const PENDING_TRAIN_CODE = 'PENDING-TRAIN-CODE';
+
+/** lock.trainCode가 #2407 fallback lock의 미확정 sentinel인지 판별. */
+export function isPendingTrainCode(trainCode: string): boolean {
+  return trainCode === PENDING_TRAIN_CODE;
+}
+
+/**
  * #2197 (ADR-025 client 절반) — 이미 등록된 trip의 route/destination 변경 재-POST를
  * coalesce하는 debounce(ms).
  *

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -217,6 +217,27 @@ export function isPendingTrainCode(trainCode: string): boolean {
 }
 
 /**
+ * #2408 (위험1 guard) — pending fallback lock 생성 전 BG_LAST_STATION과 payload.line 모순 판정에
+ * 쓰는 신선도 임계값(ms).
+ *
+ * 배경: `createPendingFallbackLock`은 payload.line/originStation을 위치 검증 없이 신뢰한다.
+ * stale prompt(예: 용마산/7호선에서 발사됐는데 실제로는 성수/2호선에 있는 사용자가 뒤늦게 탭)에서도
+ * lock을 생성해버리면 틀린 노선으로 lock이 잠기는 회귀가 생긴다. device가 최근에 관측한
+ * BG_LAST_STATION(`backgroundLocationTask`가 적재)이 payload.line과 다르면 모순으로 간주해 lock
+ * 생성을 skip한다.
+ *
+ * 5분으로 둔 이유:
+ *  - BG task 폴링 주기(30s~수분, 이동 속도에 따라 가변)를 여러 tick 커버해 오탐(일시적 GPS 튐)을
+ *    피하면서도, stale prompt가 보통 수 분~수십 분 전 발사분이라는 점을 고려하면 5분 이내 관측치는
+ *    "지금 위치"로 신뢰할 만큼 충분히 최근이다.
+ *  - 너무 짧으면(예: 1분) BG task가 저빈도 모드(이동 없음/절전)일 때 최근 관측치가 없어 guard가
+ *    거의 작동하지 않는다.
+ *  - 너무 길면(예: 30분) 실제로 이동한 사용자의 오래된 위치를 "현재 위치"로 오판해 정상 fallback
+ *    lock 생성까지 잘못 skip할 위험이 커진다.
+ */
+export const FALLBACK_LOCK_POSITION_GUARD_FRESHNESS_MS = 5 * 60_000;
+
+/**
  * #2197 (ADR-025 client 절반) — 이미 등록된 trip의 route/destination 변경 재-POST를
  * coalesce하는 debounce(ms).
  *


### PR DESCRIPTION
Closes #2407

## 배경 (근본 root — #2406 RED fixture로 확정)
`tryAutoLock`(useBoardingPromptResponder)이 arrivals=null 또는 line 매칭 train 0건이면 `createLock`을 아예 호출하지 않고 return해, 사용자가 명시 탭했는데도 lock이 하나도 생기지 않는 회귀(08-28 lockless cascade의 root)를 #2406 fixture가 실체인 구동으로 확정했다.

## 변경
train 확정 실패(arrivals null / line 매칭 0건 / ambiguity)해도 사용자가 방금 [탑승] 응답했다는 사실 자체는 확정 evidence — ADR-014 "명시 탭 = lock 활성과 동급" 그대로 lock을 생성한다. trainCode만 pending sentinel로 채우고, evidence=false, boardingLine/boardingStationId/destinationId는 payload/route 기반 확정값을 그대로 사용.

## pending 표현 방식 — sentinel 채택 (빈 문자열 vs sentinel 상수)

**채택: 명시 sentinel 상수 `PENDING_TRAIN_CODE = 'PENDING-TRAIN-CODE'` + `isPendingTrainCode()` predicate** (`src/shared/constants/boardingLock.ts`)

이유:
- 타입을 `string | undefined`로 optional化하는 대안은 `BoardingLock.trainCode`를 참조하는 전 소비처(grep 결과 수십 곳)의 타입 가드를 전수 추가해야 해 blast radius가 훨씬 크다.
- 빈 문자열(`''`)은 일부 falsy-check(`!lock.trainCode`, 예: `bgPositionTrainFire.ts`의 기존 게이트)에서는 우연히 안전하게 걸러지지만, 값 비교(`row.trainCode === lock.trainCode`)나 `.startsWith()` 호출부에서는 명시적 의도가 드러나지 않아 향후 리뷰에서 놓치기 쉽다.
- 이미 같은 패턴의 선례가 있다 — 시간표 fallback trainCode의 `SCHED-` prefix + `isScheduleFallbackTrainCode()` (`scheduleFallback.ts`). sentinel + predicate 방식이 이 코드베이스의 기존 컨벤션과 일치한다.
- `isPendingTrainCode()` 자체가 "이 값이 왜 특별한가"를 grep 한 번으로 드러내 blast radius 추적이 쉽다.

blast radius: `PENDING_TRAIN_CODE`/`isPendingTrainCode` import가 필요한 파일만 — 타입 시그니처 변경이 없어 컴파일러가 소비처를 강제하지 못하므로, 아래 "consumer 전수 처리"를 수동 grep(`.trainCode`)으로 확인해 하나씩 처리했다.

## consumer 전수 처리 목록

| consumer | 파일 | 처리 |
|---|---|---|
| position-train-lock BG 발사 (#2384) | `src/features/alarm/utils/bgPositionTrainFire.ts` | `evaluatePositionTrainFire`의 lock 게이트에 `isPendingTrainCode` 추가 — pending이면 정밀추적 skip, 호출자(`backgroundLocationTask`)가 기존 GPS/route 파이프라인으로 graceful degrade |
| mis-boarding 감지 | `src/features/route/utils/detectMisBoarding.ts` | pending이면 `'no-signal'` 반환 — 오탐 방지 (sentinel을 실 trainCode처럼 매칭에 넣으면 항상 `'absent'`로 잘못 확정됨) |
| trainCode mismatch 감지 (#1659) | `src/features/route/hooks/useTrainCodeMismatchDetector.ts` | pending이면 mismatch 카운터 미증가(no-signal) — 90s 후 정당한 pending lock 오탐 release 방지 |
| backend register/reschedule anchor | `src/features/alarm/utils/buildBoardingLockMeta.ts` | pending이면 backend register 자체를 skip(schedule fallback `SCHED-*`과 동일 패턴) — backend가 이 sentinel로 실시간 API 조회 시도하지 않도록 차단 |
| async trainCode 확정 (신규 감지 아님, 기존 lockSuggestion 채널 재사용) | `src/features/alarm/hooks/useBoardingLockController.ts` | `lockSuggestion`(backend #1534, arvlcd-confirmed evidence) 채택 effect의 `if (lock) return` 가드를 `if (lock && !isPendingUpgrade) return`로 완화 — pending lock에 한해 같은 leg(boardingLine 일치) suggestion이 도착하면 실 trainCode로 upgrade(evidence=true로 전환). 다른 leg의 suggestion은 clobber 방지 가드로 차단 |
| 관측성 (V/X) | `src/features/debug/components/DebugModal.tsx`, `src/features/alarm/utils/alarmLog.ts` | trainCode KeyValue/dump에 `(pending)` suffix, `autolock-fallback-pending` reason 추가, autoLock(1h) telemetry에 `pending=N` 카운트 |

검토했으나 수정 안 함(안전 확인):
- `useFusedNearestStation.ts`의 `lockedTrainCode`/`aliveLockedTrainCode` — 전부 strict equality(`row.trainCode === lockedTrainCode`) 비교라 pending sentinel과 매칭될 실 trainCode가 없어 자연히 no-match로 graceful degrade됨(별도 가드 불필요, 코드 리드로 확인).

## #2406 Assertion 1 flip 결과
`src/features/alarm/__tests__/replay_20260828_boarding_wire_red.test.ts`:
- 가설 A(arrivals-null), 가설 B(line-filtered-empty) 두 RED 테스트를 GREEN으로 flip — `createLock` 호출됨 + `trainCode=PENDING_TRAIN_CODE` + `boardingEvidence=false` 검증.
- GREEN 대조군(정상 arrivals → 실 trainCode lock)은 무회귀 확인.
- 5개 테스트 전부 pass.

## 스펙 이탈 사항
- **ambiguity도 fallback 대상에 포함**: 이슈 스펙은 "arrivals null / line 매칭 0건" 두 케이스를 명시했지만, `tryAutoLock`의 `if (!chosen)` 분기는 원래 empty(0건)와 ambiguity(2+ 동순위 후보)를 같은 코드 경로로 처리하고 있었다. "탭했는데 train을 못 골랐다"는 동일 실패 모드라 판단해 ambiguity도 pending fallback lock 대상에 포함시켰다. 별도 분기로 empty만 골라 fallback하고 ambiguity는 기존대로 lock 없이 두는 것은 추가 분기 복잡도만 늘리고 실익이 없다고 판단.

## 검증
- `npm run type-check`: pass
- `npm run lint:orphan`: pass (0 orphan)
- 타깃 테스트만 실행(전체 `npm test`는 watchdog stall로 생략 — 아래 파일들만 targeted 실행, 656 tests pass):
  - `useBoardingPromptResponder.test.ts`, `replay_20260828_boarding_wire_red.test.ts`
  - `bgPositionTrainFire.test.ts`, `detectMisBoarding.test.ts`, `useTrainCodeMismatchDetector.test.ts`
  - `buildBoardingLockMeta.test.ts`, `useBoardingLockController.test.tsx`
  - `boardingLock.test.ts` (신규), `DebugModal.test.tsx`
  - 개별 파일 단위로는 coverage 100% 확인(각 파일 `--coverage --collectCoverageFrom`로 개별 검증). **전역 coverage 100% 게이트(`npm test`)는 이번 세션에서 미실행** — CI의 `Type Check & Test` job이 최종 확인.

## Wire-completion 5단
1. **Orphan** — pass (`npm run lint:orphan` 0건).
2. **V/X dashboard** — DebugModal `BoardingLock` 섹션(UI KeyValue + dump 양쪽)에서 `trainCode=PENDING-TRAIN-CODE (pending)` 표기, `active=yes` 유지(잠금 자체는 걸림). autoLock(1h) telemetry row에 `pending=N` 카운트 추가.
3. **의존 PR** — #2406(RED fixture, 이미 dev에 머지됨 — `src/features/alarm/__tests__/replay_20260828_boarding_wire_red.test.ts`가 dev에 존재하는 것으로 확인). 그 외 backend/device 의존 PR 없음.
4. **측정 plan** — 1주 production: DebugModal autoLock(1h) `pending=N` 카운트 추이 관찰. `pending`이 async 확정 없이 오래 유지되면(lockSuggestion 미도착) `useBoardingLockController` 쪽 backend 지연 신호로 후속 조사. `alarmLog` reason=`autolock-fallback-pending` 빈도로 arrivals API 장애/지하 조건 빈도 추적.
5. **Device verify** — 🔴 실기기 필요. 다음 실탑승에서: 탑승 탭(BOARDED/$default) → DebugModal `BoardingLock active=yes` 확인(trainCode가 처음엔 pending, 이후 정상 API 응답 시 실 trainCode로 자동 전환되는지) + 군자 등 지하 구간에서 lockless cascade(오분류/재앵커) 재발 여부 확인.