### PR TITLE
fix(#2424): DebugModal 타임스탬프 UTC/KST 혼재 수정

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -320,14 +320,18 @@ function formatOptionalNumber(value: number | null | undefined): string {
   return value == null ? UNKNOWN_LABEL : String(value);
 }
 
-function formatOptionalTs(value: number | null | undefined): string {
-  if (value == null) return UNKNOWN_LABEL;
-  return new Date(value).toISOString();
-}
-
 function formatTime(ts: number): string {
   const d = new Date(ts);
   return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+// #2424 — 이전엔 `toISOString()`(UTC)로 렌더해 나머지 시각 표시(formatTime 기반, 로컬=KST)와
+// 타임존이 혼재되어 실기기 덤프 오독→오진단을 유발했다. tripStartedAt 등은 날짜 경계를 넘는
+// trip 구분이 필요하므로 HH:mm만이 아니라 로컬 날짜(en-CA → YYYY-MM-DD)+시각(formatTime 재사용)으로 통일.
+function formatOptionalTs(value: number | null | undefined): string {
+  if (value == null) return UNKNOWN_LABEL;
+  const date = new Date(value).toLocaleDateString('en-CA');
+  return `${date} ${formatTime(value)}`;
 }
 
 // #2284 — fired-only 독립 버퍼(FiredAlarmLogEntry) 1건 포맷. alarmLog의 formatLogLine과 달리

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -19,6 +19,18 @@ import {
   type ObservabilityMetrics,
 } from '../../../observability/api/observabilityMetricsClient';
 
+// #2424 — formatOptionalTs(로컬 날짜+시각) 기대값 재현 헬퍼. 프로덕션 구현(DebugModal.tsx
+// formatOptionalTs)과 동일한 포맷 규칙(en-CA 날짜 + en-GB HH:mm:ss)을 테스트에서 독립 재현.
+function formatLocalTs(ts: number): string {
+  const date = new Date(ts).toLocaleDateString('en-CA');
+  const time = new Date(ts).toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  return `${date} ${time}`;
+}
+
 const mockUseFusedNearestStation = jest.fn();
 const mockUseArrivalInfo = jest.fn();
 const mockUseSilentPushDiagnostics = jest.fn();
@@ -1339,11 +1351,16 @@ describe('DebugModal helpers — D9 optional formatters (#1215)', () => {
     expect(__test__.formatOptionalNumber(input as number | null | undefined)).toBe(expected);
   });
 
-  it('formatOptionalTs: 값이 있으면 ISO, null이면 —', () => {
+  it('formatOptionalTs: 값이 있으면 로컬 날짜+시각(KST), null이면 —', () => {
     const ts = Date.UTC(2026, 5, 12, 5, 0, 0);
-    expect(__test__.formatOptionalTs(ts)).toBe(new Date(ts).toISOString());
+    expect(__test__.formatOptionalTs(ts)).toBe(formatLocalTs(ts));
     expect(__test__.formatOptionalTs(null)).toBe('—');
     expect(__test__.formatOptionalTs(undefined)).toBe('—');
+  });
+
+  it('formatOptionalTs: UTC ISO 문자열을 반환하지 않는다 (#2424 회귀 방지)', () => {
+    const ts = Date.UTC(2026, 5, 12, 5, 0, 0);
+    expect(__test__.formatOptionalTs(ts)).not.toBe(new Date(ts).toISOString());
   });
 });
 
@@ -1384,7 +1401,7 @@ describe('DebugModal buildDumpText — D9 sections (#1215)', () => {
     expect(dump).toContain('tier=high');
     expect(dump).toContain('signalMask=TFT');
     expect(dump).toContain('lockless=true');
-    expect(dump).toContain(`tripStartedAt=${new Date(tripStartedAt).toISOString()}`);
+    expect(dump).toContain(`tripStartedAt=${formatLocalTs(tripStartedAt)}`);
     expect(dump).toContain('currentHopIndex=2');
     expect(dump).toContain('route hop count=7');
     expect(dump).toContain('sleepMode=on');
@@ -1623,7 +1640,7 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     // #1253 — maestro manual flow가 Trip 섹션을 testID로 잡는다.
     expect(screen.getByTestId('debug-modal-trip-section')).toBeTruthy();
     expect(screen.getByText('lockless')).toBeTruthy();
-    expect(screen.getByText(new Date(tripStartedAt).toISOString())).toBeTruthy();
+    expect(screen.getByText(formatLocalTs(tripStartedAt))).toBeTruthy();
     expect(screen.getByText('3')).toBeTruthy();
     expect(screen.getByText('8')).toBeTruthy();
   });
@@ -1921,7 +1938,7 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
       mockGetTripStartedAt.mockResolvedValue(tripAt);
       useDestinationStore.setState({ destination: wireTripDestination });
       const message = await shareAndReadDump();
-      expect(message).toContain(`tripStartedAt=${new Date(tripAt).toISOString()}`);
+      expect(message).toContain(`tripStartedAt=${formatLocalTs(tripAt)}`);
     });
 
     it('비동기 hydration 중 unmount 시 setState 호출 안 함', async () => {


### PR DESCRIPTION
## Summary

Closes #2424

- `DebugModal.tsx`의 `formatOptionalTs`가 `new Date().toISOString()`(UTC)로 렌더해, 같은 화면의 나머지 시각 표시(`formatTime` 기반 — device 로컬=KST)와 타임존이 혼재. 실기기 덤프를 읽을 때 `tripStartedAt=2026-08-29T05:58:23.543Z`(UTC)를 KST로 오독하면 실제 시각과 9시간 오차가 발생해 trip 타이밍 오진단으로 이어짐.
- `formatOptionalTs`를 로컬 날짜(`en-CA` → `YYYY-MM-DD`) + 시각(기존 `formatTime` 재사용)으로 통일. `tripStartedAt`은 trip이 날짜 경계를 넘을 수 있어 날짜도 필요.
- 사용처는 `tripStartedAt` 2곳(dump 텍스트 L907, UI 표시 L2798)뿐 — 둘 다 통일 대상.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass 확인.
2. **V/X dashboard** — DebugModal UI(`tripStartedAt` row)와 share dump 텍스트 양쪽에서 즉시 확인 가능. 별도 관측 인프라 불필요(순수 포맷 변경).
3. **의존 PR** — N/A.
4. **측정 plan** — 코드 리뷰/타입-check로 충분. 별도 회귀 측정 불필요(순수 렌더 포맷).
5. **Device verify** — 필요. 실기기에서 DebugModal 덤프 공유 시 `tripStartedAt`이 다른 시각 필드(`as of`, `lastFix`, `boardedAt` 등)와 동일 타임존(KST)으로 표시되는지 확인.

## Test plan

- [x] `npx jest src/features/debug/components/__tests__/DebugModal.test.tsx` — 417 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:orphan` — no orphan exports
- [ ] 실기기 DebugModal 덤프에서 시각 표시 타임존 일관성 확인 (사용자 검증 필요)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9