### PR TITLE
feat(#2438): LA 인터랙티브 프롬프트 piece ⑤-JS+⑥ — 버튼 탭 → lock 배선 + fallback dedup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ import {
   setupTripEndedCategory,
 } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
+import { useLiveActivityIntentBridge } from '../src/features/alarm/hooks/useLiveActivityIntentBridge';
 import { useAlarmEndTripResponder } from '../src/features/alarm/hooks/useAlarmEndTripResponder';
 import { useBoardingPromptDisplayLogger } from '../src/features/alarm/hooks/useBoardingPromptDisplayLogger';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
@@ -153,6 +154,16 @@ function RootContent() {
   // 마운트 — payload만 들어오면 silence POST는 동작.
   // #1888 (RC-13) — banner를 직접 탭한 경우 home 화면으로 navigate해 BoardingTrainList를 노출.
   useBoardingPromptResponder({
+    fetchArrivalsForStation: (stationName) => fetchArrivalInfo(stationName),
+    destinationId,
+    expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
+    onBannerTap: requestNavigate,
+  });
+
+  // #2438 — LA(Live Activity) 버튼 탭 → App Group pending intent를 위 responder와 동일한
+  // handleResponse 경로로 위임. deps shape은 useBoardingPromptResponder와 동일해 두 채널이
+  // 같은 lock 생성/해제 컨텍스트를 공유한다(⑥ dedup은 훅 내부에서 active lock 존재로 판단).
+  useLiveActivityIntentBridge({
     fetchArrivalsForStation: (stationName) => fetchArrivalInfo(stationName),
     destinationId,
     expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -151,3 +151,20 @@ export function addActivityDismissedListener(
     LiveActivityModule?.addListener('onActivityDismissed', listener) ?? NOOP_SUBSCRIPTION
   );
 }
+
+/**
+ * #2438 (LA 인터랙티브 프롬프트 piece ⑤) — AppIntent(LA 버튼 탭)가 App Group에 write한
+ * pending boarding intent를 읽는다. JSON 문자열(`{ id, tripToken, action, originStation,
+ * line, atMs }`) 또는 미존재/모듈 미지원 시 null.
+ */
+export function readPendingBoardingIntent(): Promise<string | null> {
+  return LiveActivityModule?.readPendingBoardingIntent() ?? Promise.resolve(null);
+}
+
+/**
+ * #2438 — 처리 완료한 pending boarding intent를 App Group에서 clear. 멱등(같은 id
+ * 재호출 안전) — 모듈 미지원 환경은 no-op.
+ */
+export function clearPendingBoardingIntent(id: string): Promise<void> {
+  return LiveActivityModule?.clearPendingBoardingIntent(id) ?? Promise.resolve();
+}

--- a/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
@@ -1,0 +1,311 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration 테스트 — 대상 훅과 동일 사유로 옵트인.
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import { renderHook } from '@testing-library/react-native';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+const mockReadPendingBoardingIntent = jest.fn();
+const mockClearPendingBoardingIntent = jest.fn();
+jest.mock('live-activity', () => ({
+  readPendingBoardingIntent: (...args: unknown[]) =>
+    mockReadPendingBoardingIntent(...args),
+  clearPendingBoardingIntent: (...args: unknown[]) =>
+    mockClearPendingBoardingIntent(...args),
+}));
+
+const mockHandleResponse = jest.fn();
+jest.mock('../useBoardingPromptResponder', () => ({
+  handleResponse: (...args: unknown[]) => mockHandleResponse(...args),
+}));
+
+let capturedPollCallback: (() => void) | null = null;
+jest.mock('../../../../shared/hooks/usePolling', () => ({
+  usePolling: (cb: () => void) => {
+    capturedPollCallback = cb;
+  },
+}));
+
+const mockFindStationByNameAndLine = jest.fn();
+jest.mock('../../../../shared/utils/stationLookup', () => ({
+  findStationByNameAndLine: (...args: unknown[]) =>
+    mockFindStationByNameAndLine(...args),
+}));
+
+const mockCreateLock = jest.fn();
+let mockLock: BoardingLock | null = null;
+jest.mock('../../store/useBoardingLockStore', () => {
+  const selectorFn = Object.assign(
+    (selector: (state: { createLock: jest.Mock; lock: unknown }) => unknown) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock 캡처 변수 접근
+      selector({ createLock: mockCreateLock, lock: (globalThis as any).__mockLock ?? null }),
+    {
+      getState: () => ({
+        createLock: mockCreateLock,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        lock: (globalThis as any).__mockLock ?? null,
+      }),
+    },
+  );
+  return { useBoardingLockStore: selectorFn };
+});
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import {
+  parsePendingBoardingIntent,
+  useLiveActivityIntentBridge,
+} from '../useLiveActivityIntentBridge';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  DISEMBARK_ACTION_DISEMBARKED,
+} from '../../utils/notificationCategory';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g = globalThis as any;
+
+function setMockLock(lock: BoardingLock | null): void {
+  mockLock = lock;
+  g.__mockLock = lock;
+}
+
+const baseDeps = {
+  fetchArrivalsForStation: jest.fn(),
+  destinationId: 'dest-1',
+  expectedDurationMs: 30 * 60_000,
+};
+
+const validBoardedRaw = JSON.stringify({
+  id: 'trip-1-100',
+  tripToken: 'trip-1',
+  action: 'BOARDING_BOARDED',
+  originStation: '군자',
+  line: '5',
+  atMs: 100,
+});
+
+const validDisembarkRaw = JSON.stringify({
+  id: 'trip-1-200',
+  tripToken: 'trip-1',
+  action: 'DISEMBARK_DISEMBARKED',
+  originStation: '군자',
+  line: '5',
+  atMs: 200,
+});
+
+describe('parsePendingBoardingIntent', () => {
+  it('유효한 JSON을 파싱한다', () => {
+    expect(parsePendingBoardingIntent(validBoardedRaw)).toEqual({
+      id: 'trip-1-100',
+      tripToken: 'trip-1',
+      action: 'BOARDING_BOARDED',
+      originStation: '군자',
+      line: '5',
+      atMs: 100,
+    });
+  });
+
+  it('malformed JSON → null', () => {
+    expect(parsePendingBoardingIntent('not-json{')).toBeNull();
+  });
+
+  it('object가 아님 → null', () => {
+    expect(parsePendingBoardingIntent('123')).toBeNull();
+  });
+
+  it.each([
+    ['id', { ...JSON.parse(validBoardedRaw), id: '' }],
+    ['tripToken', { ...JSON.parse(validBoardedRaw), tripToken: undefined }],
+    ['action', { ...JSON.parse(validBoardedRaw), action: 'UNKNOWN' }],
+    ['originStation', { ...JSON.parse(validBoardedRaw), originStation: 1 }],
+    ['line', { ...JSON.parse(validBoardedRaw), line: null }],
+    ['atMs', { ...JSON.parse(validBoardedRaw), atMs: 'not-a-number' }],
+  ])('필드 %s 누락/타입불일치 → null', (_field, payload) => {
+    expect(parsePendingBoardingIntent(JSON.stringify(payload))).toBeNull();
+  });
+});
+
+describe('useLiveActivityIntentBridge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedPollCallback = null;
+    setMockLock(null);
+    mockCreateLock.mockReset();
+    mockFindStationByNameAndLine.mockReset();
+    mockHandleResponse.mockResolvedValue(undefined);
+    mockClearPendingBoardingIntent.mockResolvedValue(undefined);
+  });
+
+  it('마운트 시 pending intent를 1회 확인한다', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    expect(mockReadPendingBoardingIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it('pending 없음(null) → handleResponse/clear 호출 안 함', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).not.toHaveBeenCalled();
+    expect(mockClearPendingBoardingIntent).not.toHaveBeenCalled();
+  });
+
+  it('malformed pending → handleResponse/clear 호출 안 함', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue('not-json{');
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).not.toHaveBeenCalled();
+    expect(mockClearPendingBoardingIntent).not.toHaveBeenCalled();
+  });
+
+  it('readPendingBoardingIntent 실패 → throw 없이 흡수', async () => {
+    mockReadPendingBoardingIntent.mockRejectedValue(new Error('native error'));
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).not.toHaveBeenCalled();
+  });
+
+  it('lock 없음 + BOARDING_BOARDED → handleResponse(BOARDED) 호출 후 clear', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledWith(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      expect.objectContaining({
+        kind: 'boarding-prompt',
+        originStation: '군자',
+        line: '5',
+        tripToken: 'trip-1',
+        hopEndKind: undefined,
+      }),
+      expect.objectContaining({ ...baseDeps, createLock: mockCreateLock }),
+    );
+    expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-100');
+  });
+
+  it('DISEMBARK_DISEMBARKED → handleResponse(DISEMBARKED, hopEndKind=disembark) 호출 후 clear', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(validDisembarkRaw);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledWith(
+      DISEMBARK_ACTION_DISEMBARKED,
+      expect.objectContaining({ hopEndKind: 'disembark' }),
+      expect.anything(),
+    );
+    expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-200');
+  });
+
+  it('clearPendingBoardingIntent 실패 → throw 없이 흡수', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+    mockClearPendingBoardingIntent.mockRejectedValue(new Error('clear failed'));
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+  });
+
+  describe('⑥ dedup — 동일 origin/line active lock 존재 시 no-op', () => {
+    const activeLock: BoardingLock = {
+      destinationId: 'dest-1',
+      trainCode: 'T1',
+      boardingStationId: 'stn-군자-5',
+      boardingLine: '5',
+      boardedAt: Date.now(),
+      expectedDurationMs: 30 * 60_000,
+      boardingEvidence: false,
+    };
+
+    it('같은 boardingStationId/line → handleResponse skip, clear는 호출', async () => {
+      setMockLock(activeLock);
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).not.toHaveBeenCalled();
+      expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-100');
+    });
+
+    it('lock 만료됨 → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock({ ...activeLock, boardedAt: Date.now() - 100 * 60_000 });
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('line 불일치 → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock({ ...activeLock, boardingLine: '2' });
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('station 매칭 실패(다른 역) → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock(activeLock);
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-다른역-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('station lookup이 null → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock(activeLock);
+      mockFindStationByNameAndLine.mockReturnValue(null);
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('DISEMBARK 액션은 dedup 체크 대상 아님 — lock 있어도 handleResponse 호출', async () => {
+      setMockLock(activeLock);
+      mockReadPendingBoardingIntent.mockResolvedValue(validDisembarkRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('foreground 폴링 콜백이 등록되고 재호출 시 재확인한다', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    expect(capturedPollCallback).not.toBeNull();
+    mockReadPendingBoardingIntent.mockClear();
+    capturedPollCallback!();
+    await Promise.resolve();
+    expect(mockReadPendingBoardingIntent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
+++ b/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
@@ -1,0 +1,178 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: LA 버튼 탭(App Group pending intent)을 기존
+ * `useBoardingPromptResponder`의 lock 생성/해제 로직에 연결하는 orchestrator라 여러 features의
+ * store/hook을 직접 조합하는 게 본질적이다. Phase 5 enforce 모드에서 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2438 — LA 인터랙티브 프롬프트 piece ⑤(JS) + ⑥(dedup).
+ *
+ * native(③④⑤-native, 병렬 진행)의 AppIntent가 LA 버튼 탭 시 App Group에 pending boarding
+ * intent를 write한다. 이 훅은 그 intent를 읽어 `useBoardingPromptResponder.handleResponse`
+ * (알림 [탑승]/[하차했어요] 액션과 동일한 lock 생성/해제 로직)로 그대로 위임한다 — 신규 lock
+ * 로직을 만들지 않고 기존 tryAutoLock/createPendingFallbackLock/dedup/의향 stamp를 재사용한다.
+ *
+ * App Group 계약 (native와 공유):
+ *   `readPendingBoardingIntent(): Promise<string | null>` → JSON 문자열 또는 pending 없음/모듈
+ *   미지원 시 null. `{ id, tripToken, action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED',
+ *   originStation, line, atMs }`.
+ *   `clearPendingBoardingIntent(id)` → 처리 후 호출(멱등) — 재폴링/재부팅 중복 처리 방지.
+ *
+ * 트리거: 마운트 + AppState 'active' 진입 + foreground 유지 중 짧은 폴링
+ * (`LIVE_ACTIVITY_INTENT_POLL_MS`) — native가 push event 없이 App Group write만 하는 pull
+ * 모델이라 재확인이 필요하다.
+ *
+ * ⑥ dedup — 알림 [탑승] 액션과 LA 버튼 둘 다 최종적으로 이 경로(`tryAutoLock` → `createLock`)로
+ * 수렴한다. `createLock`은 호출 즉시 기존 lock을 교체하므로(store 자체엔 dedup이 없음), 같은
+ * boarding 역/노선에 이미 active lock이 있으면 LA intent 처리를 no-op으로 skip해 이중 lock
+ * 생성(같은 trip을 두 번 잠그며 `initialEtaSeconds` 등 스냅샷을 덮어쓰는 것)을 막는다.
+ * hop-end(DISEMBARK) 액션은 `releaseLock`이 이미 멱등이라 별도 가드가 필요 없다.
+ */
+import { useCallback, useEffect } from 'react';
+import {
+  clearPendingBoardingIntent,
+  readPendingBoardingIntent,
+} from 'live-activity';
+import { usePolling } from '../../../shared/hooks/usePolling';
+import { LIVE_ACTIVITY_INTENT_POLL_MS } from '../../../shared/constants/boardingLock';
+import { isBoardingLockExpired } from '../../../shared/types/boardingLock';
+import { isValidLineNumber } from '../../../shared/constants/lineApiNames';
+import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  DISEMBARK_ACTION_DISEMBARKED,
+} from '../utils/notificationCategory';
+import {
+  handleResponse,
+  type BoardingPromptPayload,
+  type UseBoardingPromptResponderDeps,
+} from './useBoardingPromptResponder';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('liveActivityIntentBridge');
+
+/** App Group pending boarding intent — native AppIntent가 write하는 schema. */
+export interface PendingBoardingIntent {
+  id: string;
+  tripToken: string;
+  action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED';
+  originStation: string;
+  line: string;
+  atMs: number;
+}
+
+const VALID_ACTIONS: readonly PendingBoardingIntent['action'][] = [
+  'BOARDING_BOARDED',
+  'DISEMBARK_DISEMBARKED',
+];
+
+/**
+ * `readPendingBoardingIntent()`가 반환한 raw JSON 문자열을 파싱 + 검증한다.
+ * 파싱 실패 또는 필수 필드 누락/타입 불일치는 null — caller가 graceful skip.
+ */
+export function parsePendingBoardingIntent(raw: string): PendingBoardingIntent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const o = parsed as Record<string, unknown>;
+  if (typeof o.id !== 'string' || o.id.length === 0) return null;
+  if (typeof o.tripToken !== 'string' || o.tripToken.length === 0) return null;
+  if (typeof o.action !== 'string' || !VALID_ACTIONS.includes(o.action as never)) return null;
+  if (typeof o.originStation !== 'string' || o.originStation.length === 0) return null;
+  if (typeof o.line !== 'string' || o.line.length === 0) return null;
+  if (typeof o.atMs !== 'number') return null;
+  return {
+    id: o.id,
+    tripToken: o.tripToken,
+    action: o.action as PendingBoardingIntent['action'],
+    originStation: o.originStation,
+    line: o.line,
+    atMs: o.atMs,
+  };
+}
+
+interface BridgeDeps extends UseBoardingPromptResponderDeps {
+  createLock: ReturnType<typeof useBoardingLockStore.getState>['createLock'];
+}
+
+/**
+ * #2438 ⑥ — 이미 같은 탑승역/노선으로 active lock이 있으면 true(중복 boarding intent).
+ * 알림 [탑승] 액션이 먼저 처리돼 lock이 생성된 뒤 LA 버튼(같은 트립)이 뒤이어 도착하는
+ * 케이스, 또는 그 반대 순서 모두 이 체크로 흡수한다.
+ */
+function isDuplicateBoardingIntent(intent: PendingBoardingIntent): boolean {
+  const lock = useBoardingLockStore.getState().lock;
+  if (!lock) return false;
+  if (isBoardingLockExpired(lock, Date.now())) return false;
+  if (!isValidLineNumber(intent.line) || lock.boardingLine !== intent.line) return false;
+  const station = findStationByNameAndLine(intent.originStation, intent.line);
+  return station !== null && station.id === lock.boardingStationId;
+}
+
+async function processPendingBoardingIntent(deps: BridgeDeps): Promise<void> {
+  let raw: string | null;
+  try {
+    raw = await readPendingBoardingIntent();
+  } catch (err) {
+    log.warn('readPendingBoardingIntent 실패', err as Error);
+    return;
+  }
+  if (!raw) return;
+
+  const intent = parsePendingBoardingIntent(raw);
+  if (!intent) {
+    log.warn('pending boarding intent 파싱 실패 — malformed payload');
+    return;
+  }
+
+  if (intent.action === 'BOARDING_BOARDED' && isDuplicateBoardingIntent(intent)) {
+    log.info('duplicate boarding intent — active lock already exists, no-op');
+  } else {
+    const payload: BoardingPromptPayload = {
+      kind: 'boarding-prompt',
+      originStation: intent.originStation,
+      line: intent.line,
+      tripToken: intent.tripToken,
+      hopEndKind: intent.action === 'DISEMBARK_DISEMBARKED' ? 'disembark' : undefined,
+    };
+    const actionIdentifier =
+      intent.action === 'DISEMBARK_DISEMBARKED'
+        ? DISEMBARK_ACTION_DISEMBARKED
+        : BOARDING_PROMPT_ACTION_BOARDED;
+    await handleResponse(actionIdentifier, payload, deps);
+  }
+
+  try {
+    await clearPendingBoardingIntent(intent.id);
+  } catch (err) {
+    log.warn('clearPendingBoardingIntent 실패', err as Error);
+  }
+}
+
+/**
+ * 마운트 + AppState 'active' 진입 + foreground 폴링 시 App Group pending boarding intent를
+ * 확인해 기존 boarding-prompt 응답 로직으로 위임한다. `deps`는 `useBoardingPromptResponder`와
+ * 동일한 shape — caller(app/_layout.tsx)가 같은 값을 주입해 두 채널이 동일 컨텍스트를 공유한다.
+ */
+export function useLiveActivityIntentBridge(deps: UseBoardingPromptResponderDeps): void {
+  const createLock = useBoardingLockStore((s) => s.createLock);
+
+  // usePolling은 callback을 ref로 잡아 매 tick 최신 클로저를 실행하므로, deps가 caller
+  // 렌더마다 새 객체(app/_layout.tsx의 inline object)여도 run이 재생성되는 것과 무관하게
+  // interval 자체는 재시작되지 않는다.
+  const run = useCallback(() => {
+    void processPendingBoardingIntent({ ...deps, createLock });
+  }, [createLock, deps]);
+
+  useEffect(() => {
+    run();
+  }, [run]);
+
+  usePolling(run, LIVE_ACTIVITY_INTENT_POLL_MS);
+}

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -254,3 +254,18 @@ export const FALLBACK_LOCK_POSITION_GUARD_FRESHNESS_MS = 5 * 60_000;
  * 해당하며, 이 상수는 오직 "이미 등록된 trip"의 이후 변경에만 쓰인다.
  */
 export const ROUTE_CHANGE_DEBOUNCE_MS = 1500;
+
+/**
+ * #2438 (LA 인터랙티브 프롬프트 piece ⑤) — `useLiveActivityIntentBridge`가 App Group의
+ * pending boarding intent(LA 버튼 탭)를 foreground에서 재확인하는 짧은 폴링 주기(ms).
+ *
+ * native가 push event 없이 App Group write만 하는 pull 모델이라, 마운트 + AppState 'active'
+ * 진입 외에도 앱이 이미 foreground인 동안 버튼을 탭한 케이스(위젯/잠금화면에서 LA 버튼 탭 시
+ * 앱은 이미 열려 있을 수 있음)를 흡수하려면 짧은 재확인이 필요하다.
+ *
+ * 5s로 둔 이유: `usePolling`이 이미 AppState 'active' 진입 시 즉시 1회 재확인하므로, 이 값은
+ * "foreground 유지 중 버튼 탭"만 커버하면 된다 — 사용자가 버튼을 탭하고 화면을 계속 보고
+ * 있어도 5s 이내 lock이 반영되면 체감 지연이 크지 않다. 배터리 부담은 로컬 App Group 읽기
+ * 1회(AsyncStorage/UserDefaults 수준)라 무시할 만하다.
+ */
+export const LIVE_ACTIVITY_INTENT_POLL_MS = 5_000;


### PR DESCRIPTION
## Summary
Closes #2438

LA(Live Activity) 인터랙티브 프롬프트 스택의 JS 배선 piece ⑤(App Group pending intent → lock 배선) + ⑥(알림탭/LA버튼 이중 lock 방지).

- 신규 훅 `useLiveActivityIntentBridge`(`src/features/alarm/hooks/`): App Group pending boarding intent를 읽어 기존 `useBoardingPromptResponder.handleResponse`로 위임. **신규 lock 로직 없음** — 기존 `tryAutoLock`/`createPendingFallbackLock`/dedup/의향 stamp 전량 재사용.
- 트리거: 마운트 + AppState 'active' + foreground 짧은 폴링(`LIVE_ACTIVITY_INTENT_POLL_MS`=5s, `src/shared/constants/boardingLock.ts`) — native가 push event 없이 App Group write만 하는 pull 모델이라 재확인 필요.
- ⑥ dedup: 같은 `boardingStationId`/`boardingLine`으로 이미 active(비만료) lock이 있으면 `BOARDING_BOARDED` intent 처리를 no-op — 알림 [탑승] 액션과 LA 버튼이 같은 `createLock` 경로로 수렴하는데 `createLock` 자체엔 dedup이 없어(기존 lock을 그대로 교체) 이중 lock 생성을 막는다. `DISEMBARK_DISEMBARKED`는 `releaseLock`이 이미 멱등이라 별도 가드 불필요.
- `modules/live-activity/index.ts`에 `readPendingBoardingIntent`/`clearPendingBoardingIntent` JS wrapper 추가. **native Swift 함수는 이 PR에 없음** — 병렬 진행 중인 ③④⑤-native 에이전트가 추가 예정. 이 PR은 `jest.mock('live-activity', ...)`로 전부 mock 처리.
- `app/_layout.tsx`에 `useBoardingPromptResponder` 옆 동일 deps(`fetchArrivalsForStation`/`destinationId`/`expectedDurationMs`/`onBannerTap`)로 마운트.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인.
2. **V/X dashboard** — DebugModal의 기존 boardingPrompt 응답 로그(`logBoardingPromptAutoLock`/`logBoardingPromptResponded`)가 그대로 이 경로에도 찍힌다(handleResponse 재사용이라 신규 로그 불필요). LA 버튼 유래 여부는 breadcrumb `boarding_prompt_interactive_tap`(action 값)으로 구분 가능.
3. **의존 PR** — 이 PR은 native ③④⑤(AppIntent + `LiveActivityModule.readPendingBoardingIntent()`/`clearPendingBoardingIntent()` Swift 구현) PR과 병렬 진행 중인 별도 PR에 의존. 그 PR이 머지되기 전까지는 `requireOptionalNativeModule`이 해당 네이티브 함수를 찾지 못해 graceful no-op(null 반환)으로 동작 — 런타임 크래시 없음. base = `feat/#2436-la-preboarding-lifecycle`(②).
4. **측정 plan** — breadcrumb `boarding_prompt_interactive_tap`의 action 필드로 LA 버튼발 vs 알림 액션발 탑승 확정 비율 1주 관측. dedup 발동(no-op) 빈도는 향후 별도 로그 필요 시 후속.
5. **Device verify** — LA 버튼 탭 후 실제 lock 생성 + 알림탭/LA버튼 순차 사용 시 이중 lock 없음 확인 필요. native piece 머지 후에만 실기기 검증 가능(현재는 native 함수 부재로 no-op).

## Test plan
- [x] `npx jest src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts` — 23 tests, 100% coverage
- [x] `npx jest src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts src/features/alarm/hooks/__tests__/useLiveActivityPreBoardingLifecycle.test.ts` — 회귀 없음 (137 tests pass)
- [x] `npm run type-check` — 통과
- [x] `npm run lint:orphan` — 0 orphan
- [ ] Device verify — native piece 머지 후 실기기에서 LA 버튼 탭 → lock 생성 + 이중발사 없음 확인 (사용자 담당)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9