### PR TITLE
feat(#2434): LA ContentState에 boarding 프롬프트 필드 추가 (데이터 배선만)

### DIFF
--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -36,6 +36,12 @@ export interface LiveActivityData {
   // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드해 전달.
   // 누락 시 위젯/LA는 라벨 표시 생략 — 기존 인스턴스 호환 안전.
   sourceLabel?: string;
+  // #2434 — LA interactive prompt piece ①. 순수 데이터 필드만 (버튼/AppIntent는 후속 piece).
+  // 전부 optional — 미전달 시 native ContentState가 nil로 decode돼 기존 렌더와 100% 동일.
+  boardingPhase?: 'pre-boarding' | 'boarded' | 'hop-end' | 'arrival';
+  boardingPromptTripToken?: string;
+  boardingPromptOriginStation?: string;
+  boardingPromptLine?: string;
 }
 
 const LiveActivityModule =

--- a/modules/live-activity/ios/SubwayActivityAttributes.swift
+++ b/modules/live-activity/ios/SubwayActivityAttributes.swift
@@ -37,6 +37,12 @@ struct SubwayActivityAttributes: ActivityAttributes {
         // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드된 사용자 노출 텍스트.
         // 누락 시 위젯은 라벨 표시 생략 — 기존 LA 인스턴스 호환 안전.
         var sourceLabel: String?
+        // #2434 — LA interactive prompt piece ①. 순수 데이터 필드만 (버튼/AppIntent는 후속 piece).
+        // 전부 optional이라 기존 LA 세션(구 ContentState)이 decode 시 missing key → nil로 안전.
+        var boardingPhase: String?
+        var boardingPromptTripToken: String?
+        var boardingPromptOriginStation: String?
+        var boardingPromptLine: String?
     }
 }
 

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -12,6 +12,7 @@ import {
   fireFgAuxStationPassedNotification,
   fireLocalAlarmNotification,
   fireLocalBoardingPromptNotification,
+  buildLiveActivityData,
 } from '../stationNotification';
 import { buildStationNotifCollapseId } from '../stationNotifCollapseId';
 import { APNS_TOKEN_KEY } from '../../../../shared/constants/storageKeys';
@@ -1303,6 +1304,74 @@ describe('stationNotification', () => {
     ])('buildAlarmContent source=%s → body=%s', (source, expectedBody) => {
       const { body } = buildAlarmContent(earlyDest, source);
       expect(body).toBe(expectedBody);
+    });
+  });
+
+  describe('buildLiveActivityData boardingPrompt 필드 (#2434 — LA interactive piece ①)', () => {
+    it('boardingPrompt 미전달 시 boarding* 필드가 undefined (기존 동작 그대로)', () => {
+      const data = buildLiveActivityData(mockStation, 154);
+      expect(data.boardingPhase).toBeUndefined();
+      expect(data.boardingPromptTripToken).toBeUndefined();
+      expect(data.boardingPromptOriginStation).toBeUndefined();
+      expect(data.boardingPromptLine).toBeUndefined();
+    });
+
+    it('boardingPrompt=null 전달 시에도 boarding* 필드가 undefined', () => {
+      const data = buildLiveActivityData(
+        mockStation,
+        154,
+        null,
+        null,
+        null,
+        false,
+        null,
+        undefined,
+        null,
+      );
+      expect(data.boardingPhase).toBeUndefined();
+      expect(data.boardingPromptTripToken).toBeUndefined();
+      expect(data.boardingPromptOriginStation).toBeUndefined();
+      expect(data.boardingPromptLine).toBeUndefined();
+    });
+
+    it('boardingPrompt 전달 시 4개 필드를 그대로 직렬화한다', () => {
+      const data = buildLiveActivityData(
+        mockStation,
+        154,
+        null,
+        null,
+        null,
+        false,
+        null,
+        undefined,
+        {
+          phase: 'pre-boarding',
+          tripToken: 'trip-abc',
+          originStation: '시청',
+          line: '1',
+        },
+      );
+      expect(data.boardingPhase).toBe('pre-boarding');
+      expect(data.boardingPromptTripToken).toBe('trip-abc');
+      expect(data.boardingPromptOriginStation).toBe('시청');
+      expect(data.boardingPromptLine).toBe('1');
+    });
+
+    it.each(['pre-boarding', 'boarded', 'hop-end', 'arrival'] as const)(
+      'phase=%s 단독 전달도 정상 직렬화',
+      (phase) => {
+        const data = buildLiveActivityData(mockStation, 154, null, null, null, false, null, undefined, {
+          phase,
+        });
+        expect(data.boardingPhase).toBe(phase);
+        expect(data.boardingPromptTripToken).toBeUndefined();
+      },
+    );
+
+    it('기존 호출자(source까지만 전달)는 시그니처가 안 깨진다', () => {
+      const data = buildLiveActivityData(mockStation, 154, null, null, null, false, null, 'gpsOnly');
+      expect(data.stationName).toBe('시청');
+      expect(data.boardingPhase).toBeUndefined();
     });
   });
 });

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -374,6 +374,26 @@ export interface BoardingPromptLiveActivityFields {
   line?: string;
 }
 
+type BoardingPromptTarget =
+  | 'boardingPhase'
+  | 'boardingPromptTripToken'
+  | 'boardingPromptOriginStation'
+  | 'boardingPromptLine';
+
+/**
+ * #2434 — (source key → LiveActivityData target key) 매핑. 필드가 하나 더 추가돼도
+ * 이 배열에 한 줄만 늘리면 되도록 데이터 주도로 구성 (개별 if 반복 하드코딩 금지, CLAUDE.md 룰3).
+ */
+const BOARDING_PROMPT_FIELD_MAP: ReadonlyArray<{
+  source: keyof BoardingPromptLiveActivityFields;
+  target: BoardingPromptTarget;
+}> = [
+  { source: 'phase', target: 'boardingPhase' },
+  { source: 'tripToken', target: 'boardingPromptTripToken' },
+  { source: 'originStation', target: 'boardingPromptOriginStation' },
+  { source: 'line', target: 'boardingPromptLine' },
+];
+
 /**
  * Live Activity content-state payload 빌더 — 입력은 train/route/alarm 정보, 출력은 native
  * Live Activity 모듈에 전달할 직렬화된 `LiveActivityData`. `updateStationNotification`(FG)과
@@ -500,21 +520,15 @@ export function buildLiveActivityData(
     }
   }
 
-  // #2434 — LA interactive prompt piece ①. boardingPrompt 필드가 있을 때만 채운다.
-  // 미전달(undefined/null)이면 data에 필드가 세팅되지 않아 native ContentState가 nil로
-  // decode돼 기존 렌더와 100% 동일.
+  // #2434 — LA interactive prompt piece ①. boardingPrompt 필드가 있을 때만, 존재하는 값만
+  // 순회로 채운다. 미전달(undefined/null)이면 data에 필드가 세팅되지 않아 native ContentState가
+  // nil로 decode돼 기존 렌더와 100% 동일.
   if (boardingPrompt) {
-    if (boardingPrompt.phase) {
-      data.boardingPhase = boardingPrompt.phase;
-    }
-    if (boardingPrompt.tripToken) {
-      data.boardingPromptTripToken = boardingPrompt.tripToken;
-    }
-    if (boardingPrompt.originStation) {
-      data.boardingPromptOriginStation = boardingPrompt.originStation;
-    }
-    if (boardingPrompt.line) {
-      data.boardingPromptLine = boardingPrompt.line;
+    for (const { source, target } of BOARDING_PROMPT_FIELD_MAP) {
+      const value = boardingPrompt[source];
+      if (value) {
+        (data as Record<BoardingPromptTarget, string | undefined>)[target] = value;
+      }
     }
   }
 

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -363,6 +363,18 @@ function buildContent(
 }
 
 /**
+ * #2434 — LA interactive prompt piece ①. boarding 프롬프트 상태를 LA content state에 실어
+ * 보내기 위한 순수 데이터 필드. 버튼/AppIntent는 후속 piece에서 배선한다.
+ * 전부 optional — 미전달 시 `buildLiveActivityData`가 대응 필드를 세팅하지 않아 기존 동작과 동일.
+ */
+export interface BoardingPromptLiveActivityFields {
+  phase?: 'pre-boarding' | 'boarded' | 'hop-end' | 'arrival';
+  tripToken?: string;
+  originStation?: string;
+  line?: string;
+}
+
+/**
  * Live Activity content-state payload 빌더 — 입력은 train/route/alarm 정보, 출력은 native
  * Live Activity 모듈에 전달할 직렬화된 `LiveActivityData`. `updateStationNotification`(FG)과
  * `refreshLiveActivityFromBackgroundContext`(#900 Seam D, silent push BG)에서 공유한다.
@@ -376,6 +388,7 @@ export function buildLiveActivityData(
   isMock?: boolean,
   alarmEvent?: AlarmEvent | null,
   source?: NotificationSource,
+  boardingPrompt?: BoardingPromptLiveActivityFields | null,
 ): LiveActivity.LiveActivityData {
   // station layer: 항상 포함. Live Activity는 사용자 노출이므로 현재 언어로 표시.
   const data: LiveActivity.LiveActivityData = {
@@ -484,6 +497,24 @@ export function buildLiveActivityData(
         destination: destName,
         etaSuffix,
       });
+    }
+  }
+
+  // #2434 — LA interactive prompt piece ①. boardingPrompt 필드가 있을 때만 채운다.
+  // 미전달(undefined/null)이면 data에 필드가 세팅되지 않아 native ContentState가 nil로
+  // decode돼 기존 렌더와 100% 동일.
+  if (boardingPrompt) {
+    if (boardingPrompt.phase) {
+      data.boardingPhase = boardingPrompt.phase;
+    }
+    if (boardingPrompt.tripToken) {
+      data.boardingPromptTripToken = boardingPrompt.tripToken;
+    }
+    if (boardingPrompt.originStation) {
+      data.boardingPromptOriginStation = boardingPrompt.originStation;
+    }
+    if (boardingPrompt.line) {
+      data.boardingPromptLine = boardingPrompt.line;
     }
   }
 

--- a/targets/subway-widget/_shared/SubwayActivityAttributes.swift
+++ b/targets/subway-widget/_shared/SubwayActivityAttributes.swift
@@ -40,6 +40,12 @@ struct SubwayActivityAttributes: ActivityAttributes {
         // 데이터 출처 자백 라벨 (#327). JS에서 i18n으로 빌드된 사용자 노출 텍스트.
         // 누락 시 위젯은 라벨 표시 생략 — 기존 LA 인스턴스 호환 안전.
         var sourceLabel: String?
+        // #2434 — LA interactive prompt piece ①. 순수 데이터 필드만 (버튼/AppIntent는 후속 piece).
+        // 전부 optional이라 기존 LA 세션(구 ContentState)이 decode 시 missing key → nil로 안전.
+        var boardingPhase: String?
+        var boardingPromptTripToken: String?
+        var boardingPromptOriginStation: String?
+        var boardingPromptLine: String?
     }
 }
 


### PR DESCRIPTION
## Summary
- LA interactive prompt (iOS17 버튼/AppIntent) 전체 plan의 **piece ①** — 순수 데이터 배선만
- `SubwayActivityAttributes.ContentState`에 optional 필드 4종 추가: `boardingPhase`, `boardingPromptTripToken`, `boardingPromptOriginStation`, `boardingPromptLine`
- TS `LiveActivityData` 인터페이스 동기 + `buildLiveActivityData`에 optional `boardingPrompt` 파라미터 추가
- 렌더(`SubwayLiveActivityWidget.swift`/`SubwayWidget.swift` UI)는 이 PR에서 변경 없음 — nil이라 어차피 표시 안 됨. 버튼/AppIntent/lifecycle은 후속 piece(②~⑥)

## Wire-completion 5단
1. **Orphan 없음** — 신규 필드는 기존 export(`buildLiveActivityData`, `LiveActivityData`)의 확장. `npm run lint:orphan` pass
2. **V/X dashboard** — 이 PR 단독으로는 UI 미노출(nil → 렌더 X). 필드가 실제로 채워지는 시점(후속 piece)에 DebugModal/실기기에서 관측 가능
3. **의존 PR** — N/A. 독립적으로 머지 가능, 후속 piece가 이 PR에 의존
4. **측정 plan** — 코드 레벨 hard gate: JS test(`buildLiveActivityData`가 새 필드 직렬화/미전달 시 undefined) + type-check + orphan
5. **Device verify** — 기존 LA 세션이 신규 optional 필드 추가 후에도 크래시 없이 기존대로 렌더되는지 1회 확인 필요. Codable 하위호환 근거: 4개 필드 모두 `String?` optional이라 구 ContentState(필드 미보유) decode 시 missing key → nil로 안전 처리됨 (Swift `Codable` 표준 동작)

## Test plan
- [x] `npx jest src/features/alarm/utils/__tests__/stationNotification.test.ts` — 128/128 pass (신규 6 케이스 포함: 미전달/null/phase 단독/전체 필드/기존 호출자 시그니처 유지)
- [x] `npx jest modules/live-activity/__tests__` — pass
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — no orphan exports
- [ ] Device verify (사용자) — 기존 LA 실행 중 앱 업데이트 후 크래시/렌더 이상 없는지 1회 확인

Closes #2434

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9