### PR TITLE
fix(#2428): [trip 종료] 알림 버튼 dead wire 수정

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ import {
   setupTripEndedCategory,
 } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
+import { useAlarmEndTripResponder } from '../src/features/alarm/hooks/useAlarmEndTripResponder';
 import { useBoardingPromptDisplayLogger } from '../src/features/alarm/hooks/useBoardingPromptDisplayLogger';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
 import { useDeferredNavigate } from '../src/shared/hooks/useDeferredNavigate';
@@ -161,6 +162,10 @@ function RootContent() {
   // #1385 — boardingPrompt displayed 카운트. FG에서 actionable notification 수신 시 즉시
   // alarm log에 fired 1건 적재한다. responder의 cold-start 보완과 dedup된다.
   useBoardingPromptDisplayLogger();
+
+  // #2428 — ALARM_CATEGORY 알림 [trip 종료] 액션(ALARM_ACTION_END_TRIP) 응답 listener.
+  // 탭 시 cleanupUserInitiatedEndedTrip으로 trip을 완전히 종료한다(기존 dead wire 수정).
+  useAlarmEndTripResponder();
 
   // #899 (Seam C) — trip-bound 상태 단일 hydration seam. AppState 'active' 진입 시
   // destination/customOrigin/tripOrigin/lock을 storage에서 재수화하고, BG silent push가

--- a/src/features/alarm/hooks/__tests__/useAlarmEndTripResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useAlarmEndTripResponder.test.ts
@@ -1,0 +1,117 @@
+import * as Notifications from 'expo-notifications';
+import { renderHook } from '@testing-library/react-native';
+import {
+  handleAlarmEndTripResponse,
+  useAlarmEndTripResponder,
+} from '../useAlarmEndTripResponder';
+import { ALARM_ACTION_ACKNOWLEDGE, ALARM_ACTION_END_TRIP } from '../../utils/notificationCategory';
+
+jest.mock('expo-notifications', () => ({
+  addNotificationResponseReceivedListener: jest.fn(),
+  DEFAULT_ACTION_IDENTIFIER: '$default',
+}));
+
+const mockGetTripStartedAt = jest.fn<Promise<number | null>, []>();
+jest.mock('../../utils/tripStartStorage', () => ({
+  getTripStartedAt: () => mockGetTripStartedAt(),
+}));
+
+const mockCleanupUserInitiatedEndedTrip = jest.fn<Promise<void>, [number]>();
+jest.mock('../../utils/tripEndedCleanupSequence', () => ({
+  cleanupUserInitiatedEndedTrip: (...args: [number]) =>
+    mockCleanupUserInitiatedEndedTrip(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('handleAlarmEndTripResponse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ALARM_ACTION_END_TRIP 이외의 액션은 무시 (cleanup 미호출)', async () => {
+    await handleAlarmEndTripResponse(ALARM_ACTION_ACKNOWLEDGE);
+    expect(mockGetTripStartedAt).not.toHaveBeenCalled();
+    expect(mockCleanupUserInitiatedEndedTrip).not.toHaveBeenCalled();
+  });
+
+  it('$default(배너 탭) 등 임의 문자열도 무시', async () => {
+    await handleAlarmEndTripResponse('$default');
+    expect(mockCleanupUserInitiatedEndedTrip).not.toHaveBeenCalled();
+  });
+
+  it('ALARM_ACTION_END_TRIP + 활성 trip 없음 → no-op (cleanup 미호출)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(null);
+
+    await handleAlarmEndTripResponse(ALARM_ACTION_END_TRIP);
+
+    expect(mockGetTripStartedAt).toHaveBeenCalled();
+    expect(mockCleanupUserInitiatedEndedTrip).not.toHaveBeenCalled();
+  });
+
+  it('ALARM_ACTION_END_TRIP + 활성 trip 있음 → cleanupUserInitiatedEndedTrip 호출', async () => {
+    mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000);
+    const now = 1_700_000_500_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    await handleAlarmEndTripResponse(ALARM_ACTION_END_TRIP);
+
+    expect(mockCleanupUserInitiatedEndedTrip).toHaveBeenCalledWith(now);
+
+    (Date.now as jest.Mock).mockRestore();
+  });
+});
+
+describe('useAlarmEndTripResponder hook wiring', () => {
+  let registeredHandler: ((response: any) => void) | null = null;
+  const subscriptionRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registeredHandler = null;
+    (Notifications.addNotificationResponseReceivedListener as jest.Mock).mockImplementation(
+      (handler) => {
+        registeredHandler = handler;
+        return { remove: subscriptionRemove };
+      },
+    );
+  });
+
+  it('마운트 시 listener 1회 등록', () => {
+    renderHook(() => useAlarmEndTripResponder());
+    expect(Notifications.addNotificationResponseReceivedListener).toHaveBeenCalledTimes(1);
+    expect(registeredHandler).not.toBeNull();
+  });
+
+  it('unmount 시 subscription remove', () => {
+    const { unmount } = renderHook(() => useAlarmEndTripResponder());
+    unmount();
+    expect(subscriptionRemove).toHaveBeenCalled();
+  });
+
+  it('ALARM_ACTION_END_TRIP 응답 수신 시 cleanup 발화', async () => {
+    mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000);
+    renderHook(() => useAlarmEndTripResponder());
+
+    registeredHandler!({ actionIdentifier: ALARM_ACTION_END_TRIP });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockCleanupUserInitiatedEndedTrip).toHaveBeenCalled();
+  });
+
+  it('다른 액션 응답은 cleanup 미발화', async () => {
+    renderHook(() => useAlarmEndTripResponder());
+
+    registeredHandler!({ actionIdentifier: ALARM_ACTION_ACKNOWLEDGE });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockCleanupUserInitiatedEndedTrip).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/hooks/useAlarmEndTripResponder.ts
+++ b/src/features/alarm/hooks/useAlarmEndTripResponder.ts
@@ -1,0 +1,59 @@
+/**
+ * #2428 — `ALARM_CATEGORY` 알림의 [trip 종료] 액션(`ALARM_ACTION_END_TRIP`) 응답 handler.
+ *
+ * 버그: `notificationCategory.ts`가 `ALARM_CATEGORY`에 [확인]/[trip 종료] 버튼을 등록했지만
+ * (`ALARM_ACTION_END_TRIP`), 이 액션 식별자를 소비하는 response listener가 어디에도 없었다 —
+ * 탭해도 알림만 닫히고 trip이 그대로 유지되는 dead wire.
+ *
+ * `useBoardingPromptResponder`의 단일 listener는 `extractBoardingPromptPayload`가
+ * `kind: 'boarding-prompt'` payload만 통과시켜, ALARM_CATEGORY 알림(다른 payload shape)은
+ * 조기 return으로 걸러진다. expo-notifications는 multi-listener를 허용하므로
+ * (`useBoardingPromptResponder.ts` 헤더 주석과 동일 전제) 이 액션 전용 listener를 별도로 둔다.
+ *
+ * cleanup은 `tripEndedCleanupSequence.ts`의 `cleanupUserInitiatedEndedTrip`을 그대로 재사용 —
+ * `cleanupBackendConfirmedEndedTrip`과 동일한 5단 시퀀스(corrId snapshot → runTripBoundCleanups
+ * → triggerTripGroundTruthPrompt → destination store reset → sentinel)를 공유해 drift를
+ * 방지한다.
+ *
+ * 명시적 사용자 탭에만 발화 — `actionIdentifier === ALARM_ACTION_END_TRIP`만 매칭하므로
+ * 다른 액션/기본 탭/dismiss는 이 handler를 절대 타지 않는다(오발화 위험 없음). trip이 이미
+ * 없을 때(=`getTripStartedAt()` null) 탭되면 cleanup을 호출하지 않고 no-op — 이미 없는 trip을
+ * 대상으로 storage/breadcrumb/sentinel을 재발생시키지 않는다.
+ */
+import { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
+import { ALARM_ACTION_END_TRIP } from '../utils/notificationCategory';
+import { getTripStartedAt } from '../utils/tripStartStorage';
+import { cleanupUserInitiatedEndedTrip } from '../utils/tripEndedCleanupSequence';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('alarmEndTripResponder');
+
+/**
+ * `ALARM_ACTION_END_TRIP` 응답 listener를 등록한다. app root(`app/_layout.tsx`)에서 1회 마운트.
+ */
+export function useAlarmEndTripResponder(): void {
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      void handleAlarmEndTripResponse(response.actionIdentifier);
+    });
+    return () => sub.remove();
+  }, []);
+}
+
+/**
+ * actionIdentifier 분기 — pure 함수로 export해 테스트에서 직접 호출 가능
+ * (`useBoardingPromptResponder.handleResponse`와 동일 패턴).
+ */
+export async function handleAlarmEndTripResponse(actionIdentifier: string): Promise<void> {
+  if (actionIdentifier !== ALARM_ACTION_END_TRIP) return;
+
+  const tripStartedAt = await getTripStartedAt();
+  if (tripStartedAt === null) {
+    // trip이 이미 종료된 뒤 늦게 탭된 케이스 — cleanup 재실행 없이 graceful no-op.
+    log.info('ALARM_ACTION_END_TRIP tapped with no active trip — no-op');
+    return;
+  }
+
+  await cleanupUserInitiatedEndedTrip(Date.now());
+}

--- a/src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts
+++ b/src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts
@@ -1,8 +1,16 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
-import { cleanupBackendConfirmedEndedTrip } from '../tripEndedCleanupSequence';
+import {
+  cleanupBackendConfirmedEndedTrip,
+  cleanupUserInitiatedEndedTrip,
+} from '../tripEndedCleanupSequence';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+
+const mockAddDomainBreadcrumb = jest.fn();
+jest.mock('../../../../shared/infra/monitoring/breadcrumb', () => ({
+  addDomainBreadcrumb: (...args: unknown[]) => mockAddDomainBreadcrumb(...args),
+}));
 
 const mockTriggerTripEndRecall = jest.fn();
 jest.mock('../triggerTripEndRecall', () => ({
@@ -97,5 +105,47 @@ describe('cleanupBackendConfirmedEndedTrip', () => {
 
     expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledWith(null);
     expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(42, null);
+  });
+
+  it('reason=backend-confirmed breadcrumb 발사', async () => {
+    await cleanupBackendConfirmedEndedTrip(1_700_000_000_000);
+
+    expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
+      reason: 'backend-confirmed',
+    });
+  });
+});
+
+// #2428 — [trip 종료] 버튼 dead wire 수정. cleanupUserInitiatedEndedTrip은
+// cleanupBackendConfirmedEndedTrip과 동일 시퀀스(runFullTripEndCleanupSequence 공유)를 타므로
+// 핵심 순서/destination reset 검증은 위 describe에서 이미 커버 — 여기서는 함수 자체가 호출되고
+// reason이 구분되는지만 별도 검증한다(구현 재사용 확인).
+describe('cleanupUserInitiatedEndedTrip', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+    await AsyncStorage.clear();
+    useDestinationStore.setState({
+      destination: MOCK_STATIONS.gangnam,
+      customOrigin: MOCK_STATIONS.chungmuro,
+      tripOrigin: MOCK_STATIONS.hyochang,
+    });
+  });
+
+  it('cleanupBackendConfirmedEndedTrip과 동일 5단 시퀀스 실행 + reason=user-end-trip-button', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockGetCurrentTripCorrIdSync.mockReturnValue('corr-2');
+
+    await cleanupUserInitiatedEndedTrip(1_700_000_100_000);
+
+    expect(mockTriggerTripEndRecall).toHaveBeenCalled();
+    expect(mockRunTripBoundCleanups).toHaveBeenCalled();
+    expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledWith('corr-2');
+    expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(1_700_000_100_000, 'corr-2');
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+    expect(useDestinationStore.getState().destination).toBeNull();
+    expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
+      reason: 'user-end-trip-button',
+    });
   });
 });

--- a/src/features/alarm/utils/tripEndedCleanupSequence.ts
+++ b/src/features/alarm/utils/tripEndedCleanupSequence.ts
@@ -44,13 +44,20 @@ import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+
+/** breadcrumb에서 trip 종료 트리거를 구분하는 reason. */
+type TripEndReason = 'backend-confirmed' | 'user-end-trip-button';
 
 /**
- * backend-confirmed 'ended' trip을 device 상태에 반영한다.
- *
- * @param endedAt backend가 보고한 종료 시각(epoch ms). 미상이면 호출자가 `Date.now()` fallback.
+ * trip-ended cleanup 5단 시퀀스 본체. `cleanupBackendConfirmedEndedTrip` /
+ * `cleanupUserInitiatedEndedTrip`(#2428) 양쪽이 공유하는 단일 구현 — drift 방지를 위해
+ * 여기 외에는 재구현하지 않는다.
  */
-export async function cleanupBackendConfirmedEndedTrip(endedAt: number): Promise<void> {
+async function runFullTripEndCleanupSequence(
+  endedAt: number,
+  reason: TripEndReason,
+): Promise<void> {
   await triggerTripEndRecall();
   // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
   const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
@@ -61,7 +68,30 @@ export async function cleanupBackendConfirmedEndedTrip(endedAt: number): Promise
   // storage만 정리하므로 이게 없으면 stale destination이 메모리에 남아 lockless trip이
   // 유령 재시작된다 (헤더 주석 참고).
   useDestinationStore.setState({ destination: null, customOrigin: null, tripOrigin: null });
+  // #2428 — trip 종료 트리거 구분 breadcrumb (V/X dashboard 관측용: Sentry breadcrumb trail).
+  addDomainBreadcrumb('trip', 'end', { reason });
   // #2114 (방안 C′) — sentinel에 corrId 동봉.
   await setTripEndedSentinel(endedAt, endedCorrIdSnapshot);
   await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+}
+
+/**
+ * backend-confirmed 'ended' trip을 device 상태에 반영한다.
+ *
+ * @param endedAt backend가 보고한 종료 시각(epoch ms). 미상이면 호출자가 `Date.now()` fallback.
+ */
+export async function cleanupBackendConfirmedEndedTrip(endedAt: number): Promise<void> {
+  await runFullTripEndCleanupSequence(endedAt, 'backend-confirmed');
+}
+
+/**
+ * #2428 — 사용자가 `ALARM_CATEGORY` 알림의 [trip 종료] 액션(`ALARM_ACTION_END_TRIP`)을 직접
+ * 탭했을 때 호출하는 진입점. 시퀀스는 `cleanupBackendConfirmedEndedTrip`과 동일
+ * (`runFullTripEndCleanupSequence` 공유, 재구현 금지) — 사용자 명시 탭도 종료 확정 신호로
+ * backend 통지와 동급이다(ADR-014 "사용자 명시 의향 trip = lock 활성과 동급").
+ *
+ * @param endedAt 사용자가 탭한 시각(epoch ms). 호출자가 `Date.now()`를 전달.
+ */
+export async function cleanupUserInitiatedEndedTrip(endedAt: number): Promise<void> {
+  await runFullTripEndCleanupSequence(endedAt, 'user-end-trip-button');
 }


### PR DESCRIPTION
## Summary
- `ALARM_CATEGORY` 알림의 [trip 종료] 버튼(`ALARM_ACTION_END_TRIP`)을 탭해도 아무 일도 안 일어나던 dead wire 수정.
- 새 hook `useAlarmEndTripResponder`가 이 액션ID 전용 notification-response listener를 등록 (`useBoardingPromptResponder`는 `kind: 'boarding-prompt'` payload만 처리해 이 액션을 조기 return으로 무시하고 있었음 — expo-notifications는 multi-listener를 허용하므로 별도 listener로 분리).
- cleanup은 재구현하지 않고 기존 완전-cleanup SSoT(`tripEndedCleanupSequence.ts`)를 재사용. 공유 시퀀스를 `runFullTripEndCleanupSequence`로 추출해 `cleanupBackendConfirmedEndedTrip`(기존)과 `cleanupUserInitiatedEndedTrip`(신규) 양쪽이 동일 5단 시퀀스(triggerTripEndRecall → corrId snapshot → runTripBoundCleanups → triggerTripGroundTruthPrompt → destination store reset → breadcrumb → setTripEndedSentinel → ACTIVE_TRIP_KEY 제거)를 공유하도록 정리 — `useStateRehydration.ts`는 다른 에이전트가 동시 작업 중이라 건드리지 않음.

Closes #2428

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass 확인.
2. **V/X dashboard** — 신규 breadcrumb `addDomainBreadcrumb('trip', 'end', { reason })` — `reason: 'user-end-trip-button'` vs `'backend-confirmed'`로 Sentry breadcrumb trail(opt-in)에서 트리거 구분 관측 가능.
3. **의존 PR** — N/A (device-only 배선, backend/infra 변경 없음).
4. **측정 plan** — breadcrumb `reason=user-end-trip-button` 발생 빈도로 1주 측정 (Sentry opt-in 사용자 한정). 코드 레벨로는 `cleanupUserInitiatedEndedTrip` 신규 테스트 4종 + `useAlarmEndTripResponder` 신규 테스트 6종으로 액션 매칭/no-op/cleanup 호출 순서 커버.
5. **Device verify** — 필요. 시나리오: transfer/destination 알람 수신 → [trip 종료] 버튼 탭 → (a) 알람 즉시 사라짐 (b) 홈 화면에서 route/destination이 사라짐 (c) BoardingLock 해제 확인. trip 없는 상태에서 오래된 알림을 탭해도 크래시/오동작 없음(no-op) 확인.

## Test plan
- [x] `npx jest src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts src/features/alarm/hooks/__tests__/useAlarmEndTripResponder.test.ts --coverage` — 14 tests pass, 신규 파일 100% coverage
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 device verify (사용자)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9