### PR TITLE
feat(#2422): boarding prompt device FG 로컬 단일권위 — backend remote push SPOF 제거

### DIFF
--- a/src/features/alarm/__tests__/localBoardingPromptWholeWire.test.ts
+++ b/src/features/alarm/__tests__/localBoardingPromptWholeWire.test.ts
@@ -1,0 +1,159 @@
+/**
+ * #2422 (E — 회귀 fixture) — "boardable 상태 ⇒ boarding-prompt fired" whole-chain 검증.
+ *
+ * lesson_ci_tests_parts_not_wire(2026-08-28): unit 테스트가 내부 함수를 mock으로 격리하면
+ * "게이트를 통과했다고 가정한 상태에서 발사 호출이 됐다"만 증명하고, 게이트 자체가 실제로
+ * 통과 가능한 입력을 만들어내는지는 검증하지 못한다 — CI green이어도 실제로는 안 뜰 수 있다.
+ *
+ * 이 fixture는 leaf(AsyncStorage, expo-notifications)만 mock하고 나머지는 실 모듈을 그대로
+ * 구동한다: `buildBoardingPromptContext`(boardingPromptContext.ts, 실 route/station 좌표 계산) →
+ * `evaluateLocalBoardingPromptGate`(localBoardingPromptGate.ts, 실 근접/방향/arrival 판정) →
+ * `fireLocalBoardingPromptNotification`(stationNotification.ts, 실 dedup ledger + i18n content
+ * 빌드) → `Notifications.scheduleNotificationAsync`가 BOARDING_PROMPT_CATEGORY + 실제 payload
+ * shape로 호출됨을 관측한다.
+ */
+
+const storage = new Map<string, string>();
+const mockGetItem = jest.fn((key: string) =>
+  Promise.resolve(storage.has(key) ? storage.get(key)! : null),
+);
+const mockSetItem = jest.fn((key: string, value: string) => {
+  storage.set(key, value);
+  return Promise.resolve();
+});
+const mockRemoveItem = jest.fn((key: string) => {
+  storage.delete(key);
+  return Promise.resolve();
+});
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: [string]) => mockGetItem(...args),
+  setItem: (...args: [string, string]) => mockSetItem(...args),
+  removeItem: (...args: [string]) => mockRemoveItem(...args),
+}));
+
+const mockScheduleNotificationAsync = jest.fn().mockResolvedValue('scheduled');
+const mockDismissNotificationAsync = jest.fn().mockResolvedValue(undefined);
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: (...args: unknown[]) => mockScheduleNotificationAsync(...args),
+  dismissNotificationAsync: (...args: unknown[]) => mockDismissNotificationAsync(...args),
+}));
+
+jest.mock('../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useLocalBoardingPromptGate } from '../hooks/useLocalBoardingPromptGate';
+import { getStationById } from '../../../shared/utils/stationRoute';
+import { makeDirectRoute } from '../../../testUtils/routeFixtures';
+import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import { BOARDING_PROMPT_CATEGORY } from '../utils/notificationCategory';
+import type { StationArrival } from '../../../shared/types/arrival';
+
+// 대화(3-001) → 정발산(3-003), 3호선 단조 구간. boardingPromptContext.test.ts 선례와 동일 fixture —
+// direction='down' 확정 케이스.
+const current = getStationById('3-001')!; // 대화
+const destination = getStationById('3-003')!; // 정발산
+const route = makeDirectRoute(2, '3');
+
+describe('#2422 whole-chain wire — boardable ⇒ local boarding-prompt fired', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage.clear();
+  });
+
+  const boardableArrival: StationArrival = {
+    up: [],
+    down: [
+      {
+        destination: '정발산',
+        arrivalMinutes: 2,
+        arrivalSeconds: 120,
+        statusMessage: '전역 출발',
+        trainCode: '3026001',
+        line: '3',
+        receivedAtMs: Date.now(),
+        arrivalCode: 3,
+        isLastTrain: false,
+        trainType: 'normal',
+      },
+    ],
+  };
+
+  it(
+    'GREEN — 근접 GPS fix + 같은 노선/방향 도착열차 존재(boardable) + trip 등록됨(ACTIVE_TRIP_KEY) ' +
+      '이면 실 체인이 BOARDING_PROMPT_CATEGORY 로컬 알림을 실제로 스케줄한다',
+    async () => {
+      storage.set(ACTIVE_TRIP_KEY, 'trip-2422-wire');
+
+      renderHook(() =>
+        useLocalBoardingPromptGate({
+          route,
+          currentStation: current,
+          destination,
+          lock: null,
+          gpsFix: { lat: current.lat, lng: current.lng, accuracyM: 10 },
+          arrival: boardableArrival,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      });
+
+      const [[call]] = mockScheduleNotificationAsync.mock.calls;
+      expect(call.content.categoryIdentifier).toBe(BOARDING_PROMPT_CATEGORY);
+      expect(call.content.data).toEqual({
+        kind: 'boarding-prompt',
+        originStation: current.name,
+        line: '3',
+        tripToken: 'trip-2422-wire',
+        destinationDirection: 'down',
+      });
+      expect(call.trigger).toBeNull();
+    },
+  );
+
+  it('RED 대조군 — ACTIVE_TRIP_KEY 미등록(backend register 전)이면 boardable해도 발사하지 않는다', async () => {
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation: current,
+        destination,
+        lock: null,
+        gpsFix: { lat: current.lat, lng: current.lng, accuracyM: 10 },
+        arrival: boardableArrival,
+      }),
+    );
+
+    // 발사 시도 자체는 일어나지만(ACTIVE_TRIP_KEY 조회까지 진행) 최종 스케줄 호출은 없어야 한다.
+    await waitFor(() => {
+      expect(mockGetItem).toHaveBeenCalledWith(ACTIVE_TRIP_KEY);
+    });
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('RED 대조군 — GPS fix가 근접 마진 밖이면(멀리 떨어짐) boardable 판정 자체가 fail해 발사하지 않는다', async () => {
+    storage.set(ACTIVE_TRIP_KEY, 'trip-2422-wire');
+
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation: current,
+        destination,
+        lock: null,
+        // 위도 0.01도 ≈ 1.1km 이동 — LOCAL_BOARDING_PROMPT_PROXIMITY_MARGIN_M(150m)를 훌쩍 초과.
+        gpsFix: { lat: current.lat + 0.01, lng: current.lng, accuracyM: 10 },
+        arrival: boardableArrival,
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/hooks/__tests__/useLocalBoardingPromptGate.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLocalBoardingPromptGate.test.ts
@@ -1,0 +1,229 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useLocalBoardingPromptGate } from '../useLocalBoardingPromptGate';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { StationArrival } from '../../../../shared/types/arrival';
+import { getStationById } from '../../../../shared/utils/stationRoute';
+import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const mockAddDomainBreadcrumb = jest.fn();
+jest.mock('../../../../shared/infra/monitoring/breadcrumb', () => ({
+  addDomainBreadcrumb: (...args: unknown[]) => mockAddDomainBreadcrumb(...args),
+}));
+
+const mockBuildBoardingPromptContext = jest.fn();
+jest.mock('../../utils/boardingPromptContext', () => ({
+  buildBoardingPromptContext: (...args: unknown[]) => mockBuildBoardingPromptContext(...args),
+}));
+
+const mockEvaluateLocalBoardingPromptGate = jest.fn();
+jest.mock('../../utils/localBoardingPromptGate', () => ({
+  evaluateLocalBoardingPromptGate: (...args: unknown[]) =>
+    mockEvaluateLocalBoardingPromptGate(...args),
+}));
+
+const mockFireLocalBoardingPromptNotification = jest.fn();
+jest.mock('../../utils/stationNotification', () => ({
+  fireLocalBoardingPromptNotification: (...args: unknown[]) =>
+    mockFireLocalBoardingPromptNotification(...args),
+}));
+
+const currentStation = getStationById('2-020')!; // 중곡
+const destination = getStationById('2-022')!; // 건대입구
+const route = makeDirectRoute(4, '2');
+
+const arrival: StationArrival = { up: [], down: [] };
+
+function makeLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: destination.id,
+    trainCode: '7246',
+    boardingStationId: currentStation.id,
+    boardingLine: '2',
+    boardedAt: 1_700_000_000_000,
+    expectedDurationMs: 600_000,
+    ...overrides,
+  };
+}
+
+const context = {
+  promptGeoContext: {
+    origin: { lat: currentStation.lat, lng: currentStation.lng },
+    nextStation: { lat: destination.lat, lng: destination.lng },
+    direction: 'up' as const,
+    originDistanceM: 50,
+    originAccuracyM: 10,
+  },
+  promptDisplay: { originStation: currentStation.name, line: '2' },
+};
+
+describe('useLocalBoardingPromptGate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuildBoardingPromptContext.mockReturnValue(context);
+    mockEvaluateLocalBoardingPromptGate.mockReturnValue({ pass: true });
+    mockFireLocalBoardingPromptNotification.mockResolvedValue(true);
+  });
+
+  it('lock이 활성이면 게이트 평가 자체를 스킵한다 (context 빌드/발사 모두 안 함)', () => {
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: makeLock(),
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    expect(mockBuildBoardingPromptContext).not.toHaveBeenCalled();
+    expect(mockFireLocalBoardingPromptNotification).not.toHaveBeenCalled();
+  });
+
+  it('arrival이 null이면 스킵한다', () => {
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival: null,
+      }),
+    );
+    expect(mockBuildBoardingPromptContext).not.toHaveBeenCalled();
+    expect(mockFireLocalBoardingPromptNotification).not.toHaveBeenCalled();
+  });
+
+  it('context가 null이면(route/currentStation/destination 미해소 등) 발사 안 함', () => {
+    mockBuildBoardingPromptContext.mockReturnValue(null);
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    expect(mockEvaluateLocalBoardingPromptGate).not.toHaveBeenCalled();
+    expect(mockFireLocalBoardingPromptNotification).not.toHaveBeenCalled();
+  });
+
+  it('게이트 fail이면 발사 안 함', () => {
+    mockEvaluateLocalBoardingPromptGate.mockReturnValue({ pass: false, reason: 'not-near-origin' });
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    expect(mockFireLocalBoardingPromptNotification).not.toHaveBeenCalled();
+  });
+
+  it('게이트 pass면 context.promptDisplay/promptGeoContext.direction으로 발사하고, 성공 시 breadcrumb를 남긴다', async () => {
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    await waitFor(() => {
+      expect(mockFireLocalBoardingPromptNotification).toHaveBeenCalledWith(
+        currentStation.name,
+        '2',
+        'up',
+      );
+    });
+    await waitFor(() => {
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('boarding', 'local_boarding_prompt_fired', {
+        originStation: currentStation.name,
+        line: '2',
+      });
+    });
+  });
+
+  it('발사 함수가 false(이미 dedup됨)를 반환하면 breadcrumb를 남기지 않는다', async () => {
+    mockFireLocalBoardingPromptNotification.mockResolvedValue(false);
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    await waitFor(() => {
+      expect(mockFireLocalBoardingPromptNotification).toHaveBeenCalled();
+    });
+    expect(mockAddDomainBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it('발사 함수가 reject되어도 throw하지 않는다 (에러 삼킴)', async () => {
+    mockFireLocalBoardingPromptNotification.mockRejectedValue(new Error('network'));
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    await waitFor(() => {
+      expect(mockFireLocalBoardingPromptNotification).toHaveBeenCalled();
+    });
+    // reject 후에도 in-flight 가드가 풀려 재평가 가능해야 한다 — 다음 assertion으로 간접 검증.
+  });
+
+  it('발사 in-flight 중 재렌더는 중복 발사하지 않는다', async () => {
+    let resolveFire: (v: boolean) => void = () => {};
+    mockFireLocalBoardingPromptNotification.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveFire = resolve;
+      }),
+    );
+    const { rerender } = renderHook(
+      (props: { gpsFix: { lat: number; lng: number; accuracyM: number } | null }) =>
+        useLocalBoardingPromptGate({
+          route,
+          currentStation,
+          destination,
+          lock: null,
+          gpsFix: props.gpsFix,
+          arrival,
+        }),
+      { initialProps: { gpsFix: null } },
+    );
+    await waitFor(() => {
+      expect(mockFireLocalBoardingPromptNotification).toHaveBeenCalledTimes(1);
+    });
+    // deps 변경으로 effect 재실행 — in-flight 가드가 두 번째 호출을 막아야 한다.
+    rerender({ gpsFix: { lat: 1, lng: 1, accuracyM: 1 } });
+    expect(mockFireLocalBoardingPromptNotification).toHaveBeenCalledTimes(1);
+    resolveFire(true);
+    await waitFor(() => {
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/alarm/hooks/useLocalBoardingPromptGate.ts
+++ b/src/features/alarm/hooks/useLocalBoardingPromptGate.ts
@@ -1,0 +1,82 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: boarding-prompt 로컬 게이트는 alarm(발사/dedup) + route(방향 유틸
+ * 경유 context 빌더) + shared 타입을 가로지르는 본질적 cross-feature 게이트다. 선례:
+ * `boardingPromptContext.ts` 헤더와 동일 rationale.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2422 (방향 A) — boarding prompt device FG 로컬 단일권위.
+ *
+ * backend remote alert push(주 채널)의 SPOF(미발송/전달실패 시 client 대비책 0)를 제거하기 위해,
+ * device가 FG 상태에서 같은 gate 입력(`buildBoardingPromptContext`)을 로컬로 재평가해 통과하면
+ * `fireLocalBoardingPromptNotification`으로 직접 발사한다. ADR-033(station-passed FG 보조 발사,
+ * `useStationAlarm.dispatchStationPassed`)과 동일 패턴 계승.
+ *
+ * 게이트 자체(근접 + 방향/도착열차 존재)는 `localBoardingPromptGate.ts`가 순수 함수로 담당—
+ * 이 훅은 입력 조립(route/currentStation/destination/lock/gpsFix → context, arrival)과 부수효과
+ * (발사 호출 + in-flight 가드)만 담당한다.
+ *
+ * lock이 이미 활성이면 게이트 평가 자체를 스킵한다(backend #1 F2 defense와 동형 — boarding-prompt는
+ * 탑승 "이전" 게이트라 이미 탑승 확정된 trip에는 의미 없음).
+ */
+import { useEffect, useRef } from 'react';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { StationArrival } from '../../../shared/types/arrival';
+import { buildBoardingPromptContext, type GpsFix } from '../utils/boardingPromptContext';
+import { evaluateLocalBoardingPromptGate } from '../utils/localBoardingPromptGate';
+import { fireLocalBoardingPromptNotification } from '../utils/stationNotification';
+import { createLogger } from '../../../shared/utils/logger';
+import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+
+const log = createLogger('localBoardingPromptGate');
+
+export interface UseLocalBoardingPromptGateParams {
+  route: Route;
+  currentStation: Station | null;
+  destination: Station | null;
+  /** 활성 BoardingLock — non-null이면 이미 탑승 확정 상태라 게이트를 스킵한다. */
+  lock: BoardingLock | null;
+  gpsFix: GpsFix | null;
+  arrival: StationArrival | null;
+}
+
+export function useLocalBoardingPromptGate(params: UseLocalBoardingPromptGateParams): void {
+  const { route, currentStation, destination, lock, gpsFix, arrival } = params;
+  // 같은 cycle에서 발사 Promise가 아직 안 끝났는데 다음 렌더가 재평가하는 걸 막는 in-flight 가드.
+  // TTL dedup(`recentLocalStationFires`)와 별개로, await 경계 안에서의 중복 스케줄 호출을 차단한다.
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (lock != null) return; // #1921/#1921류 F2 defense와 동형 — 탑승 확정 trip은 스킵.
+    if (!arrival) return;
+    if (inFlightRef.current) return;
+
+    const context = buildBoardingPromptContext({ route, currentStation, destination, gpsFix });
+    if (!context) return;
+
+    const outcome = evaluateLocalBoardingPromptGate({ context, arrival });
+    if (!outcome.pass) return;
+
+    inFlightRef.current = true;
+    const { originStation, line } = context.promptDisplay;
+    const { direction } = context.promptGeoContext;
+    void fireLocalBoardingPromptNotification(originStation, line, direction)
+      .then((fired) => {
+        if (fired) {
+          addDomainBreadcrumb('boarding', 'local_boarding_prompt_fired', {
+            originStation,
+            line,
+          });
+        }
+      })
+      .catch((e) => {
+        log.error('로컬 boarding-prompt 발사 실패:', e as Error);
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+      });
+  }, [route, currentStation, destination, lock, gpsFix, arrival]);
+}

--- a/src/features/alarm/utils/__tests__/localBoardingPromptGate.test.ts
+++ b/src/features/alarm/utils/__tests__/localBoardingPromptGate.test.ts
@@ -1,0 +1,128 @@
+import {
+  evaluateLocalBoardingPromptGate,
+  LOCAL_BOARDING_PROMPT_PROXIMITY_MARGIN_M,
+} from '../localBoardingPromptGate';
+import type { BoardingPromptContext } from '../boardingPromptContext';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
+
+function makeContext(overrides: {
+  originDistanceM?: number;
+  originAccuracyM?: number;
+  direction?: 'up' | 'down' | null;
+  line?: string;
+}): BoardingPromptContext {
+  return {
+    promptGeoContext: {
+      origin: { lat: 37.5, lng: 127.0 },
+      nextStation: { lat: 37.51, lng: 127.01 },
+      direction: overrides.direction === undefined ? 'up' : overrides.direction,
+      originDistanceM: overrides.originDistanceM,
+      originAccuracyM: overrides.originAccuracyM,
+    },
+    promptDisplay: {
+      originStation: '중곡',
+      line: overrides.line ?? '7',
+    },
+  };
+}
+
+function makeArrival(overrides: Partial<ArrivalInfo> & { direction: 'up' | 'down' }): StationArrival {
+  const info: ArrivalInfo = {
+    destination: '건대입구',
+    arrivalMinutes: 3,
+    arrivalSeconds: 180,
+    statusMessage: '전역 출발',
+    trainCode: '1234',
+    line: '7',
+    receivedAtMs: Date.now(),
+    arrivalCode: 3,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+  return overrides.direction === 'up'
+    ? { up: [info], down: [] }
+    : { up: [], down: [info] };
+}
+
+describe('evaluateLocalBoardingPromptGate', () => {
+  it('근접(originDistanceM - originAccuracyM <= margin) + 같은 line/방향 도착열차 존재 → pass', () => {
+    const context = makeContext({ originDistanceM: 100, originAccuracyM: 20, direction: 'up' });
+    const arrival = makeArrival({ direction: 'up', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({ pass: true });
+  });
+
+  it('경계값: originDistanceM - originAccuracyM === margin → pass', () => {
+    const context = makeContext({
+      originDistanceM: LOCAL_BOARDING_PROMPT_PROXIMITY_MARGIN_M + 20,
+      originAccuracyM: 20,
+      direction: 'up',
+    });
+    const arrival = makeArrival({ direction: 'up', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival }).pass).toBe(true);
+  });
+
+  it('originDistanceM 부재(GPS fix 없음) → not-near-origin', () => {
+    const context = makeContext({ originAccuracyM: 20, direction: 'up' });
+    const arrival = makeArrival({ direction: 'up', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({
+      pass: false,
+      reason: 'not-near-origin',
+    });
+  });
+
+  it('originAccuracyM 부재 → not-near-origin', () => {
+    const context = makeContext({ originDistanceM: 100, direction: 'up' });
+    const arrival = makeArrival({ direction: 'up', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({
+      pass: false,
+      reason: 'not-near-origin',
+    });
+  });
+
+  it('margin 초과(originDistanceM - originAccuracyM > margin) → not-near-origin', () => {
+    const context = makeContext({
+      originDistanceM: LOCAL_BOARDING_PROMPT_PROXIMITY_MARGIN_M + 21,
+      originAccuracyM: 20,
+      direction: 'up',
+    });
+    const arrival = makeArrival({ direction: 'up', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({
+      pass: false,
+      reason: 'not-near-origin',
+    });
+  });
+
+  it('근접 통과했지만 같은 line 도착열차 없음 → no-arriving-train', () => {
+    const context = makeContext({ originDistanceM: 50, originAccuracyM: 10, direction: 'up', line: '7' });
+    const arrival = makeArrival({ direction: 'up', line: '2' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({
+      pass: false,
+      reason: 'no-arriving-train',
+    });
+  });
+
+  it('direction 지정 시 반대 방향 후보는 무시(다른 방향에 도착열차 있어도 no-arriving-train)', () => {
+    const context = makeContext({ originDistanceM: 50, originAccuracyM: 10, direction: 'up', line: '7' });
+    const arrival = makeArrival({ direction: 'down', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({
+      pass: false,
+      reason: 'no-arriving-train',
+    });
+  });
+
+  it('arrivalSeconds<=0인 후보는 도착열차로 인정하지 않음', () => {
+    const context = makeContext({ originDistanceM: 50, originAccuracyM: 10, direction: 'up', line: '7' });
+    const arrival = makeArrival({ direction: 'up', line: '7', arrivalSeconds: 0 });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival })).toEqual({
+      pass: false,
+      reason: 'no-arriving-train',
+    });
+  });
+
+  it('direction=null(비단조 노선)이면 양방향 후보 모두 허용', () => {
+    const context = makeContext({ originDistanceM: 50, originAccuracyM: 10, direction: null, line: '7' });
+    const arrival = makeArrival({ direction: 'down', line: '7' });
+    expect(evaluateLocalBoardingPromptGate({ context, arrival }).pass).toBe(true);
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -11,6 +11,7 @@ import {
   buildStationPassedContent,
   fireFgAuxStationPassedNotification,
   fireLocalAlarmNotification,
+  fireLocalBoardingPromptNotification,
 } from '../stationNotification';
 import { buildStationNotifCollapseId } from '../stationNotifCollapseId';
 import { APNS_TOKEN_KEY } from '../../../../shared/constants/storageKeys';
@@ -307,6 +308,80 @@ describe('stationNotification', () => {
           },
         });
         expect(emptyStation.shouldShowAlert).toBe(true);
+        expect(mockHasRecentLocalStationFire).not.toHaveBeenCalled();
+      });
+    });
+
+    // #2422 — 로컬 boarding-prompt 발사 직후 뒤늦게 도착한 backend remote alert push의
+    // 중복 표시 억제(2차 방어선, station-passed isRecentLocalAuxFireDuplicate와 동형).
+    describe('#2422 — 최근 로컬 boarding-prompt 발사 표시 억제', () => {
+      it('data.kind=boarding-prompt + hasRecentLocalStationFire=true → 표시 억제', async () => {
+        mockHasRecentLocalStationFire.mockResolvedValueOnce(true);
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const result = await handleNotification({
+          request: {
+            identifier: 'boarding-prompt-local-x',
+            content: { sound: null, data: { kind: 'boarding-prompt', originStation: '중곡' } },
+          },
+        });
+        expect(mockHasRecentLocalStationFire).toHaveBeenCalledWith('중곡', 'boarding-prompt');
+        expect(result).toEqual({
+          shouldShowAlert: false,
+          shouldShowBanner: false,
+          shouldShowList: false,
+          shouldPlaySound: false,
+          shouldSetBadge: false,
+        });
+      });
+
+      it('data.kind=boarding-prompt + hasRecentLocalStationFire=false → 정상 표시', async () => {
+        mockHasRecentLocalStationFire.mockResolvedValueOnce(false);
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const result = await handleNotification({
+          request: {
+            identifier: 'boarding-prompt-local-x',
+            content: { sound: null, data: { kind: 'boarding-prompt', originStation: '중곡' } },
+          },
+        });
+        expect(result.shouldShowAlert).toBe(true);
+      });
+
+      it('data.kind가 boarding-prompt가 아니면 hasRecentLocalStationFire 호출 안 함 (정상 표시)', async () => {
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const result = await handleNotification({
+          request: {
+            identifier: 'station-alarm',
+            content: { sound: null, data: { kind: 'intermediate', originStation: '중곡' } },
+          },
+        });
+        expect(mockHasRecentLocalStationFire).not.toHaveBeenCalled();
+        expect(result.shouldShowAlert).toBe(true);
+      });
+
+      it('data 없거나 originStation 누락/빈 문자열이면 hasRecentLocalStationFire 호출 안 함 (정상 표시)', async () => {
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const noData = await handleNotification({
+          request: { identifier: 'boarding-prompt-local-x', content: { sound: null } },
+        });
+        expect(noData.shouldShowAlert).toBe(true);
+        const noOrigin = await handleNotification({
+          request: {
+            identifier: 'boarding-prompt-local-x',
+            content: { sound: null, data: { kind: 'boarding-prompt' } },
+          },
+        });
+        expect(noOrigin.shouldShowAlert).toBe(true);
+        const emptyOrigin = await handleNotification({
+          request: {
+            identifier: 'boarding-prompt-local-x',
+            content: { sound: null, data: { kind: 'boarding-prompt', originStation: '' } },
+          },
+        });
+        expect(emptyOrigin.shouldShowAlert).toBe(true);
         expect(mockHasRecentLocalStationFire).not.toHaveBeenCalled();
       });
     });
@@ -1058,6 +1133,85 @@ describe('stationNotification', () => {
 
     it('device token 미보유 시(등록 전) 스킵 — 알림 발사/stamp 모두 안 함', async () => {
       await fireFgAuxStationPassedNotification('중곡', 1, 'destination', '강남');
+      expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fireLocalBoardingPromptNotification (#2422 — device FG 로컬 boarding-prompt 단일권위)', () => {
+    beforeEach(async () => {
+      await AsyncStorage.clear();
+      mockHasRecentLocalStationFire.mockResolvedValue(false);
+    });
+
+    it('ACTIVE_TRIP_KEY 보유 + dedup 미기록 시 BOARDING_PROMPT_CATEGORY + 응답 payload shape로 발사하고 markLocalStationFired를 stamp한다', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'trip-abc');
+
+      const fired = await fireLocalBoardingPromptNotification('중곡', '7', 'up');
+
+      expect(fired).toBe(true);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            title: '탑승하셨나요?',
+            categoryIdentifier: 'BOARDING_PROMPT',
+            data: {
+              kind: 'boarding-prompt',
+              originStation: '중곡',
+              line: '7',
+              tripToken: 'trip-abc',
+              destinationDirection: 'up',
+            },
+          }),
+          trigger: null,
+        }),
+      );
+      expect(mockMarkLocalStationFired).toHaveBeenCalledWith('중곡', 'boarding-prompt');
+    });
+
+    it('direction=null이면 data.destinationDirection 필드 자체를 생략한다', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'trip-abc');
+
+      await fireLocalBoardingPromptNotification('중곡', '7', null);
+
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            data: { kind: 'boarding-prompt', originStation: '중곡', line: '7', tripToken: 'trip-abc' },
+          }),
+        }),
+      );
+    });
+
+    it('LINE_NAMES에 없는 line 값(비정상 데이터)이면 원본 line 문자열을 그대로 body에 사용한다', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'trip-abc');
+
+      await fireLocalBoardingPromptNotification('중곡', 'not-a-line', null);
+
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            body: expect.stringContaining('not-a-line'),
+          }),
+        }),
+      );
+    });
+
+    it('ACTIVE_TRIP_KEY 미보유(backend register 전) 시 스킵 — 알림 발사/stamp 모두 안 함', async () => {
+      const fired = await fireLocalBoardingPromptNotification('중곡', '7', null);
+      expect(fired).toBe(false);
+      expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+    });
+
+    it('최근 dedup 기록 있으면(hasRecentLocalStationFire=true) 스킵 — ACTIVE_TRIP_KEY 조회조차 안 함', async () => {
+      mockHasRecentLocalStationFire.mockResolvedValueOnce(true);
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'trip-abc');
+
+      const fired = await fireLocalBoardingPromptNotification('중곡', '7', null);
+
+      expect(fired).toBe(false);
+      expect(mockHasRecentLocalStationFire).toHaveBeenCalledWith('중곡', 'boarding-prompt');
       expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
       expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
     });

--- a/src/features/alarm/utils/localBoardingPromptGate.ts
+++ b/src/features/alarm/utils/localBoardingPromptGate.ts
@@ -1,0 +1,81 @@
+/**
+ * #2422 — 로컬 boarding-prompt 게이트.
+ *
+ * backend `evaluateAndMaybeFireBoardingPrompt`(9단 AND 게이트, `backend/alarm-worker/src/
+ * boardingPrompt.ts`)의 본질만 device FG 단발 폴링 컨텍스트로 이식한다. 9개 전부 무차별
+ * 복제는 과설계(CLAUDE.md 단순성) — 오탐 방지에 실제로 필요한 것만 남긴다.
+ *
+ * 포함:
+ *   - 근접(backend #3/#4) — `isNearOrigin`(boardingPrompt.ts) 공식을 그대로 포팅:
+ *     `originDistanceM - originAccuracyM <= PROMPT_PROXIMITY_MARGIN_M`. features → backend
+ *     import는 금지 룰(CLAUDE.md)이라 상수/함수를 직접 재사용할 수 없어 값만 동기화한다.
+ *   - 방향 + 도착열차 존재(backend #5 대체) — GPS 이동방향 cosine(backend #5)은 다중 GPS
+ *     샘플(position series)이 필요해 FG 단발 폴링 훅에서 별도 유지 비용이 크다. 대신
+ *     `useBoardingPromptResponder.tryAutoLock`이 이미 쓰는 "route 방향(direction) + 같은
+ *     line arrival 필터" 패턴을 재사용 — 실제 열차가 그 방향/노선에 존재한다는 사실 자체가
+ *     "지금 이 역에서 탑승 대기 중"이라는 더 신뢰 가능한 신호다.
+ *
+ * 제외(의도적):
+ *   - motion 게이트(backend #6/#8) — ADR-032(device emitter) 사망 원인이 motion-accelerometer
+ *     오분류(walking/automotive 오분류, 감지 0건)였다. 방향 A 지침이 명시적으로 GPS/route/arrival
+ *     기반만 허용하고 motion 기반을 금지한다.
+ *   - fused speed(backend #7) — GPS position series 다중 샘플이 전제. 이 안전망은 backend의
+ *     보조/fallback 채널이므로 series 유지 비용이 가치 대비 과설계.
+ *   - 반복 발사/침묵(backend #9) — 게이트 함수 책임이 아니라 별도 dedup 레이어
+ *     (`recentLocalStationFires.ts`, #2122 station-passed 선례 재사용)가 담당.
+ *   - lock 활성 여부(backend #1)/context 존재(backend #2) — 호출자(`useLocalBoardingPromptGate`)
+ *     가 `buildBoardingPromptContext` 호출 전에 사전 보장한다.
+ */
+import type { BoardingPromptContext } from './boardingPromptContext';
+import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
+
+/**
+ * backend `PROMPT_PROXIMITY_MARGIN_M`(boardingPrompt.ts)와 동일 값. SSoT는 backend — features
+ * → backend import 금지 룰로 상수 자체는 공유 불가하니 drift 방지는 이 주석 + 값 동기화로 관리.
+ */
+export const LOCAL_BOARDING_PROMPT_PROXIMITY_MARGIN_M = 150;
+
+/** backend `isNearOrigin`(boardingPrompt.ts) 공식 포팅. */
+function isNearOriginLocal(
+  originDistanceM: number | undefined,
+  originAccuracyM: number | undefined,
+): boolean {
+  if (originDistanceM === undefined || originAccuracyM === undefined) return false;
+  return originDistanceM - originAccuracyM <= LOCAL_BOARDING_PROMPT_PROXIMITY_MARGIN_M;
+}
+
+export interface EvaluateLocalBoardingPromptGateInput {
+  context: BoardingPromptContext;
+  arrival: StationArrival;
+}
+
+export type LocalBoardingPromptGateSkipReason = 'not-near-origin' | 'no-arriving-train';
+
+export type LocalBoardingPromptGateOutcome =
+  | { pass: true }
+  | { pass: false; reason: LocalBoardingPromptGateSkipReason };
+
+/**
+ * 로컬 boarding-prompt 발사 여부 평가. pure 함수 — 부수효과 없음.
+ */
+export function evaluateLocalBoardingPromptGate(
+  input: EvaluateLocalBoardingPromptGateInput,
+): LocalBoardingPromptGateOutcome {
+  const { originDistanceM, originAccuracyM, direction } = input.context.promptGeoContext;
+  if (!isNearOriginLocal(originDistanceM, originAccuracyM)) {
+    return { pass: false, reason: 'not-near-origin' };
+  }
+
+  const { line } = input.context.promptDisplay;
+  const { arrival } = input;
+  const directionSlice: readonly ArrivalInfo[] =
+    direction === 'up' || direction === 'down'
+      ? arrival[direction]
+      : ([] as ArrivalInfo[]).concat(arrival.up, arrival.down);
+  const hasArrivingTrain = directionSlice.some((a) => a.line === line && a.arrivalSeconds > 0);
+  if (!hasArrivingTrain) {
+    return { pass: false, reason: 'no-arriving-train' };
+  }
+
+  return { pass: true };
+}

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -39,6 +39,8 @@ import {
 import { buildStationNotifCollapseId } from './stationNotifCollapseId';
 import { markLocalStationFired, hasRecentLocalStationFire } from './recentLocalStationFires';
 import type { StationWaypointKind } from '../../../shared/types/pushContract';
+import { BOARDING_PROMPT_CATEGORY } from './notificationCategory';
+import type { LineNumber } from '../../../shared/types/station';
 
 /** 알람/통과 본문 끝에 데이터 출처를 자백하는 라벨을 부착한다.
  *  - source 미지정 → 라벨 생략 (기존 caller 회귀 안전)
@@ -64,7 +66,18 @@ const STATION_PASSED_CHANNEL_ID = 'station-passed';
 
 async function scheduleNotification(
   id: string,
-  content: { title: string; body: string; sound?: boolean | string; channelId?: string; interruptionLevel?: 'timeSensitive' | 'critical'; priority?: Notifications.AndroidNotificationPriority },
+  content: {
+    title: string;
+    body: string;
+    sound?: boolean | string;
+    channelId?: string;
+    interruptionLevel?: 'timeSensitive' | 'critical';
+    priority?: Notifications.AndroidNotificationPriority;
+    /** #2422 — boarding-prompt 등 액션 버튼(UNNotificationCategory)이 필요한 로컬 발사용. */
+    categoryIdentifier?: string;
+    /** #2422 — 응답 listener(`useBoardingPromptResponder`)가 파싱하는 payload 동봉용. */
+    data?: Record<string, unknown>;
+  },
 ): Promise<void> {
   try {
     await Notifications.dismissNotificationAsync(id);
@@ -91,6 +104,11 @@ export function setupNotificationHandler(): void {
       // #2122 — FG 보조 발사(로컬 station-passed 알림) 직후 뒤늦게 도착한 backend alert push가
       // 같은 (station, kind)면 2차 방어선으로 표시 억제(1차는 apns-collapse-id 문자열 일치).
       if (await isRecentLocalAuxFireDuplicate(notification)) {
+        return SUPPRESSED_NOTIFICATION_BEHAVIOR;
+      }
+      // #2422 — 로컬 boarding-prompt 발사 직후 뒤늦게 도착하는 backend remote alert push가
+      // 같은 origin station이면 억제 (station-passed의 isRecentLocalAuxFireDuplicate와 동형 2차 방어선).
+      if (await isRecentLocalBoardingPromptDuplicate(notification)) {
         return SUPPRESSED_NOTIFICATION_BEHAVIOR;
       }
       return {
@@ -167,6 +185,27 @@ async function isRecentLocalAuxFireDuplicate(
   const localKind = mapBackendKindToLocalFireKind(backendKind);
   if (!localKind) return false;
   return hasRecentLocalStationFire(stationName, localKind);
+}
+
+/** boarding-prompt local fire dedup 키 kind — `recentLocalStationFires`(#2122 station-passed
+ *  선례) 재사용. station name과 조합해 `${kind}:${stationName}` 키를 만든다. */
+export const LOCAL_BOARDING_PROMPT_FIRE_KIND = 'boarding-prompt';
+
+/**
+ * #2422 — backend remote boarding-prompt alert push(`data.kind === 'boarding-prompt'`)가,
+ * 이 device가 방금 로컬로 발사한 것과 같은 originStation이면 true. 로컬 발사가 backend push보다
+ * 먼저 도달했을 때 뒤늦은 remote alert의 중복 표시를 억제한다.
+ */
+async function isRecentLocalBoardingPromptDuplicate(
+  notification: Notifications.Notification,
+): Promise<boolean> {
+  const data = notification.request.content.data as
+    | { kind?: unknown; originStation?: unknown }
+    | undefined;
+  if (data?.kind !== 'boarding-prompt') return false;
+  const originStation = data?.originStation;
+  if (typeof originStation !== 'string' || originStation.length === 0) return false;
+  return hasRecentLocalStationFire(originStation, LOCAL_BOARDING_PROMPT_FIRE_KIND);
 }
 
 const STATION_CHANNEL_ID = 'station';
@@ -667,4 +706,76 @@ export async function fireFgAuxStationPassedNotification(
   const { title, body } = buildStationPassedContent(stationName, count, targetKind, targetName);
   await scheduleNotification(identifier, { title, body, sound: false });
   await markLocalStationFired(stationName, 'station-passed');
+}
+
+/**
+ * #2422 — "탔어요?" boarding-prompt title/body 빌더. backend `buildBoardingPromptMessage`
+ * (backend/alarm-worker/src/scheduled.ts)의 device 쪽 대응 — ETA 절대시각까지는 복제하지 않는다
+ * (단순성. 이 로컬 발사는 backend remote push의 fallback 안전망이라 표시 정보가 backend와
+ * 100% 동일할 필요는 없다. 사용자는 앱 홈 화면에서 이미 ETA를 보고 있다).
+ */
+function buildBoardingPromptContent(
+  originStation: string,
+  line: string,
+): { title: string; body: string } {
+  return {
+    title: i18next.t('route.boardingPromptTitle'),
+    body: i18next.t('route.boardingPromptBody', {
+      line: LINE_NAMES[line as LineNumber] ?? line,
+      originStation: getStationDisplayNameByName(originStation, allStations),
+    }),
+  };
+}
+
+/** #2422 — 로컬 boarding-prompt 알림 identifier prefix. 매 발사마다 station+시각을 붙여 유일화
+ *  (동일 identifier 재사용은 `useBoardingPromptDisplayLogger`의 dedup Set이 두 번째 발사부터
+ *  displayed 카운트를 영구 억제하는 부작용이 있다 — #2422 PR 리뷰 참고). */
+const LOCAL_BOARDING_PROMPT_ID_PREFIX = 'boarding-prompt-local';
+
+/**
+ * #2422 (방향 A) — device FG 로컬 boarding-prompt 단일권위 발사.
+ *
+ * backend remote alert push(주 채널)가 미발송/전달실패해도 device가 FG에서 동일 게이트
+ * (`localBoardingPromptGate.ts`)를 통과하면 로컬로 직접 발사한다 — ADR-033(station-passed FG
+ * 보조 발사)과 동일 패턴.
+ *
+ * `useBoardingPromptResponder`가 파싱하는 payload schema(`BoardingPromptPayload`)와 동일한
+ * shape으로 `content.data`를 채운다 — [탑승]/[미탑승] 액션 버튼(BOARDING_PROMPT_CATEGORY)이
+ * 로컬 발사든 원격 발사든 동일하게 동작한다.
+ *
+ * tripToken은 `ACTIVE_TRIP_KEY`(backend register 성공 시에만 set)를 요구한다 — 아직 register가
+ * 안 된 trip은 이 로컬 발사도 스킵(register 자체의 실패는 이 안전망의 범위 밖. 이 안전망은
+ * "register는 됐지만 backend cron/APNs 전달이 실패"하는 SPOF만 커버한다).
+ *
+ * dedup: `recentLocalStationFires`(#2122 선례)로 같은 originStation 재발사를 TTL(2분) 동안 억제.
+ * 반환값은 실제 발사 여부(테스트/로깅 용) — 게이트 자체는 caller(`useLocalBoardingPromptGate`)가
+ * 이미 통과한 상태로 호출한다.
+ */
+export async function fireLocalBoardingPromptNotification(
+  originStation: string,
+  line: string,
+  destinationDirection: 'up' | 'down' | null,
+): Promise<boolean> {
+  if (await hasRecentLocalStationFire(originStation, LOCAL_BOARDING_PROMPT_FIRE_KIND)) {
+    return false;
+  }
+  const tripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+  if (!tripToken) return false;
+
+  const identifier = `${LOCAL_BOARDING_PROMPT_ID_PREFIX}:${originStation}:${Date.now()}`;
+  const { title, body } = buildBoardingPromptContent(originStation, line);
+  await scheduleNotification(identifier, {
+    title,
+    body,
+    categoryIdentifier: BOARDING_PROMPT_CATEGORY,
+    data: {
+      kind: 'boarding-prompt',
+      originStation,
+      line,
+      tripToken,
+      ...(destinationDirection ? { destinationDirection } : {}),
+    },
+  });
+  await markLocalStationFired(originStation, LOCAL_BOARDING_PROMPT_FIRE_KIND);
+  return true;
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -47,6 +47,7 @@ import { useBarometer } from '../shared/hooks/useBarometer';
 import { useTripOrigin } from '../features/route/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../features/nearest-station/hooks/useBackgroundLocation';
 import { useApnsTripRegistration } from '../features/alarm/hooks/useApnsTripRegistration';
+import { useLocalBoardingPromptGate } from '../features/alarm/hooks/useLocalBoardingPromptGate';
 import { useLiveActivityDismissBridge } from '../features/alarm/hooks/useLiveActivityDismissBridge';
 import { registerSilentPushTask } from '../features/alarm/tasks/silentPushTask';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -1039,6 +1040,22 @@ export default function HomeScreen() {
     // 있었다 — tripOrigin을 명시 송신해 backend가 우선 채택하도록 한다. 캡처 전(cold-start)이면
     // undefined로 생략(graceful) — backend는 기존 passedStations fallback으로 동작.
     originStationName: tripOrigin?.name,
+  });
+
+  // #2422 (방향 A) — boarding prompt device FG 로컬 단일권위. backend remote alert push(주 채널)
+  // 가 미발송/전달실패해도 device가 FG에서 같은 gate 입력으로 로컬 발사 안전망을 돌린다.
+  // gpsFix는 useApnsTripRegistration과 동일 소스(userLocation/accuracyMeters) — 중복 계산 없이
+  // 같은 GPS fix를 boarding-prompt context 근접 게이트 입력으로 재사용.
+  useLocalBoardingPromptGate({
+    route,
+    currentStation: result?.station ?? null,
+    destination,
+    lock: boardingLock,
+    gpsFix:
+      userLocation && accuracyMeters != null
+        ? { lat: userLocation.lat, lng: userLocation.lng, accuracyM: accuracyMeters }
+        : null,
+    arrival,
   });
 
   useEffect(() => {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "Currently at {{name}}",
     "approximateDistance": "~{{m}}m",
     "stationPassed": "Arrived at {{name}}",
+    "boardingPromptTitle": "Are you on board?",
+    "boardingPromptBody": "You're near {{originStation}} station ({{line}}).",
     "tripEndedArrivedTitle": "Arrived at destination",
     "tripEndedTitle": "Guidance ended",
     "tripEndedBody": "Route guidance has ended",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "現在 {{name}}",
     "approximateDistance": "約{{m}}m",
     "stationPassed": "{{name}}駅に到着",
+    "boardingPromptTitle": "ご乗車されましたか?",
+    "boardingPromptBody": "{{originStation}}駅付近です({{line}})。",
     "tripEndedArrivedTitle": "目的地に到着",
     "tripEndedTitle": "案内終了",
     "tripEndedBody": "ルート案内を終了しました",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "현재 {{name}}역",
     "approximateDistance": "약 {{m}}m",
     "stationPassed": "{{name}}역 도착",
+    "boardingPromptTitle": "탑승하셨나요?",
+    "boardingPromptBody": "{{line}} {{originStation}}역 근처예요.",
     "tripEndedArrivedTitle": "목적지 도착",
     "tripEndedTitle": "안내 종료",
     "tripEndedBody": "경로 안내를 종료했어요",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "当前 {{name}}",
     "approximateDistance": "约{{m}}m",
     "stationPassed": "已到达{{name}}",
+    "boardingPromptTitle": "您已乘车了吗?",
+    "boardingPromptBody": "您在{{originStation}}站附近({{line}})。",
     "tripEndedArrivedTitle": "已到达目的地",
     "tripEndedTitle": "导航结束",
     "tripEndedBody": "路线导航已结束",


### PR DESCRIPTION
## Summary

Closes #2422

방향 A(사용자 결정): boarding prompt(#819 "탔어요?" 푸시)가 backend remote alert push 전용이라 backend 미발송/전달실패 시 client 대비책이 0인 SPOF였다. device가 FG 상태에서 같은 gate 입력을 로컬로 재평가해, backend가 실패해도 로컬 발사로 커버하는 안전망을 추가한다. ADR-033(station-passed FG 보조 발사) 패턴 계승. ADR-032(motion 기반 device emitter 사망) 회피 — GPS/route/arrival 기반만 사용.

- `src/features/alarm/utils/localBoardingPromptGate.ts` (신규) — 로컬 게이트 순수 함수. backend `evaluateAndMaybeFireBoardingPrompt`(9단, `backend/alarm-worker/src/boardingPrompt.ts`)의 본질만 이식.
- `src/features/alarm/hooks/useLocalBoardingPromptGate.ts` (신규) — 기존 `buildBoardingPromptContext` 재사용해 gate 입력 조립 + 발사.
- `src/features/alarm/utils/stationNotification.ts` — `fireLocalBoardingPromptNotification` 신설(ADR-033 `fireFgAuxStationPassedNotification`과 동형) + `setupNotificationHandler` 2차 방어선(뒤늦은 backend push 중복 억제).
- `src/screens/HomeScreen.tsx` — 훅 배선(`useApnsTripRegistration`과 동일 gpsFix 소스 재사용).
- `ko/en/ja/zh.json` — `route.boardingPromptTitle`/`Body` 신규.

### 옮긴 backend 게이트 (본질만, 9개 무차별 복제 금지)

| backend 게이트 | 로컬 포함 여부 | 근거 |
|---|---|---|
| #1 lock 비활성 | 호출자가 사전 보장 | 훅에서 `lock != null` early-return |
| #2 context 존재 | 포함(재사용) | 기존 `buildBoardingPromptContext` |
| #3/#4 origin 근접 | **포함** | backend `isNearOrigin` 공식 그대로 포팅 (`originDistanceM - originAccuracyM <= 150`) |
| #5 방향 | **포함(대체)** | GPS cosine 대신 route-방향 + arrival line/direction 필터 (`useBoardingPromptResponder.tryAutoLock`과 동일 패턴, position series 불필요) |
| #6/#8 motion | **제외** | ADR-032 사망 원인(walking/automotive 오분류, 감지 0건). 방향 A 지침이 명시적으로 금지 |
| #7 fused speed | **제외** | GPS position series(다중 샘플) 전제 — FG 단발 폴링 훅에 과설계 |
| #9 반복발사/침묵 | **제외(별도 레이어)** | `recentLocalStationFires`(#2122 station-passed 선례) dedup으로 처리 |

### dedup(이중발사) 방식

- 로컬 발사 전: `recentLocalStationFires`(TTL 2분, 기존 station-passed 선례 재사용)로 재발사 억제.
- 로컬 발사 후 뒤늦게 backend remote alert가 도착: `setupNotificationHandler`에 2차 방어선 추가 — `data.kind === 'boarding-prompt'` + 같은 `originStation`이면 `hasRecentLocalStationFire`로 표시 억제(station-passed `isRecentLocalAuxFireDuplicate`와 동형).
- `ACTIVE_TRIP_KEY`(backend register 성공 시에만 set) 요구 — register 자체의 실패는 이 안전망 범위 밖(register는 단일 POST라 delivery chain보다 훨씬 신뢰 가능). backend cron/APNs 전달 실패만 커버.

### useBoardingPromptResponder.ts

무변경 — payload shape(`BoardingPromptPayload`)이 로컬/원격 무관 동일해 [탑승]/[미탑승] 액션이 그대로 동작.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — 로컬 발사 알림은 `BOARDING_PROMPT_CATEGORY` + payload shape이 원격과 동일해, 기존 `useBoardingPromptDisplayLogger`(FG `addNotificationReceivedListener`)가 자동으로 `logBoardingPromptFired`를 적재한다(DebugModal "Boarding Prompt" 카운터에서 로컬/원격 구분 없이 관측 가능). 별도 계측 추가 없이 기존 wire가 흡수.
3. **의존 PR** — N/A (device-only, backend 변경 없음).
4. **측정 plan** — 1주 production: DebugModal `boarding-prompt` outcome=`fired` 건수 중 `ACTIVE_TRIP_KEY` 존재 + backend push 실패 시나리오 재현 시 로컬 발사 발생 여부 확인. `addDomainBreadcrumb('boarding', 'local_boarding_prompt_fired', ...)`로 Sentry breadcrumb도 별도 확보.
5. **Device verify** — **필요**. 실기기 탑승 시나리오: (a) 정상 조건에서 정류장 근접 + 도착열차 존재 시 로컬 프롬프트가 발화하는지, (b) [탑승] 액션이 기존과 동일하게 자동 lock을 시도하는지, (c) backend push가 뒤늦게 와도 중복 배너가 뜨지 않는지.

## Test plan

- [x] `npx jest src/features/alarm/utils/__tests__/localBoardingPromptGate.test.ts` — 순수 게이트 함수 100% coverage
- [x] `npx jest src/features/alarm/hooks/__tests__/useLocalBoardingPromptGate.test.ts` — 훅 orchestration 100% coverage
- [x] `npx jest src/features/alarm/utils/__tests__/stationNotification.test.ts` — 발사/dedup/중복억제 100% coverage
- [x] `npx jest src/features/alarm/__tests__/localBoardingPromptWholeWire.test.ts` — E(회귀 fixture): leaf만 mock한 실 체인으로 "boardable ⇒ fired" GREEN + RED 대조군 2건
- [x] `npm run type-check`
- [x] `npm run lint:orphan`
- [ ] 실기기 검증 (Device verify 항목 참고, 머지 전 사용자 확인 필요)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9