### PR TITLE
fix(#2419): backend-confirmed trip-ended cleanup에서 in-memory destination reset

### DIFF
--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -9,6 +9,8 @@ import {
   runLaunchTripReconciliation,
   useLaunchTripReconciliation,
 } from '../useLaunchTripReconciliation';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
 
 const mockFetchTripStatus = jest.fn();
 jest.mock('../../api/tripStatus', () => ({
@@ -107,6 +109,13 @@ beforeEach(async () => {
   // #2114 (방안 C′) — 기본은 null(corrId sync cache 미수화 → timestamp fallback). 각 test가 필요 시 override.
   mockGetCurrentTripCorrIdSync.mockReturnValue(null);
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+  // #2419 — Signal 4 self-end가 in-memory destination을 실제로 clear하는지 검증하려면
+  // 매 test가 "stale destination이 남아있는 상태"에서 출발해야 한다.
+  useDestinationStore.setState({
+    destination: MOCK_STATIONS.gangnam,
+    customOrigin: MOCK_STATIONS.chungmuro,
+    tripOrigin: MOCK_STATIONS.hyochang,
+  });
 });
 
 afterEach(() => {
@@ -204,6 +213,13 @@ describe('runLaunchTripReconciliation', () => {
     expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
     expect(mockSetSentinel).toHaveBeenCalledWith(1_700_000_000_000, null);
     expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+    // #2419 — status='ended'는 cleanupBackendConfirmedEndedTrip을 경유하며, 그 함수가
+    // in-memory destination/customOrigin/tripOrigin을 reset한다. 이게 없으면 stale
+    // destination이 남아 lockless trip이 유령 재시작된다.
+    const state = useDestinationStore.getState();
+    expect(state.destination).toBeNull();
+    expect(state.customOrigin).toBeNull();
+    expect(state.tripOrigin).toBeNull();
   });
 
   it('status ended — 호출 순서: triggerTripEndRecall → runTripBoundCleanups → setTripEndedSentinel → removeItem(ACTIVE_TRIP_KEY)', async () => {
@@ -266,6 +282,8 @@ describe('runLaunchTripReconciliation', () => {
     expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
     expect(mockSetSentinel).not.toHaveBeenCalled();
     expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBe('tk');
+    // #2419 — trip이 여전히 active면 destination은 건드리면 안 된다 (회귀 방어).
+    expect(useDestinationStore.getState().destination).not.toBeNull();
   });
 
   it('404/410 (null) → active trip clear만, cleanup/recall X (기존 동작 유지)', async () => {
@@ -338,6 +356,12 @@ describe('runLaunchTripReconciliation', () => {
       expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledTimes(1);
       expect(mockSetSentinel).toHaveBeenCalledWith(now, null);
       expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+      // #2419 — Signal 4 self-end 분기는 runTripBoundCleanups만으로는 in-memory destination이
+      // stale로 남는다 — 명시적 reset이 없으면 lockless trip이 유령 재시작된다.
+      const state = useDestinationStore.getState();
+      expect(state.destination).toBeNull();
+      expect(state.customOrigin).toBeNull();
+      expect(state.tripOrigin).toBeNull();
     });
 
     it('self-end 시 호출 순서: recall → cleanup → prompt → sentinel → active clear', async () => {

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -64,6 +64,7 @@ import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { logCrossTripMirrorSkip } from '../utils/alarmLog';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useLaunchTripReconciliation');
@@ -168,6 +169,11 @@ export async function runLaunchTripReconciliation(): Promise<void> {
       const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
       await runTripBoundCleanups();
       await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+      // #2419 — in-memory destination/customOrigin/tripOrigin reset. runTripBoundCleanups는
+      // storage만 정리하므로 이게 없으면 stale destination이 메모리에 남아 lockless trip이
+      // 유령 재시작된다. status='ended' 분기는 cleanupBackendConfirmedEndedTrip을 경유해
+      // 동일하게 처리됨 (tripEndedCleanupSequence.ts 헤더 주석).
+      useDestinationStore.setState({ destination: null, customOrigin: null, tripOrigin: null });
       // #2114 (방안 C′) — sentinel에 corrId 동봉.
       await setTripEndedSentinel(now, endedCorrIdSnapshot);
       await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);

--- a/src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts
+++ b/src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts
@@ -1,6 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
 import { cleanupBackendConfirmedEndedTrip } from '../tripEndedCleanupSequence';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
 
 const mockTriggerTripEndRecall = jest.fn();
 jest.mock('../triggerTripEndRecall', () => ({
@@ -32,6 +34,41 @@ describe('cleanupBackendConfirmedEndedTrip', () => {
     jest.clearAllMocks();
     mockGetCurrentTripCorrIdSync.mockReturnValue(null);
     await AsyncStorage.clear();
+    useDestinationStore.setState({
+      destination: MOCK_STATIONS.gangnam,
+      customOrigin: MOCK_STATIONS.chungmuro,
+      tripOrigin: MOCK_STATIONS.hyochang,
+    });
+  });
+
+  // #2419 — runTripBoundCleanups는 storage(DESTINATION_KEY)만 정리하고 in-memory
+  // useDestinationStore.destination은 stale로 남는다. cleanupBackendConfirmedEndedTrip은
+  // backend가 명시적으로 trip 종료를 확정한 경우에만 호출되므로(caller 계약, 헤더 주석)
+  // 뒤이어 새 destination이 set될 일이 없다 — 여기서 memory를 직접 reset해야 stale
+  // destination이 lockless trip을 유령 재시작시키는 회귀(#2419)를 막는다.
+  it('in-memory destination/customOrigin/tripOrigin을 null로 reset', async () => {
+    await cleanupBackendConfirmedEndedTrip(1_700_000_000_000);
+
+    const state = useDestinationStore.getState();
+    expect(state.destination).toBeNull();
+    expect(state.customOrigin).toBeNull();
+    expect(state.tripOrigin).toBeNull();
+  });
+
+  it('destination reset은 prompt 이후, sentinel 이전에 발생 (cleanup 순서 유지)', async () => {
+    mockTriggerTripGroundTruthPrompt.mockImplementation(async () => {
+      // prompt가 아직 실행 중인 시점에는 destination이 아직 살아있어야 한다.
+      expect(useDestinationStore.getState().destination).not.toBeNull();
+    });
+    mockSetTripEndedSentinel.mockImplementation(async () => {
+      // sentinel 기록 시점에는 이미 destination이 reset되어 있어야 한다.
+      expect(useDestinationStore.getState().destination).toBeNull();
+    });
+
+    await cleanupBackendConfirmedEndedTrip(1_700_000_000_000);
+
+    expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalled();
+    expect(mockSetTripEndedSentinel).toHaveBeenCalled();
   });
 
   it('5단 시퀀스를 순서대로 호출: recall → cleanup → prompt → sentinel → active trip clear', async () => {

--- a/src/features/alarm/utils/tripEndedCleanupSequence.ts
+++ b/src/features/alarm/utils/tripEndedCleanupSequence.ts
@@ -15,15 +15,26 @@
  * 중복 구현하지 않고 여기를 재사용한다.
  *
  * 호출 순서 고정: triggerTripEndRecall → runTripBoundCleanups → triggerTripGroundTruthPrompt →
- * setTripEndedSentinel → removeItem(ACTIVE_TRIP_KEY). recall이 cleanup보다 먼저여야 한다 —
- * cleanup이 ROUTE_KEY/DESTINATION_KEY/TRIP_ORIGIN_KEY/TRIP_STARTED_AT_KEY를 제거하므로 그 뒤에
- * recall이 돌면 입력이 비어 'empty'/'no-trip-start'로 skip된다.
+ * destination store reset → setTripEndedSentinel → removeItem(ACTIVE_TRIP_KEY). recall이
+ * cleanup보다 먼저여야 한다 — cleanup이 ROUTE_KEY/DESTINATION_KEY/TRIP_ORIGIN_KEY/
+ * TRIP_STARTED_AT_KEY를 제거하므로 그 뒤에 recall이 돌면 입력이 비어 'empty'/'no-trip-start'로
+ * skip된다.
  *
  * 멱등: setTripEndedSentinel + removeItem(ACTIVE_TRIP_KEY) 자체가 멱등이라 silent push
  * trip-ended handler / launch reconciliation과 중복 호출돼도 안전.
  *
  * caller는 backend가 명시적으로 `status: 'ended'`를 반환한 경우에만 이 함수를 호출해야 한다 —
  * 404/410(trip 부재)은 death 확정이 아니다(ADR-010, false positive는 miss와 동급).
+ *
+ * #2419 — `runTripBoundCleanups`가 호출하는 `clearTripBoundStoreMemory`는 AsyncStorage의
+ * DESTINATION_KEY만 제거하고 in-memory `useDestinationStore.destination`은 건드리지 않는다
+ * (그 함수는 `setDestination(newStation)`으로 목적지를 전환하는 정상 플로우에서도 호출되므로
+ * 거기서 무조건 destination을 null로 지우면 방금 설정한 새 목적지가 지워지는 회귀가 생긴다 —
+ * 그래서 의도적으로 손대지 않는다). 이 함수는 backend가 trip 종료를 명시 확정한 경우에만
+ * 호출되고 뒤이어 새 destination이 set될 일이 없으므로, 여기서 memory를 직접 reset한다 —
+ * `useDeviceSelfEnd`(#2043) / `useStateRehydration`의 sentinel-reset 분기와 동형 패턴.
+ * 이게 없으면 backend-confirmed 종료 후에도 stale destination이 메모리에 남아
+ * `useFusedNearestStation`의 arcKey 판정이 lock 없는 유령 lockless trip을 재시작한다.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
@@ -32,6 +43,7 @@ import { triggerTripEndRecall } from './triggerTripEndRecall';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
 
 /**
  * backend-confirmed 'ended' trip을 device 상태에 반영한다.
@@ -45,6 +57,10 @@ export async function cleanupBackendConfirmedEndedTrip(endedAt: number): Promise
   await runTripBoundCleanups();
   // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
   await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+  // #2419 — in-memory destination/customOrigin/tripOrigin reset. runTripBoundCleanups는
+  // storage만 정리하므로 이게 없으면 stale destination이 메모리에 남아 lockless trip이
+  // 유령 재시작된다 (헤더 주석 참고).
+  useDestinationStore.setState({ destination: null, customOrigin: null, tripOrigin: null });
   // #2114 (방안 C′) — sentinel에 corrId 동봉.
   await setTripEndedSentinel(endedAt, endedCorrIdSnapshot);
   await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);


### PR DESCRIPTION
Closes #2419

## 요약

trip 종료 후 stale destination이 메모리에 안 지워져 lockless trip이 유령 재시작되는 회귀 수리.

**최초 가설(이슈 조사 요청 원문)은 기각**: `useDeviceSelfEnd.ts`가 `setDestination(null)`을 안 부른다는 가설이었으나, 코드 확인 결과 그 경로는 이미 (최초 커밋 #2043부터) `useDestinationStore.setState({destination: null, ...})`를 호출하고 있었다. `useStateRehydration.ts`의 sentinel-reset 분기 3곳도 동일하게 이미 처리 중.

**확정 root cause**: `tripEndedCleanupSequence.ts`의 `cleanupBackendConfirmedEndedTrip()` — backend가 명시적으로 `status:'ended'`를 반환했을 때 두 곳(`tripDeathPullBackstop.ts` pull backstop, `useLaunchTripReconciliation.ts` status='ended' 분기)이 공유하는 cleanup sequence — 는 `runTripBoundCleanups()`만 호출하고 **in-memory `useDestinationStore.destination`은 clear하지 않는다.** `runTripBoundCleanups`가 부르는 `clearTripBoundStoreMemory`는 storage의 `DESTINATION_KEY`만 지우고(+ customOrigin/boardingLock/alarmEvent/legAdvance 메모리는 clear) destination 자체는 대상에서 빠져 있다.

`useLaunchTripReconciliation.ts`의 Signal 4(backend-timeout self-end) 인라인 분기도 `cleanupBackendConfirmedEndedTrip`을 거치지 않고 동일 4단계를 직접 수행하며 마찬가지로 destination을 안 지운다.

이 두 지점에 `useDeviceSelfEnd`/`useStateRehydration`과 동형 패턴(`useDestinationStore.setState({destination: null, customOrigin: null, tripOrigin: null})`)을 추가.

## 왜 공유 `clearTripBoundStoreMemory`에는 손대지 않았나

`useDestinationStore.setDestination(newStation)`의 isSwitch(목적지 전환) 경로도 `runTripBoundCleanups()`를 호출한다. 이 경로는 이미 `set({destination: station})`으로 **새 목적지를 메모리에 써놓은 뒤** fire-and-forget으로 cleanup chain을 태우므로, 공유 함수에서 무조건 `destination: null`을 넣으면 방금 설정한 새 목적지가 비동기로 다시 지워지는 회귀가 생긴다. 그래서 "trip 종료가 확정되고 후속 destination이 없음"이 코드상 보장되는 두 지점(`cleanupBackendConfirmedEndedTrip`, Signal 4 분기)에만 국소 적용했다.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 기존 함수 내부 수정).
2. **V/X dashboard** — DebugModal breadcrumb(`addDomainBreadcrumb`)은 기존 sentinel-reset 분기(useStateRehydration)에 이미 있고 이번 변경은 동일 store 조작이라 별도 관측 채널 불필요. 회귀 여부는 새 unit test(destination null 검증)로 확정.
3. **의존 PR** — N/A. backend 변경 불필요, device-only fix.
4. **측정 plan** — 다음 device dump에서 backend `status:'ended'` push/pull 확인 후 `useDestinationStore`가 곧바로 null인지, lockless 유령 trip 재시작 로그가 사라졌는지 확인.
5. **Device verify** — 실기기 재현 필요(backend-confirmed trip end 시나리오, 특히 BG에서). N/A는 아님 — 이 PR은 코드-only + unit이지만 실제 trip 종료 chain은 device verify 권장. 사용자 판단.

## 테스트

- `src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts` — destination/customOrigin/tripOrigin reset 검증 + cleanup 순서(prompt 이후, sentinel 이전) 검증 2건 추가.
- `src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts` — status='ended' 분기 + Signal 4 분기 각각 destination reset 검증 추가, status='active'(trip 살아있음) 분기는 destination이 안 건드려짐을 회귀 방어로 검증.
- `npx jest` 관련 파일만 실행: 33 + 142(연관 스위트) 전부 pass.
- `npm run type-check` clean.
- `npm run lint:orphan` clean.

## 제약사항

- 전체 `npm test` (커버리지 100% 게이트)는 미실행 — 관련 파일만 검증 지시에 따름.
- 머지는 사용자 판단.