### PR TITLE
feat(#2412): 환승 후 경로 표시 origin을 현재 leg 환승역으로 re-origin

### DIFF
--- a/src/features/route/utils/__tests__/journeyOrigin.test.ts
+++ b/src/features/route/utils/__tests__/journeyOrigin.test.ts
@@ -1,0 +1,203 @@
+import { resolveJourneyOriginStation } from '../journeyOrigin';
+import { getStationById } from '../../../../shared/utils/stationRoute';
+import type {
+  DirectRoute,
+  MultiTransferRoute,
+  Route,
+  TransferRoute,
+} from '../../../../shared/utils/stationRoute';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { Station } from '../../../../shared/types/station';
+
+function makeStation(line: Station['line'], overrides: Partial<Station> = {}): Station {
+  return {
+    id: '7-015',
+    name: '용마산',
+    line,
+    lineColor: '#000',
+    lat: 37,
+    lng: 127,
+    ...overrides,
+  };
+}
+
+function makeLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'dest',
+    trainCode: 'T1',
+    boardingStationId: '2-012',
+    boardingLine: '2',
+    boardedAt: Date.now(),
+    expectedDurationMs: 600_000,
+    ...overrides,
+  };
+}
+
+function makeDirect(line: DirectRoute['line'], stops = 5): DirectRoute {
+  return { type: 'direct', stops, line, travelSeconds: 0 };
+}
+
+function makeTransfer(
+  fromLine: TransferRoute['fromLine'],
+  toLine: TransferRoute['toLine'],
+  transferName: string,
+  stopsToTransfer = 3,
+): TransferRoute {
+  return {
+    type: 'transfer',
+    transferName,
+    fromLine,
+    toLine,
+    stopsToTransfer,
+    stopsFromTransfer: 5,
+    secondsToTransfer: 0,
+    secondsFromTransfer: 0,
+  };
+}
+
+function makeMulti(
+  segments: Array<{
+    from: MultiTransferRoute['transfers'][0]['fromLine'];
+    to: MultiTransferRoute['transfers'][0]['toLine'];
+    name: string;
+    stops: number;
+  }>,
+  stopsAfterLastTransfer = 2,
+): MultiTransferRoute {
+  return {
+    type: 'multi-transfer',
+    transfers: segments.map((s) => ({
+      transferName: s.name,
+      fromLine: s.from,
+      toLine: s.to,
+      stopsToTransfer: s.stops,
+      secondsToTransfer: 0,
+    })),
+    stopsAfterLastTransfer,
+    secondsAfterLastTransfer: 0,
+  };
+}
+
+describe('resolveJourneyOriginStation', () => {
+  const tripOrigin = makeStation('7', { id: '7-015', name: '용마산' });
+
+  describe('환승 전 (기존 회귀 0)', () => {
+    it('boardingLock/legAdvance/route 진행도 모두 없으면 tripOrigin 그대로', () => {
+      const route: Route = makeTransfer('7', '2', '건대입구', 3);
+      expect(resolveJourneyOriginStation(route, null, tripOrigin, null)).toBe(tripOrigin);
+    });
+
+    it('route null이어도 tripOrigin 그대로', () => {
+      expect(resolveJourneyOriginStation(null, null, tripOrigin, null)).toBe(tripOrigin);
+    });
+
+    it('direct route(환승 없음)는 tripOrigin 그대로', () => {
+      const route = makeDirect('7');
+      expect(resolveJourneyOriginStation(route, null, tripOrigin, null)).toBe(tripOrigin);
+    });
+  });
+
+  describe('BoardingLock 우선순위 1 (새 leg lock)', () => {
+    it('lock.boardingStationId가 유효 station이면 그 station 반환 (route/legAdvance 무시)', () => {
+      const route = makeTransfer('7', '2', '건대입구', 3);
+      const lock = makeLock({ boardingStationId: '2-012', boardingLine: '2' });
+      const result = resolveJourneyOriginStation(route, lock, tripOrigin, '2');
+      expect(result).toEqual(getStationById('2-012'));
+    });
+
+    it('lock.boardingStationId가 미존재 station id면 다음 우선순위로 폴백', () => {
+      const route = makeTransfer('7', '2', '건대입구', 0);
+      const lock = makeLock({ boardingStationId: 'no-such-id' });
+      const result = resolveJourneyOriginStation(route, lock, tripOrigin, null);
+      // route 진행도 우선순위(3)로 폴백 — stopsToTransfer===0이므로 환승역(건대입구, 2호선)
+      expect(result?.name).toBe('건대입구');
+      expect(result?.line).toBe('2');
+    });
+  });
+
+  describe('legAdvance 우선순위 2 (#2278 하차 응답 stamp)', () => {
+    it('legAdvanceLine이 transfer route의 toLine과 일치하면 환승역 반환', () => {
+      const route = makeTransfer('7', '2', '건대입구', 3); // route 진행도만으론 아직 환승 전(3>0)
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, '2');
+      expect(result?.name).toBe('건대입구');
+      expect(result?.line).toBe('2');
+    });
+
+    it('multi-transfer에서 legAdvanceLine이 두 번째 환승의 toLine이면 그 환승역 반환', () => {
+      const route = makeMulti([
+        { name: '건대입구', from: '7', to: '2', stops: 0 },
+        { name: '왕십리', from: '2', to: '5', stops: 4 },
+      ]);
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, '5');
+      expect(result?.name).toBe('왕십리(성동구청)');
+      expect(result?.line).toBe('5');
+    });
+
+    it('legAdvanceLine이 어떤 transfer의 toLine과도 안 맞으면 route 진행도로 폴백', () => {
+      const route = makeTransfer('7', '2', '건대입구', 0);
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, '8');
+      expect(result?.name).toBe('건대입구');
+      expect(result?.line).toBe('2');
+    });
+
+    it('legAdvanceLine이 toLine과 일치해도 transferName이 실제 station lookup에 실패하면 route 진행도로 폴백', () => {
+      const route = makeTransfer('7', '2', '존재하지않는역이름', 0);
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, '2');
+      // findTransferStationForLine이 실패 → route 진행도(우선순위 3)도 같은 이름이라 실패 → tripOrigin
+      expect(result).toBe(tripOrigin);
+    });
+  });
+
+  describe('route 진행도 우선순위 3 (stopsToTransfer===0)', () => {
+    it('transfer route, stopsToTransfer>0(환승 전) → tripOrigin', () => {
+      const route = makeTransfer('7', '2', '건대입구', 3);
+      expect(resolveJourneyOriginStation(route, null, tripOrigin, null)).toBe(tripOrigin);
+    });
+
+    it('transfer route, stopsToTransfer===0(환승 완료) → 환승역', () => {
+      const route = makeTransfer('7', '2', '건대입구', 0);
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, null);
+      expect(result?.name).toBe('건대입구');
+      expect(result?.line).toBe('2');
+    });
+
+    it('multi-transfer: 다중 환승 각 leg별 origin — 1차 환승만 완료', () => {
+      const route = makeMulti([
+        { name: '건대입구', from: '7', to: '2', stops: 0 },
+        { name: '왕십리', from: '2', to: '5', stops: 4 },
+      ]);
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, null);
+      expect(result?.name).toBe('건대입구');
+      expect(result?.line).toBe('2');
+    });
+
+    it('multi-transfer: 다중 환승 각 leg별 origin — 2차 환승까지 완료(마지막 leg)', () => {
+      const route = makeMulti([
+        { name: '건대입구', from: '7', to: '2', stops: 0 },
+        { name: '왕십리', from: '2', to: '5', stops: 0 },
+      ]);
+      const result = resolveJourneyOriginStation(route, null, tripOrigin, null);
+      expect(result?.name).toBe('왕십리(성동구청)');
+      expect(result?.line).toBe('5');
+    });
+
+    it('multi-transfer: 아직 첫 환승도 안 함 → tripOrigin', () => {
+      const route = makeMulti([
+        { name: '건대입구', from: '7', to: '2', stops: 3 },
+        { name: '왕십리', from: '2', to: '5', stops: 4 },
+      ]);
+      expect(resolveJourneyOriginStation(route, null, tripOrigin, null)).toBe(tripOrigin);
+    });
+
+    it('transfer 환승역 이름이 station lookup에 실패하면 tripOrigin으로 폴백', () => {
+      const route = makeTransfer('7', '2', '존재하지않는역이름', 0);
+      expect(resolveJourneyOriginStation(route, null, tripOrigin, null)).toBe(tripOrigin);
+    });
+  });
+
+  describe('null/전체 부재', () => {
+    it('route/lock/legAdvance 모두 null이고 tripOrigin도 null이면 null', () => {
+      expect(resolveJourneyOriginStation(null, null, null, null)).toBeNull();
+    });
+  });
+});

--- a/src/features/route/utils/journeyOrigin.ts
+++ b/src/features/route/utils/journeyOrigin.ts
@@ -1,0 +1,91 @@
+import {
+  findStationByNameAndLine,
+  getStationById,
+  type Route,
+  type TransferSegment,
+} from '../../../shared/utils/stationRoute';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { LineNumber, Station } from '../../../shared/types/station';
+
+/**
+ * #2412 — 경로 표시 origin을 trip 시작역(tripOrigin) 고정이 아니라 **현재 leg의 시작역**으로
+ * re-origin한다. 환승 전엔 tripOrigin 그대로, 환승 후엔 그 leg가 시작된 환승역으로 앵커링해
+ * "용마산 → 뚝섬"이 아니라 "건대 → 뚝섬"으로 표시되게 한다.
+ *
+ * 새 leg 감지 신호 신설 금지(#2412) — `getApproachLine`(approachLine.ts)과 동일한 3단
+ * 우선순위로 **기존 신호만** 재사용한다:
+ *   1. BoardingLock 존재 → `boardingLock.boardingStationId` (새 leg lock, 가장 강한 신호)
+ *   2. legAdvance stamp(#2278) → 사용자가 환승역 하차 응답으로 확인한 다음 leg의 line에
+ *      대응하는 route transfer 구간의 환승역
+ *   3. Route + segment 진행도(`stopsToTransfer===0`) → 이미 통과한 마지막 환승역
+ *   4. 위 셋 다 없으면 tripOrigin 그대로(caller가 넘긴 값을 그대로 반환)
+ *
+ * 반환값이 tripOrigin과 다른 Station이면 그 leg는 "환승 후" — buildJourneyDisplay가 그 station을
+ * `current`로 받아 첫 세그먼트 fromName===toName(0-hop)이 되고, journeyDisplayToStops의
+ * isCollapsedZeroFirstHop(#665)이 자동으로 "환승역 → 목적지"로 접어준다.
+ */
+export function resolveJourneyOriginStation(
+  route: Route,
+  boardingLock: BoardingLock | null,
+  tripOrigin: Station | null,
+  legAdvanceLine?: LineNumber | null,
+): Station | null {
+  if (boardingLock) {
+    const locked = getStationById(boardingLock.boardingStationId);
+    if (locked) return locked;
+  }
+
+  if (legAdvanceLine) {
+    const advanced = findTransferStationForLine(route, legAdvanceLine);
+    if (advanced) return advanced;
+  }
+
+  const progressed = findLastCompletedTransferStation(route);
+  if (progressed) return progressed;
+
+  return tripOrigin;
+}
+
+/** route 형태에 관계없이 환승 구간 목록으로 정규화한다(direct=빈 배열). */
+function getTransferSegments(route: Route): TransferSegment[] {
+  if (!route || route.type === 'direct') return [];
+  if (route.type === 'transfer') {
+    return [
+      {
+        transferName: route.transferName,
+        fromLine: route.fromLine,
+        toLine: route.toLine,
+        stopsToTransfer: route.stopsToTransfer,
+        secondsToTransfer: route.secondsToTransfer,
+      },
+    ];
+  }
+  return route.transfers;
+}
+
+/** legAdvanceLine(다음 leg 노선)에 해당하는 환승 구간을 찾아 그 환승역을 반환한다. */
+function findTransferStationForLine(route: Route, line: LineNumber): Station | null {
+  const segments = getTransferSegments(route);
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i].toLine === line) {
+      return findStationByNameAndLine(segments[i].transferName, line) ?? null;
+    }
+  }
+  return null;
+}
+
+/**
+ * route의 실측 진행도(`stopsToTransfer===0`)로 이미 통과한 마지막 환승역을 찾는다.
+ * updateRouteFromPosition이 통과한 구간부터 순서대로 0으로 갱신하므로 배열은
+ * [0, 0, ..., 0, 진행중, 미도달...] 형태로 단조적이다 — 첫 non-zero에서 멈춘다.
+ */
+function findLastCompletedTransferStation(route: Route): Station | null {
+  const segments = getTransferSegments(route);
+  let last: TransferSegment | null = null;
+  for (const segment of segments) {
+    if (segment.stopsToTransfer > 0) break;
+    last = segment;
+  }
+  if (!last) return null;
+  return findStationByNameAndLine(last.transferName, last.toLine) ?? null;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -102,6 +102,7 @@ import { BoardingLockHopCard } from '../features/alarm/components/BoardingLockHo
 import { LocklessBadge } from '../features/alarm/components/LocklessBadge';
 import { resolveNextAdjacentStationName } from '../features/route/utils/nextAdjacentStation';
 import { getApproachLine } from '../features/route/utils/approachLine';
+import { resolveJourneyOriginStation } from '../features/route/utils/journeyOrigin';
 import { useCongestion } from '../features/congestion/hooks/useCongestion';
 import { deriveCongestionDirection } from '../features/congestion/utils/deriveDirection';
 import { CongestionBadge } from '../features/congestion/components/CongestionBadge';
@@ -605,7 +606,13 @@ export default function HomeScreen() {
   // 중 화면에 표시되는 출발역이 현재역을 따라 재앵커되는 회귀가 있었다(evidence: 07:32
   // 어린이대공원 → 07:34 건대입구). tripOrigin이 아직 캡처 전(cold-start)이면 effectiveOrigin으로
   // 1회 fallback — useTripOrigin이 곧 캡처하면 이후 렌더부터는 tripOrigin으로 고정된다.
-  const journeyOrigin = tripOrigin ?? effectiveOrigin;
+  // #2412 — 환승 후엔 origin을 trip 시작역이 아니라 현재 leg가 시작된 환승역으로 re-origin
+  // ("용마산 → 뚝섬"이 아니라 "건대 → 뚝섬"). 새 신호 신설 없이 기존 3단 신호
+  // (boardingLock.boardingStationId / legAdvanceLine / route 진행도)만 재사용해 leg를 판정하고,
+  // 판정 실패 시 위 tripOrigin ?? effectiveOrigin 체인 그대로 fallback한다.
+  const journeyOrigin =
+    resolveJourneyOriginStation(route, fusionBoardingLock, tripOrigin, legAdvanceLine) ??
+    effectiveOrigin;
   const journey = useMemo(
     () => (route && journeyOrigin && destination ? buildJourneyDisplay(route, journeyOrigin, destination) : null),
     [route, journeyOrigin?.id, destination?.id],


### PR DESCRIPTION
## 배경
2호선 환승 후에도 메인 경로 표시 origin이 trip 시작역(예: 용마산)에 고정돼 "용마산 → 뚝섬"으로 어색하게 표시됨. 환승 후엔 환승역(건대)을 origin으로 re-origin해 "건대 → 뚝섬"으로 표시.

## 변경
- `src/features/route/utils/journeyOrigin.ts` 신설 — `resolveJourneyOriginStation`이 기존 신호 3단(boardingLock.boardingStationId → legAdvanceLine(#2278) → route transfer 진행도 stopsToTransfer===0)만 재사용해 현재 leg의 origin station을 판정. 새 leg 감지 신호 신설 없음.
- `src/screens/HomeScreen.tsx`: `journeyOrigin = tripOrigin ?? effectiveOrigin` → `resolveJourneyOriginStation(...) ?? effectiveOrigin`. 실패 시 기존 tripOrigin 체인 그대로 fallback (환승 전 회귀 0).
- 기존 `buildJourneyDisplay` + `journeyDisplayToStops`의 0-hop collapse(#665)가 origin===환승역일 때 자동으로 "환승역 → 목적지" 표시로 접어줌 — 표시 로직 자체는 무변경.
- 다중 환승은 `transfers` 배열 순회로 처리(개수 하드코딩 없음).

## 금지사항 준수
- 새 leg 감지 신호 신설 안 함 (기존 3개 신호만 재사용)
- 현재역 추정/발사 로직 무관
- tripOrigin store 자체 변경 없음 (표시 도출만)

## 테스트
`src/features/route/utils/__tests__/journeyOrigin.test.ts` 신설, 100% 커버리지 (branches/functions/lines/statements).
- 환승 전: tripOrigin 그대로 (boardingLock/legAdvance/route 진행도 모두 없음)
- 환승 후(legAdvanceLine 매칭 / route stopsToTransfer===0 / boardingLock 새 leg): 환승역 반환
- 다중 환승: 1차만 완료 / 2차까지 완료(각 leg 별) / 아직 미완료
- 폴백: station lookup 실패, id 미존재, route/lock/legAdvance 전부 부재

## Wire-completion 5단
1. **Orphan 없음**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: 메인 화면 경로 표시(JourneyDisplay/timeline)에서 직접 관측 — 환승 후 "환승역 → 목적지" 렌더링 확인.
3. **의존 PR**: N/A.
4. **측정 plan**: 환승 후 실탑승 시나리오에서 표시가 "환승역 → 목적지"인지 확인 (A1(#2408)/#2410 device 번들과 함께 검증).
5. **Device verify**: 필요 — 리빌드 후 환승 탑승 시나리오로 확인. A1/#2410과 번들.

Closes #2412