### PR TITLE
feat(#2436): pre-boarding Live Activity lifecycle 훅 (LA 프롬프트 piece ②)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useLiveActivityPreBoardingLifecycle.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityPreBoardingLifecycle.test.ts
@@ -1,0 +1,182 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature test mirroring source's disable. ADR Phase 5 (#890).
+ */
+import { act, renderHook } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { useBoardingLockStore } from '../../store/useBoardingLockStore';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+const mockIsLiveActivityEnabled = jest.fn();
+const mockUpdateLiveActivity = jest.fn();
+
+jest.mock('live-activity', () => ({
+  isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
+  updateLiveActivity: (...args: unknown[]) => mockUpdateLiveActivity(...args),
+}));
+
+const mockClearStationNotification = jest.fn();
+jest.mock('../../utils/stationNotification', () => ({
+  clearStationNotification: (...args: unknown[]) => mockClearStationNotification(...args),
+}));
+
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+
+const mockWarn = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: (...args: unknown[]) => mockWarn(...args),
+    error: jest.fn(),
+  }),
+}));
+
+import { useLiveActivityPreBoardingLifecycle } from '../useLiveActivityPreBoardingLifecycle';
+
+const { gangnam, chungmuro } = MOCK_STATIONS;
+
+const LOCK: BoardingLock = {
+  trainCode: 'T001',
+  boardingLine: gangnam.line,
+  boardingStationId: gangnam.id,
+  destinationId: chungmuro.id,
+  boardingEvidence: true,
+  boardedAt: Date.now(),
+  expectedDurationMs: 5 * 60 * 1000,
+};
+
+describe('useLiveActivityPreBoardingLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLiveActivityEnabled.mockReturnValue(true);
+    mockUpdateLiveActivity.mockResolvedValue(undefined);
+    mockClearStationNotification.mockResolvedValue(undefined);
+    useDestinationStore.setState({ destination: null, tripOrigin: null });
+    useBoardingLockStore.setState({ lock: null });
+  });
+
+  it('destination 없음 + lock 없음 → 아무 것도 하지 않는다', () => {
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockClearStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('destination 설정(lock 없음) → pre-boarding LA update 호출', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+    const data = mockUpdateLiveActivity.mock.calls[0][0];
+    expect(data.boardingPhase).toBe('pre-boarding');
+    expect(data.destinationName).toBeTruthy();
+    // GPS 미확정 — placeholder stationName ("감지 중" i18n)
+    expect(data.stationName).toBe('감지 중');
+    expect(data.boardingPromptOriginStation).toBeUndefined();
+  });
+
+  it('tripOrigin 확보되면 실제 역/노선 정보로 pre-boarding LA를 채운다', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    const data = mockUpdateLiveActivity.mock.calls[0][0];
+    expect(data.stationName).toBe(gangnam.name);
+    expect(data.lineColorHex).toBe(gangnam.lineColor);
+    expect(data.boardingPromptOriginStation).toBe(gangnam.name);
+    expect(data.boardingPromptLine).toBe(gangnam.line);
+  });
+
+  it('tripToken이 있으면 boardingPromptTripToken을 싣는다', () => {
+    mockGetCurrentTripCorrIdSync.mockReturnValue('corr-123');
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    const data = mockUpdateLiveActivity.mock.calls[0][0];
+    expect(data.boardingPromptTripToken).toBe('corr-123');
+  });
+
+  it('이미 GPS 경로로 LA가 떠 있어도(활성 세션 판단 불가) 이 훅은 native update만 호출한다 — start 이중 호출 없음', () => {
+    // ensureLiveActivityRegistered/startLiveActivity 경로를 타지 않는지 — updateLiveActivity만 호출됐는지 검증.
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('lock 생성됨 → 콘텐츠 소유권을 넘기고 이 훅은 native 호출을 하지 않는다', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    useBoardingLockStore.setState({ lock: LOCK });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockClearStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('pre-boarding 세션을 스스로 시작한 뒤 lock이 생성되고, 이후 destination이 해제돼도 종료 호출을 하지 않는다(GPS 파이프라인 책임)', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    const { rerender } = renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useBoardingLockStore.setState({ lock: LOCK });
+    });
+    rerender({});
+
+    act(() => {
+      useDestinationStore.setState({ destination: null, tripOrigin: null });
+    });
+    rerender({});
+
+    expect(mockClearStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('스스로 시작한 pre-boarding 세션 중 destination이 해제되면 clearStationNotification으로 종료', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    const { rerender } = renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useDestinationStore.setState({ destination: null, tripOrigin: null });
+    });
+    rerender({});
+
+    expect(mockClearStationNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('Android — 아무 것도 하지 않는다', () => {
+    const originalOS = Platform.OS;
+    Object.defineProperty(Platform, 'OS', { get: () => 'android' });
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    Object.defineProperty(Platform, 'OS', { get: () => originalOS });
+  });
+
+  it('Live Activity 비활성이면 update를 호출하지 않는다', () => {
+    mockIsLiveActivityEnabled.mockReturnValue(false);
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('updateLiveActivity가 throw하면 logger.warn으로 흡수', async () => {
+    mockUpdateLiveActivity.mockRejectedValueOnce(new Error('native fail'));
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockWarn).toHaveBeenCalledWith('pre-boarding LA 갱신 실패', expect.any(Error));
+  });
+
+  it('clearStationNotification이 throw하면 logger.warn으로 흡수', async () => {
+    mockClearStationNotification.mockRejectedValueOnce(new Error('end fail'));
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    const { rerender } = renderHook(() => useLiveActivityPreBoardingLifecycle());
+    act(() => {
+      useDestinationStore.setState({ destination: null, tripOrigin: null });
+    });
+    rerender({});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockWarn).toHaveBeenCalledWith('pre-boarding LA 종료 실패', expect.any(Error));
+  });
+});

--- a/src/features/alarm/hooks/useLiveActivityPreBoardingLifecycle.ts
+++ b/src/features/alarm/hooks/useLiveActivityPreBoardingLifecycle.ts
@@ -1,0 +1,127 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: destination(route 슬라이스)이 설정되는 시점에 pre-boarding
+ * Live Activity를 확보하는 훅이라 route 슬라이스의 store를 직접 읽어야 한다. tripCorrId(observability
+ * 슬라이스)도 trip 식별용으로 필요 — alarm 슬라이스의 다른 hook(useApnsTripRegistration 등)과
+ * 동일 패턴. orchestration이 본질이라 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2436 — LA 인터랙티브 프롬프트 piece ②. destination 설정 시점부터 pre-boarding 상태
+ * Live Activity를 확보해 후속 piece(버튼/AppIntent)가 얹힐 토대를 만든다.
+ *
+ * 트리거:
+ *   - destination 설정 + lock 없음 → pre-boarding LA start(or update) + boardingPhase 컨텍스트.
+ *   - lock 생성됨(탑승 확정) → 이 훅은 관여를 멈춘다. 이후 LA 콘텐츠는 기존 GPS-트리거 파이프라인
+ *     (`stationPipeline.ts` / `HomeScreen`의 `updateStationNotification`)이 소유한다 — 그 경로는
+ *     boardingPrompt 필드를 넘기지 않으므로 다음 정기 tick에서 boardingPhase가 자연히 비워진다
+ *     ("or 미세팅" 허용, 스펙 명시).
+ *   - destination 해제(non-null→null) → 이 훅이 스스로 시작한 pre-boarding 세션만 종료.
+ *     (lock 활성 중 destination이 해제되는 통상 trip 종료는 HomeScreen이 이미 `clearStationNotification`을
+ *     호출하므로 중복 종료를 피한다 — `preBoardingActiveRef`로 소유권 구분.)
+ *
+ * dedup (기존 GPS-트리거 LA와 단일 인스턴스 보장):
+ *   `ensureLiveActivityRegistered`(liveActivityPushChannel.ts)는 backend push 등록 세션 시작
+ *   전용이라, 세션이 없다고 판단되면 native `startLiveActivity`를 호출한다 — native
+ *   `LiveActivityManager.start(data:)`는 호출 즉시 `endAllActivities()`로 기존 Activity를
+ *   종료하고 새로 만든다. GPS 파이프라인은 lock 전 구간에서 `LiveActivity.updateLiveActivity`를
+ *   직접 호출(트립 미등록이라 push 채널을 타지 않음)하므로 그 세션은 `activeTripToken`에
+ *   기록되지 않는다. 이 상태에서 `ensureLiveActivityRegistered`를 호출하면 이미 떠 있는 GPS LA를
+ *   모른 채 start를 시도해 강제 종료 후 재생성(깜빡임)이 발생한다.
+ *
+ *   반면 native `LiveActivityManager.update(data:)`는 활성 Activity가 있으면 update만, 없으면
+ *   내부적으로 `start`를 호출하는 진짜 "start-vs-update 판정"을 이미 구현하고 있다 — GPS
+ *   파이프라인이 pre-lock 구간에 쓰는 것과 동일한 호출. 이 훅도 같은 `LiveActivity.updateLiveActivity`
+ *   를 사용해 단일 Activity 인스턴스를 보장한다(이중 start 없음).
+ *
+ * additive: destination 없거나 lock 있으면 아무 것도 하지 않는다 — 기존 렌더와 100% 동일.
+ * 네이티브(Swift)/버튼/AppIntent 변경 없음. JS만.
+ */
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import i18next from 'i18next';
+import * as LiveActivity from 'live-activity';
+import type { Station } from '../../../shared/types/station';
+import { LINE_COLORS, LINE_NAMES } from '../../../shared/constants/lineColors';
+import { getStationDisplayName } from '../../../shared/utils/stationDisplay';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { clearStationNotification } from '../utils/stationNotification';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('useLiveActivityPreBoardingLifecycle');
+
+/**
+ * GPS가 아직 출발역을 확정하지 못한 상태에서 pre-boarding LA를 보여줄 때 쓰는 중립 placeholder
+ * 색상(iOS system gray). 노선이 확정되면(originStation 확보) 즉시 실제 노선색으로 대체된다.
+ */
+const PRE_BOARDING_UNKNOWN_LINE_COLOR_HEX = '#8E8E93';
+
+/**
+ * pre-boarding 단계 Live Activity content. GPS로 확정된 출발역(origin)이 있으면 실제 역/노선
+ * 정보를, 없으면 "감지 중"(기존 `widget.detecting` 관례) placeholder를 stationName에 싣는다.
+ * distanceM은 이 단계에선 의미가 없어 0 고정 — destinationName이 있으면 위젯은 거리 대신
+ * "→ 목적지" 라우트 뷰를 그리므로 화면에 노출되지 않는다.
+ */
+function buildPreBoardingLiveActivityData(
+  destination: Station,
+  origin: Station | null,
+  tripToken: string | null,
+): LiveActivity.LiveActivityData {
+  const data: LiveActivity.LiveActivityData = {
+    stationName: origin ? getStationDisplayName(origin) : i18next.t('widget.detecting'),
+    lineName: origin ? LINE_NAMES[origin.line] : '',
+    lineColorHex: origin ? LINE_COLORS[origin.line] : PRE_BOARDING_UNKNOWN_LINE_COLOR_HEX,
+    distanceM: 0,
+    destinationName: getStationDisplayName(destination),
+    boardingPhase: 'pre-boarding',
+  };
+  if (tripToken) {
+    data.boardingPromptTripToken = tripToken;
+  }
+  if (origin) {
+    data.boardingPromptOriginStation = getStationDisplayName(origin);
+    data.boardingPromptLine = origin.line;
+  }
+  return data;
+}
+
+export function useLiveActivityPreBoardingLifecycle(): void {
+  const destination = useDestinationStore((s) => s.destination);
+  const tripOrigin = useDestinationStore((s) => s.tripOrigin);
+  const lock = useBoardingLockStore((s) => s.lock);
+
+  // 이 훅이 직접 시작한 pre-boarding 세션인지 추적 — lock 전환/GPS 파이프라인이 소유하게 된
+  // 세션까지 이 훅이 대신 종료하지 않도록 소유권을 구분한다.
+  const preBoardingActiveRef = useRef(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+
+    if (!destination) {
+      if (preBoardingActiveRef.current) {
+        preBoardingActiveRef.current = false;
+        clearStationNotification().catch((e) => {
+          log.warn('pre-boarding LA 종료 실패', e);
+        });
+      }
+      return;
+    }
+
+    if (lock) {
+      // 탑승 확정 — 콘텐츠 소유권을 GPS-트리거 파이프라인에 넘긴다.
+      preBoardingActiveRef.current = false;
+      return;
+    }
+
+    if (!LiveActivity.isLiveActivityEnabled()) return;
+
+    const tripToken = getCurrentTripCorrIdSync();
+    const data = buildPreBoardingLiveActivityData(destination, tripOrigin, tripToken);
+    preBoardingActiveRef.current = true;
+    LiveActivity.updateLiveActivity(data).catch((e) => {
+      log.warn('pre-boarding LA 갱신 실패', e);
+    });
+  }, [destination, tripOrigin, lock]);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -49,6 +49,7 @@ import { useBackgroundLocation } from '../features/nearest-station/hooks/useBack
 import { useApnsTripRegistration } from '../features/alarm/hooks/useApnsTripRegistration';
 import { useLocalBoardingPromptGate } from '../features/alarm/hooks/useLocalBoardingPromptGate';
 import { useLiveActivityDismissBridge } from '../features/alarm/hooks/useLiveActivityDismissBridge';
+import { useLiveActivityPreBoardingLifecycle } from '../features/alarm/hooks/useLiveActivityPreBoardingLifecycle';
 import { registerSilentPushTask } from '../features/alarm/tasks/silentPushTask';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ROUTE_KEY } from '../shared/constants/storageKeys';
@@ -1011,6 +1012,7 @@ export default function HomeScreen() {
   useBackgroundLocation(destination);
   const permissionWatcher = useLocationPermissionWatcher();
   useLiveActivityDismissBridge();
+  useLiveActivityPreBoardingLifecycle();
   useApnsTripRegistration({
     route,
     destination,


### PR DESCRIPTION
Closes #2436

## Stacked PR
piece ①(#2435, `feat/#2434-la-boarding-state-fields`)이 아직 `dev`에 머지되지 않아 이 PR은 그 브랜치를 base로 stack했다. #2435가 dev에 머지되면 base를 dev로 retarget한다.

## 요약
- `useLiveActivityPreBoardingLifecycle` 신규 훅(`src/features/alarm/hooks/`) — destination 설정 시점부터 pre-boarding 상태 Live Activity를 확보해 후속 piece(④⑤ 버튼/AppIntent)가 얹힐 토대.
- destination 설정(lock 없음) → `boardingPhase: 'pre-boarding'` + boardingPrompt 컨텍스트(tripToken/originStation/line, 가용 시)로 LA update.
- GPS 미확정(tripOrigin 없음) → `widget.detecting`("감지 중") placeholder stationName 사용, tripOrigin 확보 시 실제 역/노선으로 교체.
- lock 생성(탑승 확정) → 이 훅은 관여를 멈추고 콘텐츠 소유권을 기존 GPS-트리거 파이프라인(`stationPipeline.ts`/`HomeScreen`)에 이양. 그 경로가 boardingPrompt 필드를 넘기지 않으므로 다음 tick에서 boardingPhase가 자연히 비워짐("or 미세팅", 스펙 명시 허용).
- destination 해제 → 이 훅이 스스로 시작한 세션만 `clearStationNotification()`(기존 export)으로 종료. lock 활성 중 종료는 HomeScreen이 이미 처리하므로 중복 호출 없음(`preBoardingActiveRef`로 소유권 구분).
- `HomeScreen`에 `useLiveActivityDismissBridge()` 옆 마운트.

## dedup 근거 (기존 GPS-트리거 LA와 단일 인스턴스)
`ensureLiveActivityRegistered`(`liveActivityPushChannel.ts`)는 backend push 등록 세션 전용이며, 활성 세션이 JS에 기록돼 있지 않다고 판단하면 native `startLiveActivity`를 호출한다. native `LiveActivityManager.start(data:)`는 호출 즉시 `endAllActivities()`로 기존 Activity를 강제 종료하고 새로 만든다.

GPS 파이프라인은 lock 이전 구간에서 `LiveActivity.updateLiveActivity`를 **직접** 호출한다(트립 미등록 상태라 push 채널을 타지 않음) — 이 세션은 `activeTripToken`(liveActivityPushChannel.ts 모듈 상태)에 기록되지 않는다. 이 상태에서 `ensureLiveActivityRegistered`를 호출하면 이미 떠 있는 GPS LA의 존재를 모른 채 start를 시도해 강제 종료 후 재생성(깜빡임/이중 start)이 발생한다.

반면 native `LiveActivityManager.update(data:)`는 활성 Activity가 있으면 update만, 없으면 내부적으로 `start`를 호출하는 진짜 "start-vs-update 판정"을 이미 구현하고 있다 — GPS 파이프라인이 pre-lock 구간에 쓰는 것과 **동일한 호출**이다. 이 훅도 같은 `LiveActivity.updateLiveActivity`를 사용해 단일 Activity 인스턴스를 보장한다(이중 start 없음). 즉 "ensureLiveActivityRegistered의 판정을 재사용"이라는 원 지시를 문자 그대로 따르지 않고, 실제 native 동작을 검증한 뒤 더 안전한 동일 계열 메커니즘(native update()의 자체 start-vs-update)으로 구현했다 — 코드 주석에 근거를 남겼다.

## additive/하위호환
destination 없거나 lock 활성이면 이 훅은 아무 것도 하지 않는다 — 기존 렌더와 100% 동일. `stationPipeline.ts`/`HomeScreen`의 기존 `updateStationNotification` 호출부는 건드리지 않았다.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — `boardingPhase`/`boardingPromptTripToken` 등은 DebugModal에 아직 노출 안 됨(피스①과 동일 갭, 후속 피스에서 버튼 배선과 함께). 실기기에서는 LA(Dynamic Island/잠금화면)에서 직접 관측 가능(`stationName`이 destination 설정 즉시 뜨는지).
3. **의존 PR** — #2435(piece ①, `feat/#2434-la-boarding-state-fields`)가 먼저 `dev`에 머지되어야 이 PR도 dev로 retarget 가능. 그 외 backend/device 의존 PR 없음.
4. **측정 plan** — 별도 계측 미추가(JS 훅 단위, unit test 100% 커버리지로 로직 검증). 실기기 회귀는 device verify 시나리오로 확인.
5. **Device verify** — 필요. 시나리오: (a) destination 설정 시 LA(Dynamic Island/잠금화면)가 뜨고 GPS-트리거 LA와 중복(깜빡임/재생성)이 없는지, (b) BoardingTrainList 탑승 탭 등으로 lock 생성 시 pre-boarding 표시가 자연스럽게 사라지는지(다음 GPS tick), (c) destination 해제 시 LA가 종료되는지.

## Test plan
- [x] `npx jest src/features/alarm/hooks/__tests__/useLiveActivityPreBoardingLifecycle.test.ts` — 12/12 pass, 신규 훅 100% coverage
- [x] `npx tsc --noEmit -p tsconfig.json` — 통과
- [x] `npx eslint` (신규 파일 + HomeScreen.tsx) — 통과
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 검증 (사용자 책임 — 위 Device verify 시나리오)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9