### PR TITLE
feat(#2416): DebugModal share dump에 Operation Dashboard backend 지표 포함

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -146,6 +146,10 @@ import {
   formatScheduledNotificationLine,
   type ScheduledNotificationDumpEntry,
 } from '../../../features/alarm/utils/scheduledNotificationsDump';
+import {
+  getLastObservabilityMetricsSnapshot,
+  type ObservabilityMetrics,
+} from '../../observability/api/observabilityMetricsClient';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
@@ -756,9 +760,10 @@ interface BuildDumpArgs {
     active: boolean;
   };
   /**
-   * Operation Dashboard 4 metric 중 device-local 계산 가능한 것만 share dump에 포함.
-   * backend polling 결과(locklessMiss / boardableMiss / accelPattern / latency / laPush)는
-   * dump 시점에 sync 접근 불가 → dump에서는 (backend metrics: n/a in dump) 안내로 대체.
+   * Operation Dashboard의 device-local metric 입력(alarmAccuracy). backend polling metric
+   * (locklessMiss / boardableMiss / accelPattern / latency / laPush 등)은 이 필드가 아니라
+   * `observabilityMetricsClient`의 마지막 poll snapshot에서 직접 읽는다(`buildOperationDashboardSection`
+   * 참조) — `OperationDashboardSection` 마운트 시 채워진 결과를 dump 시점에 sync로 재사용.
    *
    * 노출 metric:
    *  - alarmAccuracy (local): tripGroundTruth store `responses` accurate/answered 비율
@@ -986,16 +991,103 @@ function buildFeatureFlagSection(args: BuildDumpArgs): string[] {
   ];
 }
 
+/** `value/total` 비율을 `pct% (value/total)`로 포맷. total=0이면 0%로 표시. */
+function formatRatioPct(value: number, total: number): string {
+  const pct = total === 0 ? 0 : Math.round((value / total) * 100);
+  return `${pct}% (${value}/${total})`;
+}
+
+/** `label=pct% (value/total)` 한 줄 포맷. */
+function formatBucketLine(label: string, value: number, total: number): string {
+  return `${label}=${formatRatioPct(value, total)}`;
+}
+
 /**
- * Operation Dashboard(Modal render line 2141-2143)의 device-local 계산 가능 metric dump.
+ * #1769 accelPattern 4종 분포를 한 줄로 포맷. 분포 key 수가 늘어도 코드 변경 없이
+ * 순회(`Object.entries`)해 대응 — `OperationDashboardSection`의 `ACCEL_PATTERN_KEYS`와
+ * 동일 데이터(`AccelPatternBucket`)를 소비하되 하드코딩 배열에 의존하지 않는다.
+ */
+function formatAccelPatternLine(accelPattern: ObservabilityMetrics['accelPatternHitRatio']): string {
+  const parts = Object.entries(accelPattern).map(
+    ([key, { count, ratio }]) => `${key} ${Math.round(ratio * 100)}%(${count})`,
+  );
+  return `accelPattern: ${parts.join(' ')}`;
+}
+
+/**
+ * backend observability metrics(`ObservabilityMetrics`)를 dump 라인 배열로 변환.
+ * Modal UI(`OperationDashboardSection`)와 동일 SSOT(backend 응답 필드)를 그대로 읽어
+ * 텍스트로 재구성 — ratio 재계산 로직 분기는 두지 않고 필드값을 직접 사용.
+ */
+function formatBackendMetricsLines(metrics: ObservabilityMetrics): string[] {
+  const { locklessMissRatio, boardableMissRatio, laPushDeliveryRatio } = metrics;
+  const lines = [
+    formatBucketLine('locklessMiss', locklessMissRatio.value, locklessMissRatio.total),
+    formatBucketLine('boardableMiss', boardableMissRatio.value, boardableMissRatio.total),
+    formatAccelPatternLine(metrics.accelPatternHitRatio),
+    metrics.silentPushLatency
+      ? `silentPushLatency=p50=${metrics.silentPushLatency.p50}ms p95=${metrics.silentPushLatency.p95}ms n=${metrics.silentPushLatency.totalSamples}`
+      : 'silentPushLatency=no data',
+    formatBucketLine(
+      'laPushDelivery',
+      laPushDeliveryRatio.sent,
+      laPushDeliveryRatio.sent + laPushDeliveryRatio.failed,
+    ),
+    metrics.silentPushReachRatio
+      ? formatBucketLine(
+          'silentPushReach(backend)',
+          metrics.silentPushReachRatio.received,
+          metrics.silentPushReachRatio.sent,
+        )
+      : 'silentPushReach(backend)=no data',
+    metrics.algorithmAccuracyRatio
+      ? formatBucketLine('algorithmAccuracy', metrics.algorithmAccuracyRatio.value, metrics.algorithmAccuracyRatio.total)
+      : 'algorithmAccuracy=no data',
+    metrics.locklessTripMissRatio
+      ? `locklessTripMiss(paradigm=${metrics.locklessTripMissRatio.paradigmIntent})=${formatRatioPct(
+          metrics.locklessTripMissRatio.miss,
+          metrics.locklessTripMissRatio.miss + metrics.locklessTripMissRatio.fired,
+        )}`
+      : 'locklessTripMiss=no data',
+  ];
+  return lines;
+}
+
+/**
+ * backend observability metrics의 마지막 poll snapshot(`getLastObservabilityMetricsSnapshot`)을
+ * dump 라인으로 변환. `OperationDashboardSection`이 마운트 시 1회 `fetchObservabilityMetrics()`를
+ * 호출해 이 snapshot을 채운다 — 별도 polling을 추가하지 않고 그 결과를 dump 시점에 sync로 읽는다.
  *
- * Modal이 노출하는 6+ metric 중 backend polling 결과(locklessMiss / boardableMiss / accelPattern /
- * pushLatency / laPushDelivery / silentPushReachBackend / locklessTripMiss)는 dump 시점에 sync
- * 접근 불가 → 본 섹션은 device-local snapshot 만 노출하고 backend metric 은 명시적으로 안내.
+ * - 한 번도 poll 안 됨(모달 진입 전 dump 등): `(no backend poll yet)`
+ * - poll 실패(unconfigured/error): `(backend poll failed: <reason>)`
+ * - 성공: metric 라인들 + `as of <조회 시각>` (staleness 명시 — snapshot이 dump 시점 것이 아닐 수 있음)
+ */
+function buildBackendMetricsSection(): string[] {
+  const snapshot = getLastObservabilityMetricsSnapshot();
+  if (!snapshot) return ['(no backend poll yet)'];
+  const { result, fetchedAtMs } = snapshot;
+  if (result.kind !== 'ok') {
+    const reason = result.kind === 'unconfigured' ? 'unconfigured' : result.message;
+    return [`(backend poll failed: ${reason})`];
+  }
+  return [...formatBackendMetricsLines(result.metrics), `as of ${formatTime(fetchedAtMs)}`];
+}
+
+/**
+ * Operation Dashboard(Modal render line 2141-2143) metric dump.
+ *
+ * device-local metric(alarmAccuracy/silentPushReach)과 backend polling metric(locklessMiss /
+ * boardableMiss / accelPattern / silentPushLatency / laPushDelivery / silentPushReach(backend) /
+ * algorithmAccuracy / locklessTripMiss)을 모두 포함한다.
+ *
+ * backend metric은 `observabilityMetricsClient`의 마지막 poll 결과 snapshot을 읽는다 — dump는
+ * async fetch를 하지 않고 `OperationDashboardSection` 마운트 시 이미 완료된 poll의 결과를
+ * 그대로 노출한다(`as of` 로 조회 시각 명시, staleness graceful).
  *
  * 노출 metric:
  *  - alarmAccuracy (local): tripGroundTruth store `responses` accurate/answered 비율
  *  - silentPushReach (local): `computeSilentPushReach(logs)` visibleReceived/totalReceived (#2231)
+ *  - backend 8종: 위 참고
  *
  * 미전달 시 (n/a) — DebugModalInner 가 store snapshot 을 주입하지 않은 호출자 graceful.
  */
@@ -1008,7 +1100,7 @@ function buildOperationDashboardSection(args: BuildDumpArgs): string[] {
   return [
     `alarmAccuracy(local)=${op.groundTruthAccurateCount}/${op.groundTruthAnsweredCount}`,
     `silentPushReach(local)=${reach.visibleReceived}/${reach.totalReceived}`,
-    '(backend metrics: locklessMiss/boardableMiss/accelPattern/pushLatency/laPush — see Modal UI, not dumped)',
+    ...buildBackendMetricsSection(),
   ];
 }
 
@@ -2444,7 +2536,8 @@ function DebugModalInner({
         active: isSimpleArchEnabled(archFlagRemote.value),
       },
       // Operation Dashboard 의 device-local metric (alarmAccuracy local). backend polling metric 은
-      // dump 시점 sync 접근 불가라 안내 라인으로 대체 (buildOperationDashboardSection 참조).
+      // buildOperationDashboardSection이 observabilityMetricsClient의 마지막 poll snapshot을
+      // 직접 읽어 채운다 — 여기서는 device-local 입력만 넘긴다.
       operationDashboard: {
         groundTruthAccurateCount: groundTruthResponses.filter((r) => r.outcome === 'accurate').length,
         groundTruthAnsweredCount: groundTruthResponses.filter((r) => r.outcome !== 'unanswered').length,

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -13,6 +13,11 @@ import type { AlarmLogEntry } from '../../../../features/alarm/utils/alarmLog';
 import type { Station, NearestStationResult } from '../../../../shared/types/station';
 import type { StationArrival } from '../../../../shared/types/arrival';
 import { formatClockTimeWithSeconds } from '../../../../shared/utils/formatTime';
+import {
+  fetchObservabilityMetrics,
+  __test__ as observabilityMetricsClientTestUtils,
+  type ObservabilityMetrics,
+} from '../../../observability/api/observabilityMetricsClient';
 
 const mockUseFusedNearestStation = jest.fn();
 const mockUseArrivalInfo = jest.fn();
@@ -5656,11 +5661,15 @@ describe('DebugModal share dump — 누락 3 섹션 wire (#2044-scope)', () => {
   });
 
   describe('buildOperationDashboardSection (#1751)', () => {
+    beforeEach(() => {
+      observabilityMetricsClientTestUtils.resetLastMetricsSnapshot();
+    });
+
     it('operationDashboard 미전달 시 (n/a) 반환 — store snapshot 미주입 graceful', () => {
       expect(__test__.buildOperationDashboardSection(makeArgs())).toEqual(['(n/a)']);
     });
 
-    it('alarmAccuracy(local) 0/0 + silentPushReach(local) 0/0 + backend 안내 라인', () => {
+    it('alarmAccuracy(local) 0/0 + silentPushReach(local) 0/0 + backend poll 전이면 안내 라인', () => {
       const result = __test__.buildOperationDashboardSection(
         makeArgs({
           operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
@@ -5669,8 +5678,135 @@ describe('DebugModal share dump — 누락 3 섹션 wire (#2044-scope)', () => {
       expect(result).toEqual([
         'alarmAccuracy(local)=0/0',
         'silentPushReach(local)=0/0',
-        '(backend metrics: locklessMiss/boardableMiss/accelPattern/pushLatency/laPush — see Modal UI, not dumped)',
+        '(no backend poll yet)',
       ]);
+    });
+
+    it('backend poll 실패(unconfigured) 시 사유를 명시', async () => {
+      const originalToken = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      delete process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      await fetchObservabilityMetrics();
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = originalToken;
+
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
+        }),
+      );
+      expect(result).toContain('(backend poll failed: unconfigured)');
+    });
+
+    it('backend poll 실패(HTTP error) 시 error message를 명시', async () => {
+      const originalToken = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      const originalUrl = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'test-token';
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      }) as unknown as typeof fetch;
+      await fetchObservabilityMetrics();
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = originalToken;
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = originalUrl;
+
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
+        }),
+      );
+      expect(result).toContain('(backend poll failed: HTTP 503)');
+    });
+
+    it('backend poll 성공 시 OperationDashboardSection과 동일 SSOT metric 8종을 노출', async () => {
+      const metrics: ObservabilityMetrics = {
+        accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
+        silentPushDeliveryRatio: { value: 5, total: 6, ratio: 0.833 },
+        locklessMissRatio: { value: 0, total: 147, ratio: 0 },
+        boardableMissRatio: { value: 0, total: 0, ratio: 0 },
+        accelPatternHitRatio: {
+          automotive: { count: 4, ratio: 0.33 },
+          walking: { count: 2, ratio: 0.17 },
+          stationary: { count: 0, ratio: 0 },
+          unknown: { count: 6, ratio: 0.5 },
+        },
+        silentPushLatency: { p50: 120, p95: 400, totalSamples: 9 },
+        laPushDeliveryRatio: { sent: 10, failed: 2, ratio: 10 / 12 },
+        silentPushReachRatio: { sent: 7, received: 5, joined: 5, ratio: 5 / 7 },
+        algorithmAccuracyRatio: { value: 8, total: 10, ratio: 0.8, answeredTotal: 12 },
+        locklessTripMissRatio: { miss: 0, fired: 2, paradigmIntent: 0, ratio: 0 },
+        window: '24h',
+        timestamp: 1_700_000_000_000,
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => metrics,
+      }) as unknown as typeof fetch;
+      const originalToken = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      const originalUrl = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'test-token';
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
+      await fetchObservabilityMetrics();
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = originalToken;
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = originalUrl;
+
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
+        }),
+      );
+      expect(result).toContain('locklessMiss=0% (0/147)');
+      expect(result).toContain('boardableMiss=0% (0/0)');
+      expect(result).toContain('accelPattern: automotive 33%(4) walking 17%(2) stationary 0%(0) unknown 50%(6)');
+      expect(result).toContain('silentPushLatency=p50=120ms p95=400ms n=9');
+      expect(result).toContain('laPushDelivery=83% (10/12)');
+      expect(result).toContain('silentPushReach(backend)=71% (5/7)');
+      expect(result).toContain('algorithmAccuracy=80% (8/10)');
+      expect(result).toContain('locklessTripMiss(paradigm=0)=0% (0/2)');
+      expect(result.some((line) => line.startsWith('as of '))).toBe(true);
+    });
+
+    it('구버전 backend(optional metric 필드 미응답) 시 no data 라인으로 graceful', async () => {
+      const metrics: ObservabilityMetrics = {
+        accuracyRatio: { value: 0, total: 0, ratio: 0 },
+        silentPushDeliveryRatio: { value: 0, total: 0, ratio: 0 },
+        locklessMissRatio: { value: 0, total: 0, ratio: 0 },
+        boardableMissRatio: { value: 0, total: 0, ratio: 0 },
+        accelPatternHitRatio: {
+          automotive: { count: 0, ratio: 0 },
+          walking: { count: 0, ratio: 0 },
+          stationary: { count: 0, ratio: 0 },
+          unknown: { count: 0, ratio: 0 },
+        },
+        laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
+        window: '24h',
+        timestamp: 1_700_000_000_000,
+        // silentPushLatency / silentPushReachRatio / algorithmAccuracyRatio /
+        // locklessTripMissRatio 모두 미응답 (구버전 backend).
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => metrics,
+      }) as unknown as typeof fetch;
+      const originalToken = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      const originalUrl = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'test-token';
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
+      await fetchObservabilityMetrics();
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = originalToken;
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = originalUrl;
+
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
+        }),
+      );
+      expect(result).toContain('silentPushLatency=no data');
+      expect(result).toContain('silentPushReach(backend)=no data');
+      expect(result).toContain('algorithmAccuracy=no data');
+      expect(result).toContain('locklessTripMiss=no data');
     });
 
     it('alarmAccuracy(local) 3/5 반영 — 사용자 정답지 응답 반영', () => {

--- a/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
+++ b/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
@@ -12,6 +12,7 @@
  */
 import {
   fetchObservabilityMetrics,
+  getLastObservabilityMetricsSnapshot,
   __test__,
   type ObservabilityMetrics,
 } from '../observabilityMetricsClient';
@@ -22,6 +23,7 @@ beforeEach(() => {
   process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'test-token';
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
   global.fetch = jest.fn() as unknown as typeof fetch;
+  __test__.resetLastMetricsSnapshot();
 });
 
 afterEach(() => {
@@ -227,6 +229,39 @@ describe('fetchObservabilityMetrics', () => {
       if (result.kind === 'error') {
         expect(typeof result.message).toBe('string');
       }
+    });
+  });
+
+  describe('getLastObservabilityMetricsSnapshot', () => {
+    it('returns null before any fetch', () => {
+      expect(getLastObservabilityMetricsSnapshot()).toBeNull();
+    });
+
+    it('caches the ok result with a fetchedAtMs timestamp', async () => {
+      mockFetchOk(makeMetrics());
+      const before = Date.now();
+      await fetchObservabilityMetrics();
+      const snapshot = getLastObservabilityMetricsSnapshot();
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.result.kind).toBe('ok');
+      expect(snapshot?.fetchedAtMs).toBeGreaterThanOrEqual(before);
+    });
+
+    it('caches error/unconfigured results too', async () => {
+      mockFetchStatus(500);
+      await fetchObservabilityMetrics();
+      const snapshot = getLastObservabilityMetricsSnapshot();
+      expect(snapshot?.result.kind).toBe('error');
+    });
+
+    it('overwrites the previous snapshot on subsequent fetch', async () => {
+      mockFetchStatus(500);
+      await fetchObservabilityMetrics();
+      expect(getLastObservabilityMetricsSnapshot()?.result.kind).toBe('error');
+
+      mockFetchOk(makeMetrics());
+      await fetchObservabilityMetrics();
+      expect(getLastObservabilityMetricsSnapshot()?.result.kind).toBe('ok');
     });
   });
 

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -109,6 +109,27 @@ export type FetchMetricsResult =
   | { kind: 'error'; message: string }
   | { kind: 'unconfigured' };
 
+/**
+ * 마지막 `fetchObservabilityMetrics()` 호출 결과 + 조회 시각 snapshot.
+ * DebugModal share dump(#N)가 async poll 결과를 dump 시점에 sync로 읽기 위한 캐시 —
+ * `OperationDashboardSection`이 마운트 시 이미 이 함수를 호출하므로 별도 polling 없이
+ * side-effect로 채워진다.
+ */
+interface MetricsSnapshot {
+  result: FetchMetricsResult;
+  fetchedAtMs: number;
+}
+
+let lastMetricsSnapshot: MetricsSnapshot | null = null;
+
+/**
+ * 마지막 `fetchObservabilityMetrics()` 결과를 sync로 읽는다.
+ * 한 번도 fetch가 완료되지 않았으면 null.
+ */
+export function getLastObservabilityMetricsSnapshot(): MetricsSnapshot | null {
+  return lastMetricsSnapshot;
+}
+
 /** ADMIN_TOKEN 환경변수 조회. 미설정 시 null. */
 function getAdminToken(): string | null {
   const token = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
@@ -125,6 +146,12 @@ function getAdminToken(): string | null {
  * - 성공 → `{ kind: 'ok', metrics }`
  */
 export async function fetchObservabilityMetrics(): Promise<FetchMetricsResult> {
+  const result = await fetchObservabilityMetricsUncached();
+  lastMetricsSnapshot = { result, fetchedAtMs: Date.now() };
+  return result;
+}
+
+async function fetchObservabilityMetricsUncached(): Promise<FetchMetricsResult> {
   const token = getAdminToken();
   if (!token) return { kind: 'unconfigured' };
 
@@ -153,4 +180,8 @@ export async function fetchObservabilityMetrics(): Promise<FetchMetricsResult> {
 // Internal exports for tests — DO NOT use from app code.
 export const __test__ = {
   getAdminToken,
+  /** 테스트 간 module-level snapshot 오염 방지용 리셋. */
+  resetLastMetricsSnapshot(): void {
+    lastMetricsSnapshot = null;
+  },
 };


### PR DESCRIPTION
## Summary

- `observabilityMetricsClient`에 마지막 poll 결과를 sync로 읽는 `getLastObservabilityMetricsSnapshot()` 캐시 getter 추가. `OperationDashboardSection`이 마운트 시 이미 호출하는 `fetchObservabilityMetrics()`가 이 module-level snapshot을 채우는 side-effect로 동작 — 별도 polling 추가 없음.
- `buildOperationDashboardSection`(텍스트 share dump)이 backend 8종 지표(locklessMiss/boardableMiss/accelPattern/silentPushLatency/laPushDelivery/silentPushReach(backend)/algorithmAccuracy/locklessTripMiss)를 Modal UI와 동일 SSOT(backend 응답 필드)로 텍스트에 출력하도록 변경. 기존 `(backend metrics: ... see Modal UI, not dumped)` 안내 문구를 대체.
- poll 전(`(no backend poll yet)`) / 실패(`(backend poll failed: <reason>)`) graceful 처리, 성공 시 `as of <조회시각>`으로 staleness 명시(과거 sync 우려를 해소하는 대신 "마지막 poll 시각"임을 명시).
- accelPattern 분포는 `Object.entries` 순회로 포맷 — 분포 key가 늘어도 코드 변경 불필요(하드코딩 배열 없음).

Closes #2416

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass (No orphan exports detected).
2. **V/X dashboard** — `getLastObservabilityMetricsSnapshot`의 값은 DebugModal share dump(텍스트, `## Operation Dashboard` 섹션)에서 관측 가능. 기존 Modal UI(`OperationDashboardSection`)와 동일 데이터 소스(backend 응답 필드)를 재사용하므로 UI/dump 정합성은 소스 레벨에서 보장.
3. **의존 PR** — N/A (device-local 캐시 getter 추가만, backend/타 PR 의존 없음).
4. **측정 plan** — DebugModal을 열어 Refresh 후 Share 눌러 텍스트 dump를 확인, `## Operation Dashboard` 섹션에 backend metric 8종 + `as of` 라인이 포함되는지 확인. ADMIN_TOKEN 미설정 환경에서는 `(backend poll failed: unconfigured)`가 노출되는지 확인.
5. **Device verify** — 필요. 코드는 type-check/jest로만 검증했고, 실기기(또는 시뮬레이터)에서 DebugModal → Refresh → Share 눌러 텍스트 dump에 backend 지표 값이 실제로 뜨는지 확인 필요.

## Test plan

- [x] `npx jest src/features/debug/components/__tests__/DebugModal.test.tsx` — 438 passed
- [x] `npx jest src/features/observability/api/__tests__/observabilityMetricsClient.test.ts` — 22 passed
- [x] 위 두 파일 대상 `--coverage` — DebugModal.tsx / observabilityMetricsClient.ts 모두 100% (statements/branch/functions/lines)
- [x] `npx tsc --noEmit -p .` — 통과
- [x] `npm run lint:orphan` — 통과
- [ ] 실기기: DebugModal → Refresh → Share → 텍스트 dump에 backend 지표 노출 확인 (사용자 검증 필요)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9