### PR TITLE
perf(#2418): 정지+유휴 fusion pipeline backoff — candidate/train-position 발열 차단

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.stationaryBackoff.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.stationaryBackoff.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
+ * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인 처리. 후속 PR(별도 이슈)에서 orchestration 슬라이스(예: features/fusion/, app shell)로
+ * 추출하여 disable을 제거할 예정.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2418 (perf) — 정지+유휴 fusion backoff 회귀 가드.
+ *
+ * 정지(motionStationary===true OR gps speed < STATIC_SPEED_THRESHOLD_MPS) && lockless(lock 없음)
+ * && route 없음(trip 비활성)일 때 candidate enumeration(findTopNearestStations)과
+ * train-position poll(useTrainPositions 대상 line)이 skip되는지, 그리고 움직임 재개 /
+ * lock·route 활성 시 backoff가 절대 적용되지 않는지를 검증한다.
+ */
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../useAccelerometerFingerprint', () => ({
+  useAccelerometerFingerprint: jest.fn(() => 'automotive'),
+}));
+jest.mock('../useCellularTech', () => ({
+  useCellularTech: jest.fn(() => 'surface'),
+}));
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../../../observability/utils/rawSignalBuffer', () => ({
+  pushRawSignal: jest.fn(),
+}));
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: jest.fn(() => null),
+}));
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+function gpsBase(speedMps: number | null, userLocation = { lat: 37.5, lng: 127.0 }) {
+  const live = { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 };
+  return {
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [MOCK_STATIONS.gangnam],
+    userLocation,
+    speedMps,
+    accuracyMeters: 50,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    locationUncertain: false,
+    refresh: jest.fn(),
+  };
+}
+
+const lockFixture: BoardingLock = {
+  destinationId: 'dest-2',
+  trainCode: 'T-1',
+  boardingLine: '2',
+  boardingStationId: MOCK_STATIONS.gangnam.id,
+  boardedAt: Date.now(),
+  expectedDurationMs: 10 * 60_000,
+};
+
+describe('useFusedNearestStation — #2418 정지 backoff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+    mockUseArrival.mockReturnValue({ arrival: null, loading: false, isMock: false });
+    mockUsePositions.mockReturnValue({ positions: null, loading: false, isMock: false });
+  });
+
+  it('정지(speed=0) + lockless + route 없음 → candidate enumeration/train-position poll skip', () => {
+    mockUseNearest.mockReturnValue(gpsBase(2));
+    const { rerender } = renderHook(
+      ({ speed }: { speed: number }) =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, undefined),
+      { initialProps: { speed: 2 } },
+    );
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    // 정지 상태로 전환 — userLocation 참조도 매 tick 바뀐다고 가정(GPS jitter)해도 skip 유지.
+    mockUseNearest.mockReturnValue(gpsBase(0, { lat: 37.50001, lng: 127.00001 }));
+    rerender({ speed: 0 });
+    rerender({ speed: 0 });
+
+    // backoff 활성 이후엔 findTopNearestStations가 더 이상 호출되지 않아야 한다(직전 결과 재사용).
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    // useTrainPositions 최근 호출들은 line=null(폴링 비활성)이어야 한다.
+    const recentPositionCalls = mockUsePositions.mock.calls.slice(-3);
+    for (const call of recentPositionCalls) {
+      expect(call[0]).toBeNull();
+    }
+  });
+
+  it('motionStationary===true 단독으로도 backoff 적용 (speed=null)', () => {
+    mockUseNearest.mockReturnValue(gpsBase(null));
+    const { rerender } = renderHook(
+      ({ motion }: { motion: boolean | undefined }) =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, motion),
+      { initialProps: { motion: false } },
+    );
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    rerender({ motion: true });
+    rerender({ motion: true });
+
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+    const recentPositionCalls = mockUsePositions.mock.calls.slice(-3);
+    for (const call of recentPositionCalls) {
+      expect(call[0]).toBeNull();
+    }
+  });
+
+  it('이동 재개(speed 상승) 시 다음 렌더에서 즉시 정상 주기로 복귀', () => {
+    // 1) 이동 중 — 정상 baseline.
+    mockUseNearest.mockReturnValue(gpsBase(2));
+    const { rerender } = renderHook(
+      ({ speed }: { speed: number }) =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, undefined),
+      { initialProps: { speed: 2 } },
+    );
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    // 2) 정지 전환 — backoff 활성, 재계산 skip (userLocation 참조가 바뀌어도).
+    mockUseNearest.mockReturnValue(gpsBase(0, { lat: 37.50002, lng: 127.00002 }));
+    rerender({ speed: 0 });
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    // 3) 이동 재개 — 지연 없이 즉시 재계산 + train-position poll 재개.
+    mockUseNearest.mockReturnValue(gpsBase(5, { lat: 37.50003, lng: 127.00003 }));
+    rerender({ speed: 5 });
+    expect(mockFindTop).toHaveBeenCalledTimes(2);
+
+    const recentPositionCalls = mockUsePositions.mock.calls.slice(-3);
+    expect(recentPositionCalls.some((call) => call[0] === MOCK_STATIONS.gangnam.line)).toBe(true);
+  });
+
+  it('boardingLock 활성 trip은 정지 상태여도 backoff 미적용(정확도 우선)', () => {
+    mockUseNearest.mockReturnValue(gpsBase(0));
+    const { rerender } = renderHook(
+      () => useFusedNearestStation(undefined, undefined, undefined, null, lockFixture, true),
+      { initialProps: {} },
+    );
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    // userLocation을 매 렌더 바꿔 lock 활성 중엔 backoff 없이 매번 재계산됨을 확인.
+    mockUseNearest.mockReturnValue(gpsBase(0, { lat: 37.50004, lng: 127.00004 }));
+    rerender({});
+    mockUseNearest.mockReturnValue(gpsBase(0, { lat: 37.50005, lng: 127.00005 }));
+    rerender({});
+
+    // lock 활성이면 매 렌더 재계산 — backoff 미적용.
+    expect(mockFindTop).toHaveBeenCalledTimes(3);
+    const recentPositionCalls = mockUsePositions.mock.calls.slice(-3);
+    expect(recentPositionCalls.some((call) => call[0] === MOCK_STATIONS.gangnam.line)).toBe(true);
+  });
+
+  it('이동 중(speed=2)에는 매 렌더 정상 재계산 — backoff 미적용', () => {
+    mockUseNearest.mockReturnValue(gpsBase(2));
+    const { rerender } = renderHook(
+      () => useFusedNearestStation(undefined, undefined, undefined, null, null, false),
+      { initialProps: {} },
+    );
+    expect(mockFindTop).toHaveBeenCalledTimes(1);
+
+    mockUseNearest.mockReturnValue(gpsBase(3, { lat: 37.50006, lng: 127.00006 }));
+    rerender({});
+    mockUseNearest.mockReturnValue(gpsBase(3, { lat: 37.50007, lng: 127.00007 }));
+    rerender({});
+
+    expect(mockFindTop).toHaveBeenCalledTimes(3);
+    const recentPositionCalls = mockUsePositions.mock.calls.slice(-3);
+    expect(recentPositionCalls.some((call) => call[0] === MOCK_STATIONS.gangnam.line)).toBe(true);
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -36,7 +36,7 @@ import { BAROMETER_RECENT_SUBSURFACE_STICKY_WINDOW_MS } from '../../../shared/co
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../../route/utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
-import { shouldDowngradeFusion } from '../utils/movementGate';
+import { shouldDowngradeFusion, STATIC_SPEED_THRESHOLD_MPS } from '../utils/movementGate';
 import { isStrongFusionSource } from '../../../shared/constants/fusionSourceStrength';
 import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
@@ -628,17 +628,36 @@ export function useFusedNearestStation(
     [routeContext?.route],
   );
 
-  // GPS 좌표 → 거리순 후보 N개. 좌표 갱신 시에만 재계산.
+  // #2418 (perf) — 정지+유휴 backoff. movementGate(evaluateMovement)가 이미 계산하는 동일 정적 신호
+  // (motionStationary===true OR gps speed < STATIC_SPEED_THRESHOLD_MPS)를 재사용해, lockless(잠금
+  // 없음) && route 없음(trip 비활성)일 때 candidate enumeration/train-position poll을 skip한다.
+  // suppression(evaluateMovement/useStationAlarm)은 "발사"만 막고 "연산"은 막지 않아 정지 상태(주차/
+  // 실내/취침)에도 GPS·CPU가 계속 도는 발열 root — lock/route/trip 활성이면 정확도 우선으로 미적용.
+  // 이동 재개(speed 상승 또는 motion 비정지) 시 다음 렌더에서 즉시 정상 주기로 복귀한다(지연 금지 —
+  // 탑승 순간을 놓치면 안 됨).
+  const isStationaryForBackoff =
+    motionStationary === true ||
+    (gps.speedMps != null && gps.speedMps < STATIC_SPEED_THRESHOLD_MPS);
+  const stationaryBackoffActive = isStationaryForBackoff && !tripActive && boardingLock == null;
+
+  // 직전 candidate enumeration 결과. backoff 활성 중엔 재계산 없이 이 값을 재사용해 참조를
+  // 고정 — 하류(activeLines/[candidates,environment] effect)의 불필요 재실행도 함께 차단한다.
+  const lastCandidatesRef = useRef<NearestStationResult[]>([]);
+
+  // GPS 좌표 → 거리순 후보 N개. 좌표 갱신 시에만 재계산 (정지 backoff 시엔 skip).
   const candidates = useMemo<NearestStationResult[]>(() => {
+    if (stationaryBackoffActive) return lastCandidatesRef.current;
     if (!gps.userLocation) return [];
-    return findTopNearestStations(
+    const next = findTopNearestStations(
       gps.userLocation.lat,
       gps.userLocation.lng,
       FUSION_CANDIDATE_LIMIT,
       MAX_STATION_DISTANCE_KM,
       allowedLines,
     );
-  }, [gps.userLocation, allowedLines]);
+    lastCandidatesRef.current = next;
+    return next;
+  }, [gps.userLocation, allowedLines, stationaryBackoffActive]);
 
   // arrival 폴링: 후보 역명 단위 K=3 고정.
   // 각 후보의 호선을 lineHint로 함께 전달해 schedule fallback이 환승역에서 정확한
@@ -656,9 +675,11 @@ export function useFusedNearestStation(
   // position 폴링: 후보 역들의 호선만 dedup 후 K=3 고정 슬롯.
   // (대부분 1~2개 호선이지만 환승 인근에서 3개까지 가능)
   const activeLines = useMemo(() => findActiveLines(candidates), [candidates]);
-  const l0 = activeLines[0] ?? null;
-  const l1 = activeLines[1] ?? null;
-  const l2 = activeLines[2] ?? null;
+  // #2418 (perf) — 정지 backoff 중엔 line을 null로 넘겨 useTrainPositions 폴링 자체를 비활성화
+  // (useTrainPositions는 line=null이면 network poll을 skip하는 기존 계약을 그대로 사용).
+  const l0 = stationaryBackoffActive ? null : activeLines[0] ?? null;
+  const l1 = stationaryBackoffActive ? null : activeLines[1] ?? null;
+  const l2 = stationaryBackoffActive ? null : activeLines[2] ?? null;
   const p0 = useTrainPositions(l0, positionProvider);
   const p1 = useTrainPositions(l1, positionProvider);
   const p2 = useTrainPositions(l2, positionProvider);


### PR DESCRIPTION
## Summary

정지 상태(주차/실내/취침)에도 useFusedNearestStation의 candidate enumeration + train-position poll이 movement 무관하게 매 tick 실행돼 발열 유발하던 문제 수정. movementGate의 정적 신호(motionStationary/gps.speedMps)를 재사용해 lockless(잠금 없음) && route 없음(trip 비활성)일 때만 무거운 연산을 skip한다.

Closes #2418

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass (로컬 확인). 신규 export 없음(내부 로직 변경만).
- [x] **2. V/X dashboard** — 별도 신규 관측 신호 없음. 기존 candidateRejectBuffer/DebugModal 지표가 backoff 중 감소하는 것으로 간접 관측 가능(호출 빈도 감소).
- [x] **3. 의존 PR** — N/A.
- [x] **4. 측정 plan** — 실기기에서 정지 상태(화면 켜둔 채 5분+) 기기 온도/CPU 사용률 비교, DebugModal candidateRejectBuffer 항목 수 변화(정지 구간 감소 기대).
- [ ] **5. Device verify** — 필요. 시나리오: (a) 실내 정지 상태로 5분+ 방치 후 발열/배터리 체감 비교, (b) 정지→도보 이동 전환 시 nearest station이 지연 없이 갱신되는지, (c) lock/route 활성 trip 중 정지해도 기존 정확도가 유지되는지.

### V/X dashboard URL

DebugModal candidateRejectBuffer 섹션 — backoff 활성 구간에서 push 빈도 감소로 간접 확인.

### 의존 PR

N/A

---

## 계약 변경 체크리스트

N/A — push kind 변경 없음.

---

## 변경 내용

- `src/features/nearest-station/hooks/useFusedNearestStation.ts`
  - `stationaryBackoffActive` 계산: `(motionStationary===true OR gps.speedMps < STATIC_SPEED_THRESHOLD_MPS)` (movementGate 기존 상수 재사용, 신규 매직넘버 없음) `&& !tripActive && boardingLock == null`
  - candidate enumeration(`findTopNearestStations`): backoff 활성 시 직전 결과(`lastCandidatesRef`) 재사용, 재계산 skip — 참조 고정으로 하류 `[candidates, environment]` effect 재실행도 자연 감소
  - train-position poll(`useTrainPositions` l0/l1/l2): backoff 활성 시 line을 null로 전달해 기존 "line=null이면 비활성" 계약으로 network poll 차단
  - lock/route/trip 활성이면 조건에서 자동 제외 — 정확도 영향 없음
  - 이동 재개(speed↑ 또는 motion 비정지) 시 다음 렌더에서 즉시 정상 주기 복귀(지연 로직 없음)

## Test plan

- [x] `npx jest src/features/nearest-station/hooks/__tests__/useFusedNearestStation*` — 442 passed (기존 21개 파일 + 신규 1개), 회귀 없음
- [x] `npx tsc --noEmit` pass
- [x] `npm run lint:orphan` pass
- [x] `npx eslint` 변경 파일 pass
- [x] 신규 커버리지 99.8%/99.65%/100%/99.78% (미커버 라인 560은 본 PR과 무관한 기존 코드)
- [ ] 실기기 발열/배터리 체감 검증 (Device verify 항목 참고)

### 신규 테스트 (`useFusedNearestStation.stationaryBackoff.test.ts`, 5 케이스)

1. 정지(speed=0) + lockless + route 없음 → candidate enumeration/train-position poll skip
2. motionStationary===true 단독(speed=null)으로도 backoff 적용
3. 이동 재개(speed 상승) 시 다음 렌더에서 즉시 정상 주기로 복귀(지연 없음)
4. boardingLock 활성 trip은 정지 상태여도 backoff 미적용(정확도 우선)
5. 이동 중(speed=2)에는 매 렌더 정상 재계산 — backoff 미적용

## 제약 확인

- cap/overshoot/estimator 로직 무변경 (#2415/#898 무관)
- 하드코딩 신규 상수 없음 — 기존 `STATIC_SPEED_THRESHOLD_MPS`(movementGate.ts) 재사용

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9