### PR TITLE
feat(#2439): LA 인터랙티브 프롬프트 piece ③+④+⑤-native — AppIntent 버튼 + App Group 브릿지

### DIFF
--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -104,6 +104,27 @@ export function clearWidgetStation(): Promise<void> {
   return LiveActivityModule?.clearWidgetStation() ?? Promise.resolve();
 }
 
+/**
+ * #2439 — LA 인터랙티브 프롬프트 piece ⑤-native. 잠금화면 버튼(BoardingConfirmIntent/
+ * DisembarkConfirmIntent, `targets/subway-widget/BoardingIntents.swift`)이 App Group
+ * (`group.com.subwaynow.app`, key `pendingBoardingIntent`)에 write한 raw JSON 문자열을 읽는다.
+ * 없으면 null. 파싱/도메인 처리(lock 생성 등)는 호출 측(⑤-JS) 책임 — 이 함수는 read-only 브릿지.
+ *
+ * value(JSON) 계약: `{ id, tripToken, action: "BOARDING_BOARDED" | "DISEMBARK_DISEMBARKED",
+ * originStation, line, atMs }`
+ */
+export function readPendingBoardingIntent(): string | null {
+  return LiveActivityModule?.readPendingBoardingIntent() ?? null;
+}
+
+/**
+ * 처리 완료한 pending intent를 제거. `id`가 저장된 값과 일치할 때만 제거되는 멱등 연산 —
+ * 이미 지워졌거나 그 사이 새 intent로 덮어써졌으면 native가 no-op 처리한다.
+ */
+export function clearPendingBoardingIntent(id: string): void {
+  LiveActivityModule?.clearPendingBoardingIntent(id);
+}
+
 const NOOP_SUBSCRIPTION: EventSubscription = { remove: () => undefined };
 
 export interface PushTokenEvent {

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -14,6 +14,11 @@ private let WIDGET_KEY_DESTINATION_NAME = "destinationName"
 private let WIDGET_KEY_NEXT_TRANSFER_NAME = "nextTransferName"
 private let WIDGET_KEY_TRIP_ACTIVE = "tripActive"
 
+// #2439 — LA 인터랙티브 프롬프트 piece ⑤-native. App Group 계약(⑤-JS 브릿지와 공유,
+// 정확히 일치해야 함). targets/subway-widget/BoardingIntents.swift의
+// PENDING_BOARDING_INTENT_KEY와 동일 리터럴 — 별도 컴파일 단위(pod)라 미러링한다.
+private let PENDING_BOARDING_INTENT_KEY = "pendingBoardingIntent"
+
 public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
@@ -120,6 +125,26 @@ public class LiveActivityModule: Module {
             if #available(iOS 14.0, *) {
                 WidgetCenter.shared.reloadAllTimelines()
             }
+        }
+
+        // #2439 — LA 잠금화면 버튼(BoardingConfirmIntent/DisembarkConfirmIntent, 위젯
+        // 익스텐션 프로세스)이 App Group에 write한 pending intent를 JS가 읽는다. 계약은
+        // BoardingIntents.swift 헤더 주석 참조. raw JSON 문자열을 그대로 반환 — 파싱은 JS 측 책임.
+        Function("readPendingBoardingIntent") { () -> String? in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return nil }
+            return defaults.string(forKey: PENDING_BOARDING_INTENT_KEY)
+        }
+
+        // id가 저장된 값과 일치할 때만 제거 — 멱등(이미 지워졌거나 그새 새 intent로 덮어써졌으면
+        // no-op). 새 intent를 실수로 지우는 race를 방지한다.
+        Function("clearPendingBoardingIntent") { (id: String) -> Void in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            guard let raw = defaults.string(forKey: PENDING_BOARDING_INTENT_KEY) else { return }
+            guard let jsonData = raw.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let storedId = json["id"] as? String,
+                  storedId == id else { return }
+            defaults.removeObject(forKey: PENDING_BOARDING_INTENT_KEY)
         }
     }
 }

--- a/targets/subway-widget/BoardingIntents.swift
+++ b/targets/subway-widget/BoardingIntents.swift
@@ -1,0 +1,145 @@
+#if os(iOS)
+import ActivityKit
+import AppIntents
+import Foundation
+
+// LA 인터랙티브 프롬프트 piece ③ (#2439). 잠금화면 Live Activity 버튼에서 직접 실행되는
+// AppIntent 2종. `LiveActivityIntent` 채택(iOS 17+)이 핵심 — 이 프로토콜을 채택한 intent는
+// 앱을 열지 않고 위젯 익스텐션 프로세스 안에서 곧바로 `perform()`이 실행된다. 그래서
+// 백그라운드/취침 중 앱이 완전히 정지된 상태에서도 버튼 탭이 cold-start race 없이 즉시 반영된다.
+//
+// App Group 계약(⑤-JS 브릿지와 공유, 정확히 일치해야 함):
+//   suite = "group.com.subwaynow.app" (modules/live-activity/ios/LiveActivityModule.swift의
+//           APP_GROUP과 동일 — 별도 pod 컴파일 단위라 리터럴을 미러링한다)
+//   key   = "pendingBoardingIntent" (LiveActivityModule.swift의 PENDING_BOARDING_INTENT_KEY와 동일)
+//   value(JSON) = { id, tripToken, action, originStation, line, atMs }
+//     - id: "<tripToken>-<atMs>" — clear 시 대조용
+//     - action: "BOARDING_BOARDED" | "DISEMBARK_DISEMBARKED"
+
+private let APP_GROUP = "group.com.subwaynow.app"
+private let PENDING_BOARDING_INTENT_KEY = "pendingBoardingIntent"
+private let ACTION_BOARDING_BOARDED = "BOARDING_BOARDED"
+private let ACTION_DISEMBARK_DISEMBARKED = "DISEMBARK_DISEMBARKED"
+
+/// boardingPhase enum 값(모듈 index.ts LiveActivityData.boardingPhase 타입과 동일 어휘 사용).
+/// 'pre-boarding' → 탑승 확인 버튼 탭 → 'boarded'. 'hop-end' → 하차 확인 버튼 탭 → 'arrival'.
+private let PHASE_BOARDED = "boarded"
+private let PHASE_ARRIVAL = "arrival"
+
+/// (b) App Group에 pending intent를 write — JS가 다음 foreground/폴링 시점에 읽어 lock 생성 등
+/// 실제 도메인 로직을 실행한다(이 파일은 상태 write만, 도메인 처리는 ⑤-JS 담당).
+@available(iOS 17.0, *)
+private func writePendingBoardingIntent(
+    action: String,
+    tripToken: String,
+    originStation: String,
+    line: String
+) {
+    guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+    let atMs = Date().timeIntervalSince1970 * 1000
+    let payload: [String: Any] = [
+        "id": "\(tripToken)-\(Int(atMs))",
+        "tripToken": tripToken,
+        "action": action,
+        "originStation": originStation,
+        "line": line,
+        "atMs": atMs,
+    ]
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+          let jsonString = String(data: jsonData, encoding: .utf8) else { return }
+    defaults.set(jsonString, forKey: PENDING_BOARDING_INTENT_KEY)
+}
+
+/// (a) 현재 추적 중인 Activity(들)의 boardingPhase를 즉시 전환 — 버튼 탭 즉시 시각 피드백.
+/// 아키텍처상 활성 Activity는 최대 1개(LiveActivityManager.endAllActivities)이므로 전수 update해도
+/// 안전하다.
+@available(iOS 17.0, *)
+private func markCurrentActivity(boardingPhase: String) async {
+    for activity in Activity<SubwayActivityAttributes>.activities {
+        var state = activity.content.state
+        state.boardingPhase = boardingPhase
+        await activity.update(ActivityContent(state: state, staleDate: nil))
+    }
+}
+
+/// pre-boarding 단계 "탑승하셨나요?" 버튼의 AppIntent.
+@available(iOS 17.0, *)
+struct BoardingConfirmIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "탑승 확인"
+    // Siri/Shortcuts 등 외부 진입점에 노출하지 않는다 — LA 버튼 전용 intent.
+    static var isDiscoverable: Bool = false
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "tripToken")
+    var tripToken: String
+
+    @Parameter(title: "originStation")
+    var originStation: String
+
+    @Parameter(title: "line")
+    var line: String
+
+    init() {
+        self.tripToken = ""
+        self.originStation = ""
+        self.line = ""
+    }
+
+    init(tripToken: String, originStation: String, line: String) {
+        self.tripToken = tripToken
+        self.originStation = originStation
+        self.line = line
+    }
+
+    func perform() async throws -> some IntentResult {
+        await markCurrentActivity(boardingPhase: PHASE_BOARDED)
+        writePendingBoardingIntent(
+            action: ACTION_BOARDING_BOARDED,
+            tripToken: tripToken,
+            originStation: originStation,
+            line: line
+        )
+        return .result()
+    }
+}
+
+/// hop-end 단계 "하차하셨나요?" 버튼의 AppIntent.
+@available(iOS 17.0, *)
+struct DisembarkConfirmIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "하차 확인"
+    static var isDiscoverable: Bool = false
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "tripToken")
+    var tripToken: String
+
+    @Parameter(title: "originStation")
+    var originStation: String
+
+    @Parameter(title: "line")
+    var line: String
+
+    init() {
+        self.tripToken = ""
+        self.originStation = ""
+        self.line = ""
+    }
+
+    init(tripToken: String, originStation: String, line: String) {
+        self.tripToken = tripToken
+        self.originStation = originStation
+        self.line = line
+    }
+
+    func perform() async throws -> some IntentResult {
+        await markCurrentActivity(boardingPhase: PHASE_ARRIVAL)
+        writePendingBoardingIntent(
+            action: ACTION_DISEMBARK_DISEMBARKED,
+            tripToken: tripToken,
+            originStation: originStation,
+            line: line
+        )
+        return .result()
+    }
+}
+#endif

--- a/targets/subway-widget/Localizable.xcstrings
+++ b/targets/subway-widget/Localizable.xcstrings
@@ -203,6 +203,122 @@
           }
         }
       }
+    },
+    "widget.boardingPrompt.boarded.question" : {
+      "comment" : "Live Activity boarding/disembark confirmation prompt",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Did you board?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗車しましたか?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탑승하셨나요?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您上车了吗?"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.boarded.button" : {
+      "comment" : "Confirm boarding button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Boarded"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗車した"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탑승했어요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已上车"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.disembark.question" : {
+      "comment" : "Live Activity boarding/disembark confirmation prompt",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Did you get off?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下車しましたか?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하차하셨나요?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您下车了吗?"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.disembark.button" : {
+      "comment" : "Confirm disembark button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got off"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下車した"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하차했어요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下车"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import ActivityKit
+import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -102,8 +103,15 @@ private struct LockScreenView: View {
     }
 
 
+    /// #2439 — pre-boarding/hop-end 단계는 "탑승/하차 확인" 프롬프트를 최우선 표시.
+    var isBoardingPrompt: Bool {
+        state.boardingPhase == "pre-boarding" || state.boardingPhase == "hop-end"
+    }
+
     var body: some View {
-        if isUrgent {
+        if isBoardingPrompt {
+            BoardingPromptView(state: state, phase: state.boardingPhase ?? "")
+        } else if isUrgent {
             // 긴급 모드
             HStack(spacing: 12) {
                 RoundedRectangle(cornerRadius: 4)
@@ -208,6 +216,76 @@ private struct LockScreenView: View {
                 Color.black.opacity(isLuminanceReduced ? 0.9 : 0.85)
                     .overlay(isLuminanceReduced ? lineColor.opacity(0.08) : Color.clear)
             )
+        }
+    }
+}
+
+/// #2439 — pre-boarding("탑승하셨나요?") / hop-end("하차하셨나요?") 프롬프트 배너.
+/// LA 자체는 16.1+ 유지 — 버튼만 iOS 17+ `@available` 가드로 분리해, 17 미만 기기는 텍스트만 본다.
+@available(iOS 16.1, *)
+private struct BoardingPromptView: View {
+    let state: SubwayActivityAttributes.ContentState
+    let phase: String
+
+    var questionKey: String {
+        phase == "pre-boarding"
+            ? "widget.boardingPrompt.boarded.question"
+            : "widget.boardingPrompt.disembark.question"
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(state.boardingPromptOriginStation ?? state.stationName)
+                    .font(.title3)
+                    .fontWeight(.black)
+                    .foregroundColor(.white)
+                Text(NSLocalizedString(questionKey, comment: "Live Activity boarding/disembark confirmation prompt"))
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white.opacity(0.85))
+            }
+
+            Spacer()
+
+            if #available(iOS 17.0, *) {
+                BoardingPromptButton(state: state, phase: phase)
+            }
+        }
+        .padding(16)
+        .background(Color.black.opacity(0.85))
+    }
+}
+
+/// AppIntent 버튼 자체는 iOS 17+ (`LiveActivityIntent`)에서만 렌더 — 17 미만은 위 텍스트만 노출.
+@available(iOS 17.0, *)
+private struct BoardingPromptButton: View {
+    let state: SubwayActivityAttributes.ContentState
+    let phase: String
+
+    var body: some View {
+        if phase == "pre-boarding" {
+            Button(intent: BoardingConfirmIntent(
+                tripToken: state.boardingPromptTripToken ?? "",
+                originStation: state.boardingPromptOriginStation ?? "",
+                line: state.boardingPromptLine ?? ""
+            )) {
+                Text(NSLocalizedString("widget.boardingPrompt.boarded.button", comment: "Confirm boarding button label"))
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+            }
+            .tint(.white)
+        } else {
+            Button(intent: DisembarkConfirmIntent(
+                tripToken: state.boardingPromptTripToken ?? "",
+                originStation: state.boardingPromptOriginStation ?? "",
+                line: state.boardingPromptLine ?? ""
+            )) {
+                Text(NSLocalizedString("widget.boardingPrompt.disembark.button", comment: "Confirm disembark button label"))
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+            }
+            .tint(.white)
         }
     }
 }


### PR DESCRIPTION
Closes #2439

## Summary
- `targets/subway-widget/BoardingIntents.swift` (신규): `BoardingConfirmIntent`/`DisembarkConfirmIntent` — `LiveActivityIntent`(iOS 17+) 채택으로 앱 cold-start 없이 위젯 익스텐션 프로세스에서 즉시 실행. `perform()`에서 (a) 현재 Activity의 `boardingPhase`를 즉시 `boarded`/`arrival`로 update, (b) App Group에 `pendingBoardingIntent`(JSON) write.
- `SubwayLiveActivityWidget.swift`: `boardingPhase`(`pre-boarding`/`hop-end`) 분기로 `BoardingPromptView` 추가. 버튼은 `@available(iOS 17.0, *)`(`BoardingPromptButton`) — 17 미만은 텍스트 프롬프트만, 버튼 없음. LA 자체는 16.1+ 그대로.
- `Localizable.xcstrings`: boarding/disembark question·button 4키 × ko/en/ja/zh-Hans.
- `LiveActivityModule.swift`: `readPendingBoardingIntent()`/`clearPendingBoardingIntent(id:)` native Function 추가. clear는 id 일치 시에만 제거하는 멱등 연산.
- `modules/live-activity/index.ts`: 위 두 함수 JS 타입 노출 (⑤-JS 브릿지 에이전트가 소비 — lock 생성 등 도메인 처리는 이 PR 범위 밖).

## App Group 계약 (⑤-JS 브릿지와 공유)
- suite: `group.com.subwaynow.app` (기존 재사용)
- key: `pendingBoardingIntent`
- value(JSON): `{ id, tripToken, action: "BOARDING_BOARDED" | "DISEMBARK_DISEMBARKED", originStation, line, atMs }`

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass. `modules/`는 기존 ignore pattern에 포함된 entry-point.
2. **V/X dashboard** — Swift는 device-only, CI 관측 불가. 실기기 검증 시 잠금화면 LA UI 직접 관찰 + Xcode console(`print`) 없음(신규 로직에 디버그 print 미추가, 필요 시 후속). App Group write는 `readPendingBoardingIntent()`를 device 콘솔/DebugModal에서 호출해 확인 가능.
3. **의존 PR** — base는 `feat/#2436-la-preboarding-lifecycle`(piece ②, dev 미머지). piece ①(#2434)도 미머지 스택. lock 생성 등 pending intent 소비 로직은 ⑤-JS 브릿지 PR(별도, 미생성)에 의존 — 그 PR 없이는 버튼 탭이 App Group write까지만 도달하고 실제 도메인 반영(lock 등)은 없음.
4. **측정 plan** — 이 PR 자체는 순수 native 배선이라 별도 회귀 측정 대상 없음. ⑤-JS 연결 후 실탑승에서 "버튼 탭 → lock 생성 → 이후 안내 정확도" 시나리오로 측정 예정.
5. **Device verify** — **REQUIRED, N/A 아님**. 실기기 잠금화면에서: (a) pre-boarding 단계 진입 시 "탑승하셨나요?" + 버튼 노출 확인, (b) 버튼 탭 → LA가 즉시 boarded 반영되는지, (c) `readPendingBoardingIntent()`로 App Group write 확인, (d) hop-end 단계 "하차하셨나요?" + 버튼 동일 검증, (e) iOS17 미만 시뮬레이터/기기에서 버튼 없이 텍스트만 뜨는지 fallback 확인.

## 검증
- `npm run type-check` pass
- `npm run lint:orphan` pass (0 orphan)
- `npx jest src/features/alarm` — 3500 passed (관련 기존 테스트 전부 green, 이 PR은 Swift-only라 JS 로직 회귀 없음)
- Swift는 CI 밖 — 컴파일 가능성은 문법/시그니처 정확성으로 담보. 빌드는 사용자 실기기 책임.

머지는 보류합니다 (사용자 결정).