### PR TITLE
feat(#2442): LA ②③④⑤⑥ stacked dead-end 복구 — dev 통합 + index.ts 중복 해소

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ import {
   setupTripEndedCategory,
 } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
+import { useLiveActivityIntentBridge } from '../src/features/alarm/hooks/useLiveActivityIntentBridge';
 import { useAlarmEndTripResponder } from '../src/features/alarm/hooks/useAlarmEndTripResponder';
 import { useBoardingPromptDisplayLogger } from '../src/features/alarm/hooks/useBoardingPromptDisplayLogger';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
@@ -153,6 +154,16 @@ function RootContent() {
   // 마운트 — payload만 들어오면 silence POST는 동작.
   // #1888 (RC-13) — banner를 직접 탭한 경우 home 화면으로 navigate해 BoardingTrainList를 노출.
   useBoardingPromptResponder({
+    fetchArrivalsForStation: (stationName) => fetchArrivalInfo(stationName),
+    destinationId,
+    expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
+    onBannerTap: requestNavigate,
+  });
+
+  // #2438 — LA(Live Activity) 버튼 탭 → App Group pending intent를 위 responder와 동일한
+  // handleResponse 경로로 위임. deps shape은 useBoardingPromptResponder와 동일해 두 채널이
+  // 같은 lock 생성/해제 컨텍스트를 공유한다(⑥ dedup은 훅 내부에서 active lock 존재로 판단).
+  useLiveActivityIntentBridge({
     fetchArrivalsForStation: (stationName) => fetchArrivalInfo(stationName),
     destinationId,
     expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -172,20 +172,3 @@ export function addActivityDismissedListener(
     LiveActivityModule?.addListener('onActivityDismissed', listener) ?? NOOP_SUBSCRIPTION
   );
 }
-
-/**
- * #2438 (LA 인터랙티브 프롬프트 piece ⑤) — AppIntent(LA 버튼 탭)가 App Group에 write한
- * pending boarding intent를 읽는다. JSON 문자열(`{ id, tripToken, action, originStation,
- * line, atMs }`) 또는 미존재/모듈 미지원 시 null.
- */
-export function readPendingBoardingIntent(): Promise<string | null> {
-  return LiveActivityModule?.readPendingBoardingIntent() ?? Promise.resolve(null);
-}
-
-/**
- * #2438 — 처리 완료한 pending boarding intent를 App Group에서 clear. 멱등(같은 id
- * 재호출 안전) — 모듈 미지원 환경은 no-op.
- */
-export function clearPendingBoardingIntent(id: string): Promise<void> {
-  return LiveActivityModule?.clearPendingBoardingIntent(id) ?? Promise.resolve();
-}

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -172,3 +172,20 @@ export function addActivityDismissedListener(
     LiveActivityModule?.addListener('onActivityDismissed', listener) ?? NOOP_SUBSCRIPTION
   );
 }
+
+/**
+ * #2438 (LA 인터랙티브 프롬프트 piece ⑤) — AppIntent(LA 버튼 탭)가 App Group에 write한
+ * pending boarding intent를 읽는다. JSON 문자열(`{ id, tripToken, action, originStation,
+ * line, atMs }`) 또는 미존재/모듈 미지원 시 null.
+ */
+export function readPendingBoardingIntent(): Promise<string | null> {
+  return LiveActivityModule?.readPendingBoardingIntent() ?? Promise.resolve(null);
+}
+
+/**
+ * #2438 — 처리 완료한 pending boarding intent를 App Group에서 clear. 멱등(같은 id
+ * 재호출 안전) — 모듈 미지원 환경은 no-op.
+ */
+export function clearPendingBoardingIntent(id: string): Promise<void> {
+  return LiveActivityModule?.clearPendingBoardingIntent(id) ?? Promise.resolve();
+}

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -104,6 +104,27 @@ export function clearWidgetStation(): Promise<void> {
   return LiveActivityModule?.clearWidgetStation() ?? Promise.resolve();
 }
 
+/**
+ * #2439 — LA 인터랙티브 프롬프트 piece ⑤-native. 잠금화면 버튼(BoardingConfirmIntent/
+ * DisembarkConfirmIntent, `targets/subway-widget/BoardingIntents.swift`)이 App Group
+ * (`group.com.subwaynow.app`, key `pendingBoardingIntent`)에 write한 raw JSON 문자열을 읽는다.
+ * 없으면 null. 파싱/도메인 처리(lock 생성 등)는 호출 측(⑤-JS) 책임 — 이 함수는 read-only 브릿지.
+ *
+ * value(JSON) 계약: `{ id, tripToken, action: "BOARDING_BOARDED" | "DISEMBARK_DISEMBARKED",
+ * originStation, line, atMs }`
+ */
+export function readPendingBoardingIntent(): string | null {
+  return LiveActivityModule?.readPendingBoardingIntent() ?? null;
+}
+
+/**
+ * 처리 완료한 pending intent를 제거. `id`가 저장된 값과 일치할 때만 제거되는 멱등 연산 —
+ * 이미 지워졌거나 그 사이 새 intent로 덮어써졌으면 native가 no-op 처리한다.
+ */
+export function clearPendingBoardingIntent(id: string): void {
+  LiveActivityModule?.clearPendingBoardingIntent(id);
+}
+
 const NOOP_SUBSCRIPTION: EventSubscription = { remove: () => undefined };
 
 export interface PushTokenEvent {

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -14,6 +14,11 @@ private let WIDGET_KEY_DESTINATION_NAME = "destinationName"
 private let WIDGET_KEY_NEXT_TRANSFER_NAME = "nextTransferName"
 private let WIDGET_KEY_TRIP_ACTIVE = "tripActive"
 
+// #2439 — LA 인터랙티브 프롬프트 piece ⑤-native. App Group 계약(⑤-JS 브릿지와 공유,
+// 정확히 일치해야 함). targets/subway-widget/BoardingIntents.swift의
+// PENDING_BOARDING_INTENT_KEY와 동일 리터럴 — 별도 컴파일 단위(pod)라 미러링한다.
+private let PENDING_BOARDING_INTENT_KEY = "pendingBoardingIntent"
+
 public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
@@ -120,6 +125,26 @@ public class LiveActivityModule: Module {
             if #available(iOS 14.0, *) {
                 WidgetCenter.shared.reloadAllTimelines()
             }
+        }
+
+        // #2439 — LA 잠금화면 버튼(BoardingConfirmIntent/DisembarkConfirmIntent, 위젯
+        // 익스텐션 프로세스)이 App Group에 write한 pending intent를 JS가 읽는다. 계약은
+        // BoardingIntents.swift 헤더 주석 참조. raw JSON 문자열을 그대로 반환 — 파싱은 JS 측 책임.
+        Function("readPendingBoardingIntent") { () -> String? in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return nil }
+            return defaults.string(forKey: PENDING_BOARDING_INTENT_KEY)
+        }
+
+        // id가 저장된 값과 일치할 때만 제거 — 멱등(이미 지워졌거나 그새 새 intent로 덮어써졌으면
+        // no-op). 새 intent를 실수로 지우는 race를 방지한다.
+        Function("clearPendingBoardingIntent") { (id: String) -> Void in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            guard let raw = defaults.string(forKey: PENDING_BOARDING_INTENT_KEY) else { return }
+            guard let jsonData = raw.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let storedId = json["id"] as? String,
+                  storedId == id else { return }
+            defaults.removeObject(forKey: PENDING_BOARDING_INTENT_KEY)
         }
     }
 }

--- a/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
@@ -140,18 +140,18 @@ describe('useLiveActivityIntentBridge', () => {
     mockCreateLock.mockReset();
     mockFindStationByNameAndLine.mockReset();
     mockHandleResponse.mockResolvedValue(undefined);
-    mockClearPendingBoardingIntent.mockResolvedValue(undefined);
+    mockClearPendingBoardingIntent.mockReturnValue(undefined);
   });
 
   it('마운트 시 pending intent를 1회 확인한다', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    mockReadPendingBoardingIntent.mockReturnValue(null);
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     expect(mockReadPendingBoardingIntent).toHaveBeenCalledTimes(1);
   });
 
   it('pending 없음(null) → handleResponse/clear 호출 안 함', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    mockReadPendingBoardingIntent.mockReturnValue(null);
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     await Promise.resolve();
@@ -160,7 +160,7 @@ describe('useLiveActivityIntentBridge', () => {
   });
 
   it('malformed pending → handleResponse/clear 호출 안 함', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue('not-json{');
+    mockReadPendingBoardingIntent.mockReturnValue('not-json{');
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     await Promise.resolve();
@@ -169,7 +169,9 @@ describe('useLiveActivityIntentBridge', () => {
   });
 
   it('readPendingBoardingIntent 실패 → throw 없이 흡수', async () => {
-    mockReadPendingBoardingIntent.mockRejectedValue(new Error('native error'));
+    mockReadPendingBoardingIntent.mockImplementation(() => {
+      throw new Error('native error');
+    });
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     await Promise.resolve();
@@ -177,7 +179,7 @@ describe('useLiveActivityIntentBridge', () => {
   });
 
   it('lock 없음 + BOARDING_BOARDED → handleResponse(BOARDED) 호출 후 clear', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+    mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     await Promise.resolve();
@@ -197,7 +199,7 @@ describe('useLiveActivityIntentBridge', () => {
   });
 
   it('DISEMBARK_DISEMBARKED → handleResponse(DISEMBARKED, hopEndKind=disembark) 호출 후 clear', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue(validDisembarkRaw);
+    mockReadPendingBoardingIntent.mockReturnValue(validDisembarkRaw);
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     await Promise.resolve();
@@ -211,8 +213,10 @@ describe('useLiveActivityIntentBridge', () => {
   });
 
   it('clearPendingBoardingIntent 실패 → throw 없이 흡수', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
-    mockClearPendingBoardingIntent.mockRejectedValue(new Error('clear failed'));
+    mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
+    mockClearPendingBoardingIntent.mockImplementation(() => {
+      throw new Error('clear failed');
+    });
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     await Promise.resolve();
@@ -234,7 +238,7 @@ describe('useLiveActivityIntentBridge', () => {
     it('같은 boardingStationId/line → handleResponse skip, clear는 호출', async () => {
       setMockLock(activeLock);
       mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
-      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
       renderHook(() => useLiveActivityIntentBridge(baseDeps));
       await Promise.resolve();
       await Promise.resolve();
@@ -246,7 +250,7 @@ describe('useLiveActivityIntentBridge', () => {
     it('lock 만료됨 → dedup 미적용, handleResponse 호출', async () => {
       setMockLock({ ...activeLock, boardedAt: Date.now() - 100 * 60_000 });
       mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
-      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
       renderHook(() => useLiveActivityIntentBridge(baseDeps));
       await Promise.resolve();
       await Promise.resolve();
@@ -257,7 +261,7 @@ describe('useLiveActivityIntentBridge', () => {
     it('line 불일치 → dedup 미적용, handleResponse 호출', async () => {
       setMockLock({ ...activeLock, boardingLine: '2' });
       mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
-      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
       renderHook(() => useLiveActivityIntentBridge(baseDeps));
       await Promise.resolve();
       await Promise.resolve();
@@ -268,7 +272,7 @@ describe('useLiveActivityIntentBridge', () => {
     it('station 매칭 실패(다른 역) → dedup 미적용, handleResponse 호출', async () => {
       setMockLock(activeLock);
       mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-다른역-5' });
-      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
       renderHook(() => useLiveActivityIntentBridge(baseDeps));
       await Promise.resolve();
       await Promise.resolve();
@@ -279,7 +283,7 @@ describe('useLiveActivityIntentBridge', () => {
     it('station lookup이 null → dedup 미적용, handleResponse 호출', async () => {
       setMockLock(activeLock);
       mockFindStationByNameAndLine.mockReturnValue(null);
-      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      mockReadPendingBoardingIntent.mockReturnValue(validBoardedRaw);
       renderHook(() => useLiveActivityIntentBridge(baseDeps));
       await Promise.resolve();
       await Promise.resolve();
@@ -289,7 +293,7 @@ describe('useLiveActivityIntentBridge', () => {
 
     it('DISEMBARK 액션은 dedup 체크 대상 아님 — lock 있어도 handleResponse 호출', async () => {
       setMockLock(activeLock);
-      mockReadPendingBoardingIntent.mockResolvedValue(validDisembarkRaw);
+      mockReadPendingBoardingIntent.mockReturnValue(validDisembarkRaw);
       renderHook(() => useLiveActivityIntentBridge(baseDeps));
       await Promise.resolve();
       await Promise.resolve();
@@ -299,7 +303,7 @@ describe('useLiveActivityIntentBridge', () => {
   });
 
   it('foreground 폴링 콜백이 등록되고 재호출 시 재확인한다', async () => {
-    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    mockReadPendingBoardingIntent.mockReturnValue(null);
     renderHook(() => useLiveActivityIntentBridge(baseDeps));
     await Promise.resolve();
     expect(capturedPollCallback).not.toBeNull();

--- a/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
@@ -1,0 +1,311 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration 테스트 — 대상 훅과 동일 사유로 옵트인.
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import { renderHook } from '@testing-library/react-native';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+const mockReadPendingBoardingIntent = jest.fn();
+const mockClearPendingBoardingIntent = jest.fn();
+jest.mock('live-activity', () => ({
+  readPendingBoardingIntent: (...args: unknown[]) =>
+    mockReadPendingBoardingIntent(...args),
+  clearPendingBoardingIntent: (...args: unknown[]) =>
+    mockClearPendingBoardingIntent(...args),
+}));
+
+const mockHandleResponse = jest.fn();
+jest.mock('../useBoardingPromptResponder', () => ({
+  handleResponse: (...args: unknown[]) => mockHandleResponse(...args),
+}));
+
+let capturedPollCallback: (() => void) | null = null;
+jest.mock('../../../../shared/hooks/usePolling', () => ({
+  usePolling: (cb: () => void) => {
+    capturedPollCallback = cb;
+  },
+}));
+
+const mockFindStationByNameAndLine = jest.fn();
+jest.mock('../../../../shared/utils/stationLookup', () => ({
+  findStationByNameAndLine: (...args: unknown[]) =>
+    mockFindStationByNameAndLine(...args),
+}));
+
+const mockCreateLock = jest.fn();
+let mockLock: BoardingLock | null = null;
+jest.mock('../../store/useBoardingLockStore', () => {
+  const selectorFn = Object.assign(
+    (selector: (state: { createLock: jest.Mock; lock: unknown }) => unknown) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock 캡처 변수 접근
+      selector({ createLock: mockCreateLock, lock: (globalThis as any).__mockLock ?? null }),
+    {
+      getState: () => ({
+        createLock: mockCreateLock,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        lock: (globalThis as any).__mockLock ?? null,
+      }),
+    },
+  );
+  return { useBoardingLockStore: selectorFn };
+});
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import {
+  parsePendingBoardingIntent,
+  useLiveActivityIntentBridge,
+} from '../useLiveActivityIntentBridge';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  DISEMBARK_ACTION_DISEMBARKED,
+} from '../../utils/notificationCategory';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g = globalThis as any;
+
+function setMockLock(lock: BoardingLock | null): void {
+  mockLock = lock;
+  g.__mockLock = lock;
+}
+
+const baseDeps = {
+  fetchArrivalsForStation: jest.fn(),
+  destinationId: 'dest-1',
+  expectedDurationMs: 30 * 60_000,
+};
+
+const validBoardedRaw = JSON.stringify({
+  id: 'trip-1-100',
+  tripToken: 'trip-1',
+  action: 'BOARDING_BOARDED',
+  originStation: '군자',
+  line: '5',
+  atMs: 100,
+});
+
+const validDisembarkRaw = JSON.stringify({
+  id: 'trip-1-200',
+  tripToken: 'trip-1',
+  action: 'DISEMBARK_DISEMBARKED',
+  originStation: '군자',
+  line: '5',
+  atMs: 200,
+});
+
+describe('parsePendingBoardingIntent', () => {
+  it('유효한 JSON을 파싱한다', () => {
+    expect(parsePendingBoardingIntent(validBoardedRaw)).toEqual({
+      id: 'trip-1-100',
+      tripToken: 'trip-1',
+      action: 'BOARDING_BOARDED',
+      originStation: '군자',
+      line: '5',
+      atMs: 100,
+    });
+  });
+
+  it('malformed JSON → null', () => {
+    expect(parsePendingBoardingIntent('not-json{')).toBeNull();
+  });
+
+  it('object가 아님 → null', () => {
+    expect(parsePendingBoardingIntent('123')).toBeNull();
+  });
+
+  it.each([
+    ['id', { ...JSON.parse(validBoardedRaw), id: '' }],
+    ['tripToken', { ...JSON.parse(validBoardedRaw), tripToken: undefined }],
+    ['action', { ...JSON.parse(validBoardedRaw), action: 'UNKNOWN' }],
+    ['originStation', { ...JSON.parse(validBoardedRaw), originStation: 1 }],
+    ['line', { ...JSON.parse(validBoardedRaw), line: null }],
+    ['atMs', { ...JSON.parse(validBoardedRaw), atMs: 'not-a-number' }],
+  ])('필드 %s 누락/타입불일치 → null', (_field, payload) => {
+    expect(parsePendingBoardingIntent(JSON.stringify(payload))).toBeNull();
+  });
+});
+
+describe('useLiveActivityIntentBridge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedPollCallback = null;
+    setMockLock(null);
+    mockCreateLock.mockReset();
+    mockFindStationByNameAndLine.mockReset();
+    mockHandleResponse.mockResolvedValue(undefined);
+    mockClearPendingBoardingIntent.mockResolvedValue(undefined);
+  });
+
+  it('마운트 시 pending intent를 1회 확인한다', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    expect(mockReadPendingBoardingIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it('pending 없음(null) → handleResponse/clear 호출 안 함', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).not.toHaveBeenCalled();
+    expect(mockClearPendingBoardingIntent).not.toHaveBeenCalled();
+  });
+
+  it('malformed pending → handleResponse/clear 호출 안 함', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue('not-json{');
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).not.toHaveBeenCalled();
+    expect(mockClearPendingBoardingIntent).not.toHaveBeenCalled();
+  });
+
+  it('readPendingBoardingIntent 실패 → throw 없이 흡수', async () => {
+    mockReadPendingBoardingIntent.mockRejectedValue(new Error('native error'));
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).not.toHaveBeenCalled();
+  });
+
+  it('lock 없음 + BOARDING_BOARDED → handleResponse(BOARDED) 호출 후 clear', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledWith(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      expect.objectContaining({
+        kind: 'boarding-prompt',
+        originStation: '군자',
+        line: '5',
+        tripToken: 'trip-1',
+        hopEndKind: undefined,
+      }),
+      expect.objectContaining({ ...baseDeps, createLock: mockCreateLock }),
+    );
+    expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-100');
+  });
+
+  it('DISEMBARK_DISEMBARKED → handleResponse(DISEMBARKED, hopEndKind=disembark) 호출 후 clear', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(validDisembarkRaw);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledWith(
+      DISEMBARK_ACTION_DISEMBARKED,
+      expect.objectContaining({ hopEndKind: 'disembark' }),
+      expect.anything(),
+    );
+    expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-200');
+  });
+
+  it('clearPendingBoardingIntent 실패 → throw 없이 흡수', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+    mockClearPendingBoardingIntent.mockRejectedValue(new Error('clear failed'));
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+  });
+
+  describe('⑥ dedup — 동일 origin/line active lock 존재 시 no-op', () => {
+    const activeLock: BoardingLock = {
+      destinationId: 'dest-1',
+      trainCode: 'T1',
+      boardingStationId: 'stn-군자-5',
+      boardingLine: '5',
+      boardedAt: Date.now(),
+      expectedDurationMs: 30 * 60_000,
+      boardingEvidence: false,
+    };
+
+    it('같은 boardingStationId/line → handleResponse skip, clear는 호출', async () => {
+      setMockLock(activeLock);
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).not.toHaveBeenCalled();
+      expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-100');
+    });
+
+    it('lock 만료됨 → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock({ ...activeLock, boardedAt: Date.now() - 100 * 60_000 });
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('line 불일치 → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock({ ...activeLock, boardingLine: '2' });
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-군자-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('station 매칭 실패(다른 역) → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock(activeLock);
+      mockFindStationByNameAndLine.mockReturnValue({ id: 'stn-다른역-5' });
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('station lookup이 null → dedup 미적용, handleResponse 호출', async () => {
+      setMockLock(activeLock);
+      mockFindStationByNameAndLine.mockReturnValue(null);
+      mockReadPendingBoardingIntent.mockResolvedValue(validBoardedRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('DISEMBARK 액션은 dedup 체크 대상 아님 — lock 있어도 handleResponse 호출', async () => {
+      setMockLock(activeLock);
+      mockReadPendingBoardingIntent.mockResolvedValue(validDisembarkRaw);
+      renderHook(() => useLiveActivityIntentBridge(baseDeps));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockHandleResponse).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('foreground 폴링 콜백이 등록되고 재호출 시 재확인한다', async () => {
+    mockReadPendingBoardingIntent.mockResolvedValue(null);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    expect(capturedPollCallback).not.toBeNull();
+    mockReadPendingBoardingIntent.mockClear();
+    capturedPollCallback!();
+    await Promise.resolve();
+    expect(mockReadPendingBoardingIntent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/alarm/hooks/__tests__/useLiveActivityPreBoardingLifecycle.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityPreBoardingLifecycle.test.ts
@@ -1,0 +1,182 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature test mirroring source's disable. ADR Phase 5 (#890).
+ */
+import { act, renderHook } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { useBoardingLockStore } from '../../store/useBoardingLockStore';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+const mockIsLiveActivityEnabled = jest.fn();
+const mockUpdateLiveActivity = jest.fn();
+
+jest.mock('live-activity', () => ({
+  isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
+  updateLiveActivity: (...args: unknown[]) => mockUpdateLiveActivity(...args),
+}));
+
+const mockClearStationNotification = jest.fn();
+jest.mock('../../utils/stationNotification', () => ({
+  clearStationNotification: (...args: unknown[]) => mockClearStationNotification(...args),
+}));
+
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+
+const mockWarn = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: (...args: unknown[]) => mockWarn(...args),
+    error: jest.fn(),
+  }),
+}));
+
+import { useLiveActivityPreBoardingLifecycle } from '../useLiveActivityPreBoardingLifecycle';
+
+const { gangnam, chungmuro } = MOCK_STATIONS;
+
+const LOCK: BoardingLock = {
+  trainCode: 'T001',
+  boardingLine: gangnam.line,
+  boardingStationId: gangnam.id,
+  destinationId: chungmuro.id,
+  boardingEvidence: true,
+  boardedAt: Date.now(),
+  expectedDurationMs: 5 * 60 * 1000,
+};
+
+describe('useLiveActivityPreBoardingLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLiveActivityEnabled.mockReturnValue(true);
+    mockUpdateLiveActivity.mockResolvedValue(undefined);
+    mockClearStationNotification.mockResolvedValue(undefined);
+    useDestinationStore.setState({ destination: null, tripOrigin: null });
+    useBoardingLockStore.setState({ lock: null });
+  });
+
+  it('destination 없음 + lock 없음 → 아무 것도 하지 않는다', () => {
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockClearStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('destination 설정(lock 없음) → pre-boarding LA update 호출', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+    const data = mockUpdateLiveActivity.mock.calls[0][0];
+    expect(data.boardingPhase).toBe('pre-boarding');
+    expect(data.destinationName).toBeTruthy();
+    // GPS 미확정 — placeholder stationName ("감지 중" i18n)
+    expect(data.stationName).toBe('감지 중');
+    expect(data.boardingPromptOriginStation).toBeUndefined();
+  });
+
+  it('tripOrigin 확보되면 실제 역/노선 정보로 pre-boarding LA를 채운다', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    const data = mockUpdateLiveActivity.mock.calls[0][0];
+    expect(data.stationName).toBe(gangnam.name);
+    expect(data.lineColorHex).toBe(gangnam.lineColor);
+    expect(data.boardingPromptOriginStation).toBe(gangnam.name);
+    expect(data.boardingPromptLine).toBe(gangnam.line);
+  });
+
+  it('tripToken이 있으면 boardingPromptTripToken을 싣는다', () => {
+    mockGetCurrentTripCorrIdSync.mockReturnValue('corr-123');
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    const data = mockUpdateLiveActivity.mock.calls[0][0];
+    expect(data.boardingPromptTripToken).toBe('corr-123');
+  });
+
+  it('이미 GPS 경로로 LA가 떠 있어도(활성 세션 판단 불가) 이 훅은 native update만 호출한다 — start 이중 호출 없음', () => {
+    // ensureLiveActivityRegistered/startLiveActivity 경로를 타지 않는지 — updateLiveActivity만 호출됐는지 검증.
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('lock 생성됨 → 콘텐츠 소유권을 넘기고 이 훅은 native 호출을 하지 않는다', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    useBoardingLockStore.setState({ lock: LOCK });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    expect(mockClearStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('pre-boarding 세션을 스스로 시작한 뒤 lock이 생성되고, 이후 destination이 해제돼도 종료 호출을 하지 않는다(GPS 파이프라인 책임)', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    const { rerender } = renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useBoardingLockStore.setState({ lock: LOCK });
+    });
+    rerender({});
+
+    act(() => {
+      useDestinationStore.setState({ destination: null, tripOrigin: null });
+    });
+    rerender({});
+
+    expect(mockClearStationNotification).not.toHaveBeenCalled();
+  });
+
+  it('스스로 시작한 pre-boarding 세션 중 destination이 해제되면 clearStationNotification으로 종료', () => {
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    const { rerender } = renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useDestinationStore.setState({ destination: null, tripOrigin: null });
+    });
+    rerender({});
+
+    expect(mockClearStationNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('Android — 아무 것도 하지 않는다', () => {
+    const originalOS = Platform.OS;
+    Object.defineProperty(Platform, 'OS', { get: () => 'android' });
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    Object.defineProperty(Platform, 'OS', { get: () => originalOS });
+  });
+
+  it('Live Activity 비활성이면 update를 호출하지 않는다', () => {
+    mockIsLiveActivityEnabled.mockReturnValue(false);
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('updateLiveActivity가 throw하면 logger.warn으로 흡수', async () => {
+    mockUpdateLiveActivity.mockRejectedValueOnce(new Error('native fail'));
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: null });
+    renderHook(() => useLiveActivityPreBoardingLifecycle());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockWarn).toHaveBeenCalledWith('pre-boarding LA 갱신 실패', expect.any(Error));
+  });
+
+  it('clearStationNotification이 throw하면 logger.warn으로 흡수', async () => {
+    mockClearStationNotification.mockRejectedValueOnce(new Error('end fail'));
+    useDestinationStore.setState({ destination: chungmuro, tripOrigin: gangnam });
+    const { rerender } = renderHook(() => useLiveActivityPreBoardingLifecycle());
+    act(() => {
+      useDestinationStore.setState({ destination: null, tripOrigin: null });
+    });
+    rerender({});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockWarn).toHaveBeenCalledWith('pre-boarding LA 종료 실패', expect.any(Error));
+  });
+});

--- a/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
+++ b/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
@@ -14,10 +14,10 @@
  * 로직을 만들지 않고 기존 tryAutoLock/createPendingFallbackLock/dedup/의향 stamp를 재사용한다.
  *
  * App Group 계약 (native와 공유):
- *   `readPendingBoardingIntent(): Promise<string | null>` → JSON 문자열 또는 pending 없음/모듈
- *   미지원 시 null. `{ id, tripToken, action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED',
- *   originStation, line, atMs }`.
- *   `clearPendingBoardingIntent(id)` → 처리 후 호출(멱등) — 재폴링/재부팅 중복 처리 방지.
+ *   `readPendingBoardingIntent(): string | null` → JSON 문자열 또는 pending 없음/모듈
+ *   미지원 시 null (native `Function`이 sync라 JS 래퍼도 sync). `{ id, tripToken,
+ *   action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED', originStation, line, atMs }`.
+ *   `clearPendingBoardingIntent(id): void` → 처리 후 호출(멱등) — 재폴링/재부팅 중복 처리 방지.
  *
  * 트리거: 마운트 + AppState 'active' 진입 + foreground 유지 중 짧은 폴링
  * (`LIVE_ACTIVITY_INTENT_POLL_MS`) — native가 push event 없이 App Group write만 하는 pull
@@ -118,7 +118,7 @@ function isDuplicateBoardingIntent(intent: PendingBoardingIntent): boolean {
 async function processPendingBoardingIntent(deps: BridgeDeps): Promise<void> {
   let raw: string | null;
   try {
-    raw = await readPendingBoardingIntent();
+    raw = readPendingBoardingIntent();
   } catch (err) {
     log.warn('readPendingBoardingIntent 실패', err as Error);
     return;
@@ -149,7 +149,7 @@ async function processPendingBoardingIntent(deps: BridgeDeps): Promise<void> {
   }
 
   try {
-    await clearPendingBoardingIntent(intent.id);
+    clearPendingBoardingIntent(intent.id);
   } catch (err) {
     log.warn('clearPendingBoardingIntent 실패', err as Error);
   }

--- a/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
+++ b/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
@@ -1,0 +1,178 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: LA 버튼 탭(App Group pending intent)을 기존
+ * `useBoardingPromptResponder`의 lock 생성/해제 로직에 연결하는 orchestrator라 여러 features의
+ * store/hook을 직접 조합하는 게 본질적이다. Phase 5 enforce 모드에서 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2438 — LA 인터랙티브 프롬프트 piece ⑤(JS) + ⑥(dedup).
+ *
+ * native(③④⑤-native, 병렬 진행)의 AppIntent가 LA 버튼 탭 시 App Group에 pending boarding
+ * intent를 write한다. 이 훅은 그 intent를 읽어 `useBoardingPromptResponder.handleResponse`
+ * (알림 [탑승]/[하차했어요] 액션과 동일한 lock 생성/해제 로직)로 그대로 위임한다 — 신규 lock
+ * 로직을 만들지 않고 기존 tryAutoLock/createPendingFallbackLock/dedup/의향 stamp를 재사용한다.
+ *
+ * App Group 계약 (native와 공유):
+ *   `readPendingBoardingIntent(): Promise<string | null>` → JSON 문자열 또는 pending 없음/모듈
+ *   미지원 시 null. `{ id, tripToken, action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED',
+ *   originStation, line, atMs }`.
+ *   `clearPendingBoardingIntent(id)` → 처리 후 호출(멱등) — 재폴링/재부팅 중복 처리 방지.
+ *
+ * 트리거: 마운트 + AppState 'active' 진입 + foreground 유지 중 짧은 폴링
+ * (`LIVE_ACTIVITY_INTENT_POLL_MS`) — native가 push event 없이 App Group write만 하는 pull
+ * 모델이라 재확인이 필요하다.
+ *
+ * ⑥ dedup — 알림 [탑승] 액션과 LA 버튼 둘 다 최종적으로 이 경로(`tryAutoLock` → `createLock`)로
+ * 수렴한다. `createLock`은 호출 즉시 기존 lock을 교체하므로(store 자체엔 dedup이 없음), 같은
+ * boarding 역/노선에 이미 active lock이 있으면 LA intent 처리를 no-op으로 skip해 이중 lock
+ * 생성(같은 trip을 두 번 잠그며 `initialEtaSeconds` 등 스냅샷을 덮어쓰는 것)을 막는다.
+ * hop-end(DISEMBARK) 액션은 `releaseLock`이 이미 멱등이라 별도 가드가 필요 없다.
+ */
+import { useCallback, useEffect } from 'react';
+import {
+  clearPendingBoardingIntent,
+  readPendingBoardingIntent,
+} from 'live-activity';
+import { usePolling } from '../../../shared/hooks/usePolling';
+import { LIVE_ACTIVITY_INTENT_POLL_MS } from '../../../shared/constants/boardingLock';
+import { isBoardingLockExpired } from '../../../shared/types/boardingLock';
+import { isValidLineNumber } from '../../../shared/constants/lineApiNames';
+import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import {
+  BOARDING_PROMPT_ACTION_BOARDED,
+  DISEMBARK_ACTION_DISEMBARKED,
+} from '../utils/notificationCategory';
+import {
+  handleResponse,
+  type BoardingPromptPayload,
+  type UseBoardingPromptResponderDeps,
+} from './useBoardingPromptResponder';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('liveActivityIntentBridge');
+
+/** App Group pending boarding intent — native AppIntent가 write하는 schema. */
+export interface PendingBoardingIntent {
+  id: string;
+  tripToken: string;
+  action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED';
+  originStation: string;
+  line: string;
+  atMs: number;
+}
+
+const VALID_ACTIONS: readonly PendingBoardingIntent['action'][] = [
+  'BOARDING_BOARDED',
+  'DISEMBARK_DISEMBARKED',
+];
+
+/**
+ * `readPendingBoardingIntent()`가 반환한 raw JSON 문자열을 파싱 + 검증한다.
+ * 파싱 실패 또는 필수 필드 누락/타입 불일치는 null — caller가 graceful skip.
+ */
+export function parsePendingBoardingIntent(raw: string): PendingBoardingIntent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const o = parsed as Record<string, unknown>;
+  if (typeof o.id !== 'string' || o.id.length === 0) return null;
+  if (typeof o.tripToken !== 'string' || o.tripToken.length === 0) return null;
+  if (typeof o.action !== 'string' || !VALID_ACTIONS.includes(o.action as never)) return null;
+  if (typeof o.originStation !== 'string' || o.originStation.length === 0) return null;
+  if (typeof o.line !== 'string' || o.line.length === 0) return null;
+  if (typeof o.atMs !== 'number') return null;
+  return {
+    id: o.id,
+    tripToken: o.tripToken,
+    action: o.action as PendingBoardingIntent['action'],
+    originStation: o.originStation,
+    line: o.line,
+    atMs: o.atMs,
+  };
+}
+
+interface BridgeDeps extends UseBoardingPromptResponderDeps {
+  createLock: ReturnType<typeof useBoardingLockStore.getState>['createLock'];
+}
+
+/**
+ * #2438 ⑥ — 이미 같은 탑승역/노선으로 active lock이 있으면 true(중복 boarding intent).
+ * 알림 [탑승] 액션이 먼저 처리돼 lock이 생성된 뒤 LA 버튼(같은 트립)이 뒤이어 도착하는
+ * 케이스, 또는 그 반대 순서 모두 이 체크로 흡수한다.
+ */
+function isDuplicateBoardingIntent(intent: PendingBoardingIntent): boolean {
+  const lock = useBoardingLockStore.getState().lock;
+  if (!lock) return false;
+  if (isBoardingLockExpired(lock, Date.now())) return false;
+  if (!isValidLineNumber(intent.line) || lock.boardingLine !== intent.line) return false;
+  const station = findStationByNameAndLine(intent.originStation, intent.line);
+  return station !== null && station.id === lock.boardingStationId;
+}
+
+async function processPendingBoardingIntent(deps: BridgeDeps): Promise<void> {
+  let raw: string | null;
+  try {
+    raw = await readPendingBoardingIntent();
+  } catch (err) {
+    log.warn('readPendingBoardingIntent 실패', err as Error);
+    return;
+  }
+  if (!raw) return;
+
+  const intent = parsePendingBoardingIntent(raw);
+  if (!intent) {
+    log.warn('pending boarding intent 파싱 실패 — malformed payload');
+    return;
+  }
+
+  if (intent.action === 'BOARDING_BOARDED' && isDuplicateBoardingIntent(intent)) {
+    log.info('duplicate boarding intent — active lock already exists, no-op');
+  } else {
+    const payload: BoardingPromptPayload = {
+      kind: 'boarding-prompt',
+      originStation: intent.originStation,
+      line: intent.line,
+      tripToken: intent.tripToken,
+      hopEndKind: intent.action === 'DISEMBARK_DISEMBARKED' ? 'disembark' : undefined,
+    };
+    const actionIdentifier =
+      intent.action === 'DISEMBARK_DISEMBARKED'
+        ? DISEMBARK_ACTION_DISEMBARKED
+        : BOARDING_PROMPT_ACTION_BOARDED;
+    await handleResponse(actionIdentifier, payload, deps);
+  }
+
+  try {
+    await clearPendingBoardingIntent(intent.id);
+  } catch (err) {
+    log.warn('clearPendingBoardingIntent 실패', err as Error);
+  }
+}
+
+/**
+ * 마운트 + AppState 'active' 진입 + foreground 폴링 시 App Group pending boarding intent를
+ * 확인해 기존 boarding-prompt 응답 로직으로 위임한다. `deps`는 `useBoardingPromptResponder`와
+ * 동일한 shape — caller(app/_layout.tsx)가 같은 값을 주입해 두 채널이 동일 컨텍스트를 공유한다.
+ */
+export function useLiveActivityIntentBridge(deps: UseBoardingPromptResponderDeps): void {
+  const createLock = useBoardingLockStore((s) => s.createLock);
+
+  // usePolling은 callback을 ref로 잡아 매 tick 최신 클로저를 실행하므로, deps가 caller
+  // 렌더마다 새 객체(app/_layout.tsx의 inline object)여도 run이 재생성되는 것과 무관하게
+  // interval 자체는 재시작되지 않는다.
+  const run = useCallback(() => {
+    void processPendingBoardingIntent({ ...deps, createLock });
+  }, [createLock, deps]);
+
+  useEffect(() => {
+    run();
+  }, [run]);
+
+  usePolling(run, LIVE_ACTIVITY_INTENT_POLL_MS);
+}

--- a/src/features/alarm/hooks/useLiveActivityPreBoardingLifecycle.ts
+++ b/src/features/alarm/hooks/useLiveActivityPreBoardingLifecycle.ts
@@ -1,0 +1,127 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: destination(route 슬라이스)이 설정되는 시점에 pre-boarding
+ * Live Activity를 확보하는 훅이라 route 슬라이스의 store를 직접 읽어야 한다. tripCorrId(observability
+ * 슬라이스)도 trip 식별용으로 필요 — alarm 슬라이스의 다른 hook(useApnsTripRegistration 등)과
+ * 동일 패턴. orchestration이 본질이라 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2436 — LA 인터랙티브 프롬프트 piece ②. destination 설정 시점부터 pre-boarding 상태
+ * Live Activity를 확보해 후속 piece(버튼/AppIntent)가 얹힐 토대를 만든다.
+ *
+ * 트리거:
+ *   - destination 설정 + lock 없음 → pre-boarding LA start(or update) + boardingPhase 컨텍스트.
+ *   - lock 생성됨(탑승 확정) → 이 훅은 관여를 멈춘다. 이후 LA 콘텐츠는 기존 GPS-트리거 파이프라인
+ *     (`stationPipeline.ts` / `HomeScreen`의 `updateStationNotification`)이 소유한다 — 그 경로는
+ *     boardingPrompt 필드를 넘기지 않으므로 다음 정기 tick에서 boardingPhase가 자연히 비워진다
+ *     ("or 미세팅" 허용, 스펙 명시).
+ *   - destination 해제(non-null→null) → 이 훅이 스스로 시작한 pre-boarding 세션만 종료.
+ *     (lock 활성 중 destination이 해제되는 통상 trip 종료는 HomeScreen이 이미 `clearStationNotification`을
+ *     호출하므로 중복 종료를 피한다 — `preBoardingActiveRef`로 소유권 구분.)
+ *
+ * dedup (기존 GPS-트리거 LA와 단일 인스턴스 보장):
+ *   `ensureLiveActivityRegistered`(liveActivityPushChannel.ts)는 backend push 등록 세션 시작
+ *   전용이라, 세션이 없다고 판단되면 native `startLiveActivity`를 호출한다 — native
+ *   `LiveActivityManager.start(data:)`는 호출 즉시 `endAllActivities()`로 기존 Activity를
+ *   종료하고 새로 만든다. GPS 파이프라인은 lock 전 구간에서 `LiveActivity.updateLiveActivity`를
+ *   직접 호출(트립 미등록이라 push 채널을 타지 않음)하므로 그 세션은 `activeTripToken`에
+ *   기록되지 않는다. 이 상태에서 `ensureLiveActivityRegistered`를 호출하면 이미 떠 있는 GPS LA를
+ *   모른 채 start를 시도해 강제 종료 후 재생성(깜빡임)이 발생한다.
+ *
+ *   반면 native `LiveActivityManager.update(data:)`는 활성 Activity가 있으면 update만, 없으면
+ *   내부적으로 `start`를 호출하는 진짜 "start-vs-update 판정"을 이미 구현하고 있다 — GPS
+ *   파이프라인이 pre-lock 구간에 쓰는 것과 동일한 호출. 이 훅도 같은 `LiveActivity.updateLiveActivity`
+ *   를 사용해 단일 Activity 인스턴스를 보장한다(이중 start 없음).
+ *
+ * additive: destination 없거나 lock 있으면 아무 것도 하지 않는다 — 기존 렌더와 100% 동일.
+ * 네이티브(Swift)/버튼/AppIntent 변경 없음. JS만.
+ */
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import i18next from 'i18next';
+import * as LiveActivity from 'live-activity';
+import type { Station } from '../../../shared/types/station';
+import { LINE_COLORS, LINE_NAMES } from '../../../shared/constants/lineColors';
+import { getStationDisplayName } from '../../../shared/utils/stationDisplay';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { clearStationNotification } from '../utils/stationNotification';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('useLiveActivityPreBoardingLifecycle');
+
+/**
+ * GPS가 아직 출발역을 확정하지 못한 상태에서 pre-boarding LA를 보여줄 때 쓰는 중립 placeholder
+ * 색상(iOS system gray). 노선이 확정되면(originStation 확보) 즉시 실제 노선색으로 대체된다.
+ */
+const PRE_BOARDING_UNKNOWN_LINE_COLOR_HEX = '#8E8E93';
+
+/**
+ * pre-boarding 단계 Live Activity content. GPS로 확정된 출발역(origin)이 있으면 실제 역/노선
+ * 정보를, 없으면 "감지 중"(기존 `widget.detecting` 관례) placeholder를 stationName에 싣는다.
+ * distanceM은 이 단계에선 의미가 없어 0 고정 — destinationName이 있으면 위젯은 거리 대신
+ * "→ 목적지" 라우트 뷰를 그리므로 화면에 노출되지 않는다.
+ */
+function buildPreBoardingLiveActivityData(
+  destination: Station,
+  origin: Station | null,
+  tripToken: string | null,
+): LiveActivity.LiveActivityData {
+  const data: LiveActivity.LiveActivityData = {
+    stationName: origin ? getStationDisplayName(origin) : i18next.t('widget.detecting'),
+    lineName: origin ? LINE_NAMES[origin.line] : '',
+    lineColorHex: origin ? LINE_COLORS[origin.line] : PRE_BOARDING_UNKNOWN_LINE_COLOR_HEX,
+    distanceM: 0,
+    destinationName: getStationDisplayName(destination),
+    boardingPhase: 'pre-boarding',
+  };
+  if (tripToken) {
+    data.boardingPromptTripToken = tripToken;
+  }
+  if (origin) {
+    data.boardingPromptOriginStation = getStationDisplayName(origin);
+    data.boardingPromptLine = origin.line;
+  }
+  return data;
+}
+
+export function useLiveActivityPreBoardingLifecycle(): void {
+  const destination = useDestinationStore((s) => s.destination);
+  const tripOrigin = useDestinationStore((s) => s.tripOrigin);
+  const lock = useBoardingLockStore((s) => s.lock);
+
+  // 이 훅이 직접 시작한 pre-boarding 세션인지 추적 — lock 전환/GPS 파이프라인이 소유하게 된
+  // 세션까지 이 훅이 대신 종료하지 않도록 소유권을 구분한다.
+  const preBoardingActiveRef = useRef(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+
+    if (!destination) {
+      if (preBoardingActiveRef.current) {
+        preBoardingActiveRef.current = false;
+        clearStationNotification().catch((e) => {
+          log.warn('pre-boarding LA 종료 실패', e);
+        });
+      }
+      return;
+    }
+
+    if (lock) {
+      // 탑승 확정 — 콘텐츠 소유권을 GPS-트리거 파이프라인에 넘긴다.
+      preBoardingActiveRef.current = false;
+      return;
+    }
+
+    if (!LiveActivity.isLiveActivityEnabled()) return;
+
+    const tripToken = getCurrentTripCorrIdSync();
+    const data = buildPreBoardingLiveActivityData(destination, tripOrigin, tripToken);
+    preBoardingActiveRef.current = true;
+    LiveActivity.updateLiveActivity(data).catch((e) => {
+      log.warn('pre-boarding LA 갱신 실패', e);
+    });
+  }, [destination, tripOrigin, lock]);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -49,6 +49,7 @@ import { useBackgroundLocation } from '../features/nearest-station/hooks/useBack
 import { useApnsTripRegistration } from '../features/alarm/hooks/useApnsTripRegistration';
 import { useLocalBoardingPromptGate } from '../features/alarm/hooks/useLocalBoardingPromptGate';
 import { useLiveActivityDismissBridge } from '../features/alarm/hooks/useLiveActivityDismissBridge';
+import { useLiveActivityPreBoardingLifecycle } from '../features/alarm/hooks/useLiveActivityPreBoardingLifecycle';
 import { registerSilentPushTask } from '../features/alarm/tasks/silentPushTask';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ROUTE_KEY } from '../shared/constants/storageKeys';
@@ -1011,6 +1012,7 @@ export default function HomeScreen() {
   useBackgroundLocation(destination);
   const permissionWatcher = useLocationPermissionWatcher();
   useLiveActivityDismissBridge();
+  useLiveActivityPreBoardingLifecycle();
   useApnsTripRegistration({
     route,
     destination,

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -254,3 +254,18 @@ export const FALLBACK_LOCK_POSITION_GUARD_FRESHNESS_MS = 5 * 60_000;
  * 해당하며, 이 상수는 오직 "이미 등록된 trip"의 이후 변경에만 쓰인다.
  */
 export const ROUTE_CHANGE_DEBOUNCE_MS = 1500;
+
+/**
+ * #2438 (LA 인터랙티브 프롬프트 piece ⑤) — `useLiveActivityIntentBridge`가 App Group의
+ * pending boarding intent(LA 버튼 탭)를 foreground에서 재확인하는 짧은 폴링 주기(ms).
+ *
+ * native가 push event 없이 App Group write만 하는 pull 모델이라, 마운트 + AppState 'active'
+ * 진입 외에도 앱이 이미 foreground인 동안 버튼을 탭한 케이스(위젯/잠금화면에서 LA 버튼 탭 시
+ * 앱은 이미 열려 있을 수 있음)를 흡수하려면 짧은 재확인이 필요하다.
+ *
+ * 5s로 둔 이유: `usePolling`이 이미 AppState 'active' 진입 시 즉시 1회 재확인하므로, 이 값은
+ * "foreground 유지 중 버튼 탭"만 커버하면 된다 — 사용자가 버튼을 탭하고 화면을 계속 보고
+ * 있어도 5s 이내 lock이 반영되면 체감 지연이 크지 않다. 배터리 부담은 로컬 App Group 읽기
+ * 1회(AsyncStorage/UserDefaults 수준)라 무시할 만하다.
+ */
+export const LIVE_ACTIVITY_INTENT_POLL_MS = 5_000;

--- a/targets/subway-widget/BoardingIntents.swift
+++ b/targets/subway-widget/BoardingIntents.swift
@@ -1,0 +1,145 @@
+#if os(iOS)
+import ActivityKit
+import AppIntents
+import Foundation
+
+// LA 인터랙티브 프롬프트 piece ③ (#2439). 잠금화면 Live Activity 버튼에서 직접 실행되는
+// AppIntent 2종. `LiveActivityIntent` 채택(iOS 17+)이 핵심 — 이 프로토콜을 채택한 intent는
+// 앱을 열지 않고 위젯 익스텐션 프로세스 안에서 곧바로 `perform()`이 실행된다. 그래서
+// 백그라운드/취침 중 앱이 완전히 정지된 상태에서도 버튼 탭이 cold-start race 없이 즉시 반영된다.
+//
+// App Group 계약(⑤-JS 브릿지와 공유, 정확히 일치해야 함):
+//   suite = "group.com.subwaynow.app" (modules/live-activity/ios/LiveActivityModule.swift의
+//           APP_GROUP과 동일 — 별도 pod 컴파일 단위라 리터럴을 미러링한다)
+//   key   = "pendingBoardingIntent" (LiveActivityModule.swift의 PENDING_BOARDING_INTENT_KEY와 동일)
+//   value(JSON) = { id, tripToken, action, originStation, line, atMs }
+//     - id: "<tripToken>-<atMs>" — clear 시 대조용
+//     - action: "BOARDING_BOARDED" | "DISEMBARK_DISEMBARKED"
+
+private let APP_GROUP = "group.com.subwaynow.app"
+private let PENDING_BOARDING_INTENT_KEY = "pendingBoardingIntent"
+private let ACTION_BOARDING_BOARDED = "BOARDING_BOARDED"
+private let ACTION_DISEMBARK_DISEMBARKED = "DISEMBARK_DISEMBARKED"
+
+/// boardingPhase enum 값(모듈 index.ts LiveActivityData.boardingPhase 타입과 동일 어휘 사용).
+/// 'pre-boarding' → 탑승 확인 버튼 탭 → 'boarded'. 'hop-end' → 하차 확인 버튼 탭 → 'arrival'.
+private let PHASE_BOARDED = "boarded"
+private let PHASE_ARRIVAL = "arrival"
+
+/// (b) App Group에 pending intent를 write — JS가 다음 foreground/폴링 시점에 읽어 lock 생성 등
+/// 실제 도메인 로직을 실행한다(이 파일은 상태 write만, 도메인 처리는 ⑤-JS 담당).
+@available(iOS 17.0, *)
+private func writePendingBoardingIntent(
+    action: String,
+    tripToken: String,
+    originStation: String,
+    line: String
+) {
+    guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+    let atMs = Date().timeIntervalSince1970 * 1000
+    let payload: [String: Any] = [
+        "id": "\(tripToken)-\(Int(atMs))",
+        "tripToken": tripToken,
+        "action": action,
+        "originStation": originStation,
+        "line": line,
+        "atMs": atMs,
+    ]
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+          let jsonString = String(data: jsonData, encoding: .utf8) else { return }
+    defaults.set(jsonString, forKey: PENDING_BOARDING_INTENT_KEY)
+}
+
+/// (a) 현재 추적 중인 Activity(들)의 boardingPhase를 즉시 전환 — 버튼 탭 즉시 시각 피드백.
+/// 아키텍처상 활성 Activity는 최대 1개(LiveActivityManager.endAllActivities)이므로 전수 update해도
+/// 안전하다.
+@available(iOS 17.0, *)
+private func markCurrentActivity(boardingPhase: String) async {
+    for activity in Activity<SubwayActivityAttributes>.activities {
+        var state = activity.content.state
+        state.boardingPhase = boardingPhase
+        await activity.update(ActivityContent(state: state, staleDate: nil))
+    }
+}
+
+/// pre-boarding 단계 "탑승하셨나요?" 버튼의 AppIntent.
+@available(iOS 17.0, *)
+struct BoardingConfirmIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "탑승 확인"
+    // Siri/Shortcuts 등 외부 진입점에 노출하지 않는다 — LA 버튼 전용 intent.
+    static var isDiscoverable: Bool = false
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "tripToken")
+    var tripToken: String
+
+    @Parameter(title: "originStation")
+    var originStation: String
+
+    @Parameter(title: "line")
+    var line: String
+
+    init() {
+        self.tripToken = ""
+        self.originStation = ""
+        self.line = ""
+    }
+
+    init(tripToken: String, originStation: String, line: String) {
+        self.tripToken = tripToken
+        self.originStation = originStation
+        self.line = line
+    }
+
+    func perform() async throws -> some IntentResult {
+        await markCurrentActivity(boardingPhase: PHASE_BOARDED)
+        writePendingBoardingIntent(
+            action: ACTION_BOARDING_BOARDED,
+            tripToken: tripToken,
+            originStation: originStation,
+            line: line
+        )
+        return .result()
+    }
+}
+
+/// hop-end 단계 "하차하셨나요?" 버튼의 AppIntent.
+@available(iOS 17.0, *)
+struct DisembarkConfirmIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "하차 확인"
+    static var isDiscoverable: Bool = false
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "tripToken")
+    var tripToken: String
+
+    @Parameter(title: "originStation")
+    var originStation: String
+
+    @Parameter(title: "line")
+    var line: String
+
+    init() {
+        self.tripToken = ""
+        self.originStation = ""
+        self.line = ""
+    }
+
+    init(tripToken: String, originStation: String, line: String) {
+        self.tripToken = tripToken
+        self.originStation = originStation
+        self.line = line
+    }
+
+    func perform() async throws -> some IntentResult {
+        await markCurrentActivity(boardingPhase: PHASE_ARRIVAL)
+        writePendingBoardingIntent(
+            action: ACTION_DISEMBARK_DISEMBARKED,
+            tripToken: tripToken,
+            originStation: originStation,
+            line: line
+        )
+        return .result()
+    }
+}
+#endif

--- a/targets/subway-widget/Localizable.xcstrings
+++ b/targets/subway-widget/Localizable.xcstrings
@@ -203,6 +203,122 @@
           }
         }
       }
+    },
+    "widget.boardingPrompt.boarded.question" : {
+      "comment" : "Live Activity boarding/disembark confirmation prompt",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Did you board?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗車しましたか?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탑승하셨나요?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您上车了吗?"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.boarded.button" : {
+      "comment" : "Confirm boarding button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Boarded"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗車した"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탑승했어요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已上车"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.disembark.question" : {
+      "comment" : "Live Activity boarding/disembark confirmation prompt",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Did you get off?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下車しましたか?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하차하셨나요?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您下车了吗?"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.disembark.button" : {
+      "comment" : "Confirm disembark button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Got off"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下車した"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하차했어요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下车"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import ActivityKit
+import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -102,8 +103,15 @@ private struct LockScreenView: View {
     }
 
 
+    /// #2439 — pre-boarding/hop-end 단계는 "탑승/하차 확인" 프롬프트를 최우선 표시.
+    var isBoardingPrompt: Bool {
+        state.boardingPhase == "pre-boarding" || state.boardingPhase == "hop-end"
+    }
+
     var body: some View {
-        if isUrgent {
+        if isBoardingPrompt {
+            BoardingPromptView(state: state, phase: state.boardingPhase ?? "")
+        } else if isUrgent {
             // 긴급 모드
             HStack(spacing: 12) {
                 RoundedRectangle(cornerRadius: 4)
@@ -208,6 +216,76 @@ private struct LockScreenView: View {
                 Color.black.opacity(isLuminanceReduced ? 0.9 : 0.85)
                     .overlay(isLuminanceReduced ? lineColor.opacity(0.08) : Color.clear)
             )
+        }
+    }
+}
+
+/// #2439 — pre-boarding("탑승하셨나요?") / hop-end("하차하셨나요?") 프롬프트 배너.
+/// LA 자체는 16.1+ 유지 — 버튼만 iOS 17+ `@available` 가드로 분리해, 17 미만 기기는 텍스트만 본다.
+@available(iOS 16.1, *)
+private struct BoardingPromptView: View {
+    let state: SubwayActivityAttributes.ContentState
+    let phase: String
+
+    var questionKey: String {
+        phase == "pre-boarding"
+            ? "widget.boardingPrompt.boarded.question"
+            : "widget.boardingPrompt.disembark.question"
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(state.boardingPromptOriginStation ?? state.stationName)
+                    .font(.title3)
+                    .fontWeight(.black)
+                    .foregroundColor(.white)
+                Text(NSLocalizedString(questionKey, comment: "Live Activity boarding/disembark confirmation prompt"))
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white.opacity(0.85))
+            }
+
+            Spacer()
+
+            if #available(iOS 17.0, *) {
+                BoardingPromptButton(state: state, phase: phase)
+            }
+        }
+        .padding(16)
+        .background(Color.black.opacity(0.85))
+    }
+}
+
+/// AppIntent 버튼 자체는 iOS 17+ (`LiveActivityIntent`)에서만 렌더 — 17 미만은 위 텍스트만 노출.
+@available(iOS 17.0, *)
+private struct BoardingPromptButton: View {
+    let state: SubwayActivityAttributes.ContentState
+    let phase: String
+
+    var body: some View {
+        if phase == "pre-boarding" {
+            Button(intent: BoardingConfirmIntent(
+                tripToken: state.boardingPromptTripToken ?? "",
+                originStation: state.boardingPromptOriginStation ?? "",
+                line: state.boardingPromptLine ?? ""
+            )) {
+                Text(NSLocalizedString("widget.boardingPrompt.boarded.button", comment: "Confirm boarding button label"))
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+            }
+            .tint(.white)
+        } else {
+            Button(intent: DisembarkConfirmIntent(
+                tripToken: state.boardingPromptTripToken ?? "",
+                originStation: state.boardingPromptOriginStation ?? "",
+                line: state.boardingPromptLine ?? ""
+            )) {
+                Text(NSLocalizedString("widget.boardingPrompt.disembark.button", comment: "Confirm disembark button label"))
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+            }
+            .tint(.white)
         }
     }
 }


### PR DESCRIPTION
## 배경
LA piece ②③④⑤⑥ (#2436, #2439, #2438)가 stacked 브랜치(`feat/#2436-la-preboarding-lifecycle`)에 갇혀 dev에 반영되지 않고 있었다. 각 PR이 이전 stacked 브랜치를 base로 열려 있어 dev로 못 들어가는 dead-end 상태.

Closes #2442. 관련: #2436, #2439, #2438 (기존 PR — 이 PR로 대체 통합).

## 작업
- `origin/dev` 기준 새 브랜치에서 3개 커밋 cherry-pick:
  - `7761dd96` #2436 = ② pre-boarding lifecycle 훅
  - `c6a02483` #2439 = ③④ AppIntent 버튼(Swift) + native read/clear + App Group
  - `62e7eee2` #2438 = ⑤⑥ JS 브릿지(`useLiveActivityIntentBridge`) + dedup
- `modules/live-activity/index.ts`의 `readPendingBoardingIntent`/`clearPendingBoardingIntent` 중복 선언(sync vs async) 해소 — native `LiveActivityModule.swift`가 sync `Function`이므로 sync 시그니처로 통일, async(Promise) 버전 제거
- `useLiveActivityIntentBridge`가 async로 await하던 부분을 sync 호출로 수정
- 관련 테스트 mock을 `mockResolvedValue`/`mockRejectedValue` → `mockReturnValue`/throw하는 `mockImplementation`으로 조정

## 검증
- `git diff --stat origin/dev` — LA 관련 파일만 (backend/①/기타 dev 파일 없음, revert 없음)
- `npm run type-check` pass
- `npm run lint:orphan` pass — orphan 0
- LA 관련 test만 `npx jest useLiveActivityIntentBridge useLiveActivityPreBoardingLifecycle stationNotification` — 158 passed

## Wire-completion 5단
1. **Orphan 없음** — lint:orphan pass
2. **V/X dashboard** — LA 버튼 탭(App Group pending intent)/lock 생성/pre-boarding lifecycle 전환은 DebugModal + 실기기 잠금화면/Dynamic Island에서 관측
3. **의존 PR** — N/A (device-only, backend 의존 없음)
4. **측정 plan** — 실기기 탑승 시 LA 버튼 탭 → App Group write → 폴링(`LIVE_ACTIVITY_INTENT_POLL_MS`) → lock 생성/해제 확인. dedup(⑥)은 알림 [탑승] 액션과 LA 버튼 동시 처리 시나리오로 확인
5. **Device verify** — 필수. iOS 실기기에서 LA 버튼(BoardingConfirmIntent/DisembarkConfirmIntent) 탭 → pending intent App Group write → JS 폴링 pickup → lock 생성/해제 확인. pre-boarding lifecycle(destination 설정 시 LA update) 확인

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9