### PR TITLE
fix(#2430): boardingPrompt autolock cold-start race — storage live-read

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -385,12 +385,42 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok');
   });
 
-  it('destinationId null → dismiss POST만 발사 (lock 시도 안 함)', async () => {
+  // 진짜 trip 종료(storage에도 destination 없음) — dismiss만, lock 시도 안 함.
+  // readWidgetRefreshContextMock 기본값(destination: null)을 그대로 사용.
+  it('destinationId null + storage에도 destination 없음(진짜 trip 종료) → dismiss POST만 발사 (lock 시도 안 함)', async () => {
     const deps = makeDeps({ destinationId: null });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(deps.fetchArrivalsForStation).not.toHaveBeenCalled();
     expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok');
     expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  // #2430 (cold-start race) — 알림의 "탑승했어요" 액션은 opensAppToForeground:true라
+  // 탭 시 앱이 cold-start된다. HomeScreen의 destination store가 hydrate되기 전에 이 listener가
+  // 응답을 처리하면 deps.destinationId(in-memory)는 일시 null이지만, trip은 여전히 활성이고
+  // AsyncStorage(DESTINATION_KEY)에는 올바른 destination이 남아 있다(진짜 trip 종료 시에만 storage도
+  // clear됨). storage live-read로 hydrate-전 일시 null과 진짜 종료를 구분해야 한다.
+  it('#2430 destinationId null이지만 storage에 destination 존재(cold-start race) → storage 값으로 lock 생성', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    readWidgetRefreshContextMock.mockResolvedValueOnce({
+      destination: { id: 'dst-from-storage', name: '잠실', line: '2' },
+      route: null,
+      bgContext: null,
+    });
+    const deps = makeDeps({ destinationId: null });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(deps.fetchArrivalsForStation).toHaveBeenCalledWith('강남');
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ destinationId: 'dst-from-storage', trainCode: 'T1' }),
+      true,
+      'boarding-prompt-response',
+    );
+    expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
+    expect(logBoardingPromptAutoLock).toHaveBeenCalledWith({
+      reason: 'autolock-success',
+      originStation: '강남',
+      line: '2',
+    });
   });
 
   // #2407 (root fix) — train 확정 실패해도 lock은 생성한다(ADR-014 명시 탭=lock 동급).

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -141,8 +141,15 @@ export interface UseBoardingPromptResponderDeps {
 /**
  * 응답 listener wiring + 분기 처리.
  *
- * destinationId가 null이면 lock 생성 불가 — 사용자가 trip을 이미 종료한 후 푸시를 늦게 탭한 케이스.
- * 그 경우 dismiss POST만 발사하고 lock 시도는 silent skip.
+ * deps.destinationId가 null이면 두 가지 케이스가 구분 안 된 상태다:
+ *   1) 진짜 trip 종료 후 푸시를 늦게 탭한 케이스.
+ *   2) cold-start race — "탑승했어요" 액션은 opensAppToForeground:true라 탭 시 앱이 killed 상태에서
+ *      새로 뜬다. HomeScreen의 destination store가 AsyncStorage(DESTINATION_KEY)로부터 hydrate되기
+ *      전에 이 listener가 응답을 먼저 처리하면 deps.destinationId(in-memory)는 일시 null이지만
+ *      storage에는 여전히 올바른 destination이 남아 있다(진짜 종료 시에만 storage도 clear됨).
+ *
+ * `tryAutoLock`이 destinationId가 null일 때 storage를 live-read해 둘을 구분한다 — storage에도
+ * 없으면 케이스 1로 간주해 dismiss POST만 발사하고 lock 시도는 silent skip.
  */
 export function useBoardingPromptResponder(deps: UseBoardingPromptResponderDeps): void {
   const createLock = useBoardingLockStore((s) => s.createLock);
@@ -366,14 +373,18 @@ async function tryAutoLock(
 ): Promise<void> {
   const telemetry = { originStation: payload.originStation, line: payload.line };
 
-  if (!deps.destinationId) {
-    // trip이 이미 끝남 — lock 시도 안 함, dismiss로 backend silence.
+  // #2430 (cold-start race) — deps.destinationId(HomeScreen in-memory state)가 null이면
+  // storage(DESTINATION_KEY)를 live-read해 hydrate-전 일시 null과 진짜 trip 종료를 구분한다.
+  // deps.destinationId가 있으면 storage read는 short-circuit으로 건너뛴다(정상 경로 비용 無).
+  const destinationId =
+    deps.destinationId ?? (await readWidgetRefreshContext()).destination?.id ?? null;
+
+  if (!destinationId) {
+    // storage에도 destination이 없음 — 진짜 trip 종료. lock 시도 안 함, dismiss로 backend silence.
     logBoardingPromptAutoLock({ reason: 'autolock-no-trip', ...telemetry });
     await dismissBoardingPrompt(payload.tripToken);
     return;
   }
-  // await 경계를 넘어도 non-null narrowing이 유지되도록 local const로 고정.
-  const destinationId = deps.destinationId;
 
   const arrival = await deps.fetchArrivalsForStation(payload.originStation);
   if (!arrival) {


### PR DESCRIPTION
## 근본
Closes #2430

`useBoardingPromptResponder.ts`의 `tryAutoLock`이 `deps.destinationId`(HomeScreen in-memory state)가 null이면 즉시 "trip 이미 종료"로 판단해 lock 생성을 skip했다.

"탑승했어요" 액션은 `opensAppToForeground:true`(notificationCategory.ts:70)라 탭 시 앱이 cold-start된다. HomeScreen의 destination store가 AsyncStorage로부터 hydrate되기 전에 이 listener가 응답을 처리하면 `deps.destinationId`가 일시 null이 되어 오판이 발생 → lock 미생성 → 사용자가 BoardingTrainList에서 수동 선택해야 함(8/31 실탑승 dump 근거).

## Fix
storage(AsyncStorage `DESTINATION_KEY`)에는 trip 활성 중이면 destination이 남아있음(진짜 종료 시에만 storage도 cleanup). `deps.destinationId`가 null이면 기존 storage read 유틸 `readWidgetRefreshContext()`(`src/features/alarm/utils/widgetRefreshContext.ts`, 이미 이 파일이 import 중)로 live-read해:
- storage에 destination 있음 → 그 값으로 진행 (cold-start race, trip 활성)
- storage도 null → 기존대로 `autolock-no-trip` skip (진짜 trip 종료)

`deps.destinationId`가 있는 정상 경로는 `??` short-circuit으로 추가 storage read 없음.

## 변경 파일
- `src/features/alarm/hooks/useBoardingPromptResponder.ts` — `tryAutoLock` null 분기 수정
- `src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts` — RED-first test 추가 + genuine-ended 회귀 test 유지

## TDD
- RED: destinationId null + storage에 destination 존재 → lock 생성 assert. 수정 전 실패 확인(fetchArrivalsForStation 미호출로 실패).
- Fix 적용 후 GREEN.
- genuine-ended 회귀: destinationId null + storage도 null(기존 테스트, 기본 mock 유지) → lock 미생성 그대로 통과.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 기존 `readWidgetRefreshContext` 재사용).
2. **V/X dashboard** — `logBoardingPromptAutoLock({ reason: 'autolock-success' | 'autolock-no-trip', ... })` breadcrumb/telemetry로 기존과 동일하게 관측(DebugModal / Sentry breadcrumb). 신규 reason 없음 — 기존 채널 그대로.
3. **의존 PR** — N/A (frontend 단독 fix, backend/device 변경 불요).
4. **측정 plan** — production에서 `autolock-success` 비율이 boardingPrompt 탭 대비 상승하는지 1주 관찰(cold-start race 케이스가 기존엔 `autolock-no-trip`으로 카운트됐음).
5. **Device verify** — 필요. 시나리오: 폰을 주머니에 넣고 이동 중 "탑승했어요" 알림이 오면(앱이 완전히 종료된 상태에서), 알림을 탭해 앱이 cold-start로 열려도 BoardingLock이 자동 생성되는지 확인 (수동 선택 화면으로 빠지지 않아야 함).

## 제약 준수
- 알림 제거 없음 — P1 fix만, 기존 알림/LA 경로 그대로.
- 관련 테스트만 실행(`npx jest`), 전체 `npm test` 미실행.
- 머지는 하지 않음 — 사용자 결정 대기.