### PR TITLE
fix(#2425): 일시정지 15분 자동종료 backstop에 trip-ended sentinel 추가

### DIFF
--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -511,7 +511,7 @@ describe('useStateRehydration', () => {
       (Date.now as jest.Mock).mockRestore();
     });
 
-    it('pausedAt 존재 + 경과 ≥ PAUSE_AUTO_END_MS — runTripBoundCleanups + setState reset + releaseLock + alarmLog fired (RED: cold-start 자동 종료)', async () => {
+    it('pausedAt 존재 + 경과 ≥ PAUSE_AUTO_END_MS — runTripBoundCleanups + setState reset + releaseLock + sentinel + alarmLog fired (RED: cold-start 자동 종료)', async () => {
       const now = 1_700_000_000_000;
       jest.spyOn(Date, 'now').mockReturnValue(now);
       mockGetNavigationPausedAt.mockResolvedValue(now - PAUSE_AUTO_END_MS);
@@ -536,6 +536,8 @@ describe('useStateRehydration', () => {
       expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
         reason: 'navigation-pause-auto-end',
       });
+      // 버그 #3 fix — force-end 경로와 동일하게 종료 시 sentinel set, BG 채널이 인지 가능.
+      await waitFor(() => expect(mockSetSentinel).toHaveBeenCalled());
       (Date.now as jest.Mock).mockRestore();
     });
 

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -243,6 +243,8 @@ async function runLifecycleBackstop(trigger: 'mount' | 'active'): Promise<void> 
  *
  * force-end(9h+) 분기와 동일한 cleanup 시퀀스를 재사용한다(silent push trip-ended와 동형) —
  * setDestination 호출 대신 runTripBoundCleanups + setState 직접 호출은 #1351 R2와 동일 이유.
+ * force-end와 동일하게 종료 후 setTripEndedSentinel을 호출해 BG 채널(silent push 등)이 이 종료를
+ * 인지하도록 한다 — 누락 시 backend trip이 계속 살아있을 수 있음(버그 #3).
  */
 async function runNavigationPauseBackstop(trigger: 'mount' | 'active'): Promise<void> {
   try {
@@ -269,6 +271,9 @@ async function runNavigationPauseBackstop(trigger: 'mount' | 'active'): Promise<
     });
     addDomainBreadcrumb('trip', 'end', { reason: 'navigation-pause-auto-end' });
     await useBoardingLockStore.getState().releaseLock();
+    // #2114 (방안 C′) — sentinel에 corrId 동봉해 다음 소비 시점 trip 인스턴스 스코프 비교 가능하게.
+    // force-end 경로와 동일 — BG 채널(silent push 등)이 이 종료를 인지하도록 mirror 남김.
+    await setTripEndedSentinel(now, endedCorrIdSnapshot);
   } catch (e) {
     logger.warn('navigation pause backstop 실패 (graceful)', e);
   }


### PR DESCRIPTION
## Summary
- `runNavigationPauseBackstop`(일시정지 15분 자동종료, #2293)이 trip 종료 cleanup은 수행하지만 `setTripEndedSentinel`을 호출하지 않던 버그 수정
- `runLifecycleBackstop`의 force-end 경로(corrId snapshot 캡처 → cleanup → sentinel set)와 동일한 패턴으로 맞춤
- sentinel 누락 시 BG 채널(silent push 등)이 이 종료를 인지하지 못해 backend trip이 계속 살아있을 개연성이 있었음

Closes #2425

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 기존 import 재사용)
2. **V/X dashboard** — sentinel은 `TRIP_ENDED_BY_BACKEND_AT_KEY` storage 값. DebugModal의 trip lifecycle 섹션 / AsyncStorage 직접 조회로 확인 가능 (force-end 경로와 동일 관측 경로)
3. **의존 PR** — N/A (단일 함수 내 수정, 다른 PR 의존 없음)
4. **측정 plan** — 다음 사용자 trip에서 일시정지 15분 경과 자동종료 발생 시 sentinel key가 storage에 set되는지 확인. #2114 corrId 패턴과 동일하므로 backend D1 trip_events에서 해당 corrId의 종료 반영 여부로 교차검증 가능
5. **Device verify** — 필요. 시나리오: 앱에서 목적지 설정 → navigationActive=false로 전환(일시정지) → 15분 경과 후 앱 재진입(mount) 또는 AppState active 진입 → sentinel set 확인 (storage 또는 로그 `pause auto-end ... → cleanup`)

## Test plan
- [x] `npx jest src/shared/hooks/__tests__/useStateRehydration.test.ts` — 32/32 통과, pause 종료 시 `setTripEndedSentinel` 호출 검증 테스트 추가
- [x] `npm run type-check` — 통과
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 device verify (사용자 책임, 위 시나리오)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9