### PR TITLE
fix(#2432): 지하 advance stall — locked trainCode arvlcd 확증은 motion gate 면제

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -334,7 +334,7 @@ describe('advanceTripPosition — 6단 게이트 양방향 시나리오 (accepta
     },
     // Negative
     {
-      name: 'N1 정지 + arvlcd + userIntent OFF → blocked(motion-stationary)',
+      name: 'P9 (#2432) 정지 + lock + arvlcd-confirmed-train(trainCode 일치) → advanced (locked trainCode 확증은 motion 무관 독립 증거)',
       motion: 'stationary',
       userIntent: false,
       hasLock: true,
@@ -343,6 +343,33 @@ describe('advanceTripPosition — 6단 게이트 양방향 시나리오 (accepta
       trainMatch: true,
       gatePassed: true,
       lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'advanced',
+    },
+    {
+      name: 'N1 (#2432 회귀방어) 정지 + lock + arvlcd 확증 없는 evidence(position-train) → blocked(motion-stationary)',
+      motion: 'stationary',
+      userIntent: false,
+      hasLock: true,
+      env: 'surface',
+      evidenceType: 'position-train',
+      trainMatch: false,
+      gatePassed: true,
+      lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'blocked',
+      expectedReason: 'motion-stationary',
+    },
+    {
+      name: 'N1b (#2432 회귀방어) lockless + 정지 + arvlcd-lockless → blocked(motion-stationary)',
+      motion: 'stationary',
+      userIntent: false,
+      hasLock: false,
+      env: 'surface',
+      evidenceType: 'arvlcd-lockless',
+      trainMatch: false,
+      gatePassed: true,
+      lockAttachable: false,
       extraStrongInRing: 0,
       expected: 'blocked',
       expectedReason: 'motion-stationary',
@@ -1056,7 +1083,10 @@ describe('advanceTripPosition — alarmEvents stamping (#1572 T9)', () => {
 
   // Shared setup — seedSsot(motion) + putTrip(with lock) + advanceTripPosition 4-line 시퀀스.
   // 3 case가 motion state만 다르고 나머지가 동일 → factory + advance 호출 통합으로 SonarCloud CPD 회피.
-  async function setupAndAdvance(motion: 'moving' | 'stationary'): Promise<{
+  async function setupAndAdvance(
+    motion: 'moving' | 'stationary',
+    evidence: AdvanceEvidence = makeEvidence(),
+  ): Promise<{
     result: AdvanceResult;
     after: Awaited<ReturnType<typeof readSsot>>;
   }> {
@@ -1068,7 +1098,7 @@ describe('advanceTripPosition — alarmEvents stamping (#1572 T9)', () => {
       kv as unknown as KVNamespace,
       TOKEN,
       '중곡',
-      makeEvidence(),
+      evidence,
       { gatePassed: true, lockAttachable: true },
     );
     const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
@@ -1095,7 +1125,12 @@ describe('advanceTripPosition — alarmEvents stamping (#1572 T9)', () => {
   });
 
   it('blocked advance → alarmEvents stamp 안 함', async () => {
-    const { result, after } = await setupAndAdvance('stationary'); // motion gate 차단
+    // #2432 — arvlcd-confirmed-train evidence는 lock 활성 + stationary여도 motion gate를 우회하므로,
+    // 본 blocked 시나리오는 확증 없는 evidence type(position-train)으로 motion gate를 차단시킨다.
+    const { result, after } = await setupAndAdvance(
+      'stationary',
+      makeEvidence({ type: 'position-train', arvlCd: null, arvlcdTrainCode: undefined }),
+    );
     expect(result).toBe('blocked');
     expect(after?.alarmEvents).toEqual([]);
   });

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -21,6 +21,11 @@
  *                             lock 활성과 동급 정확도 → motion stationary 게이트도 우회 X 아닌 동급 처리.
  *                             그러나 P8 acceptance "userIntentDeclared=true + 정지 → advanced"가
  *                             명시되어 있어 #2에서만 명시 의향 trip을 통과시킨다. 다른 게이트는 동급.)
+ *                            #2432 — lock 활성 + `arvlcd-confirmed-train` evidence는 locked trainCode
+ *                             자체가 실제 이동 중이라는 독립 확증이므로 device sync 신선도와 무관하게
+ *                             motion gate를 면제한다(지하 GPS 끊김으로 motion 신호가 고정되는 사각
+ *                             차단). false-positive 방어는 #5 train identity + T7
+ *                             `evaluateTransferDestinationGate`가 담당.
  *   #3 Environment 게이트  — evaluateConsensusGate 통과 필수 (지하 GPS-only false positive 차단)
  *   #4 Evidence type 게이트 — ADR-015 §E4: 'time-only' evidence 절대 거부
  *   #5 Train identity 게이트 — lock 활성 + arvlcd-confirmed-train evidence면 trainCode 일치 필수
@@ -431,7 +436,22 @@ export async function advanceTripPosition(
   // leg 자율 전진만, 환승 후 leg는 범위 밖).
   const deviceSyncStaleBypass =
     isDeviceSyncStale(ssot, evidence.ts) && evidence.type === 'arvlcd-confirmed-train';
-  if (ssot.motionState === 'stationary' && !ssot.userIntentDeclared && !deviceSyncStaleBypass) {
+  // #2432 — lock 활성 + `arvlcd-confirmed-train` evidence는 그 자체로 "locked trainCode가 실제
+  // 이동 중"이라는 독립 확증이다(#1315 주석 자백: 지하 GPS 끊김으로 motion=unknown/stationary
+  // 고정 시 trainCode 바인딩도 이동 게이트에 의존해 사각 발생 — 8/30 D1 trip 어대/건대 advance
+  // stall 재현). deviceSyncStale 여부와 무관하게, 열차 자체의 arvlCd 진행이 device motion보다
+  // 강한 ground truth이므로 motion gate를 면제한다. false-positive 방어는 gate #5(train identity
+  // — `lock.trainCode` 불일치 시 blocked('train-mismatch'))와 T7
+  // `evaluateTransferDestinationGate`(transfer/destination kind 60s 신선도, 2026-06-19 회귀 방어)가
+  // 유지 — 본 게이트에서 lock 없음/trainCode 확증 없는 evidence(예: `position-train`)는 기존대로
+  // 차단된다.
+  const lockedTrainArvlcdBypass = lock !== undefined && evidence.type === 'arvlcd-confirmed-train';
+  if (
+    ssot.motionState === 'stationary' &&
+    !ssot.userIntentDeclared &&
+    !deviceSyncStaleBypass &&
+    !lockedTrainArvlcdBypass
+  ) {
     return { result: 'blocked', blockReason: 'motion-stationary', ssot };
   }
 


### PR DESCRIPTION
## Summary
- `advanceTripPosition` gate #2(motion-stationary)를 lock 활성 + `arvlcd-confirmed-train` evidence에 대해 확장 면제. locked trainCode 자체의 arvlCd 진행(ARRIVING/ARRIVED)이 device GPS/accelerometer motion보다 강한 독립 확증이라는 근거(ADR-014).
- 근본: `src/scheduled.ts:405-424`(#1315) 주석이 자백한 사각 — 지하 GPS 끊김으로 motion=unknown/stationary 고정 시 trainCode 바인딩도 이동 게이트 의존이라 advance가 막힘. D1 실증(8/30 trip): 군자까지 advance → device sync GPS 역행 → 어대/건대 건너뛰고 성수서 재개(어대 도착 알림 누락).
- false-positive 방어 유지: gate #5(train identity 불일치 시 `blocked('train-mismatch')`) + T7 `evaluateTransferDestinationGate`(transfer/destination kind 60s 신선도, 2026-06-19 회귀 원 방어)는 변경 없음 — 본 PR은 gate #2에서만 "locked trainCode 확증" evidence를 통과시키고, 이후 게이트가 계속 신원/신선도를 재검증한다.

Closes #2432

## Wire-completion 5단
1. **Orphan 없음** — 신규 export 없음(기존 export만 조건 확장). N/A.
2. **V/X dashboard** — `AdvanceBlockReason='motion-stationary'` 분포는 기존 `AdvanceStats.blockedMotionStationary` / V8 acceptance query(`vxAcceptanceQueries.ts`)로 이미 관측 중 — 이 PR 이후 lock-active 지하 trip에서 해당 카운트 감소가 기대 신호.
3. **의존 PR** — backend deploy 필요 (사용자 책임, Cloudflare deploy는 코드 머지와 별도). N/A(다른 PR 의존 없음).
4. **측정 plan** — D1 `trip_events` 쿼리로 지하 waypoint(예: 어대/건대) 구간 advance stall 재발 여부를 1주 관측. `blockedMotionStationary` 카운터가 lock-active + underground trip에서 감소하는지 확인.
5. **Device verify** — 필요. 지하 재탑승 시 GPS 끊긴 구간에서 매역 advance/알림이 지속되는지 실기기 확인 필요 (사용자 책임).

## Test plan
- [x] `npx vitest run src/__tests__/advanceTripPosition.test.ts` — 103 passed (RED→GREEN 시나리오 P9 + 회귀 방어 N1/N1b 추가)
- [x] `npx vitest run` (backend 전체) — 86 files / 3057 tests passed
- [x] `npx tsc --noEmit` — clean

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9