### PR TITLE
fix(#2444): LA AppIntent perform() 무반응 — BoardingIntents.swift _shared/ 이동

### DIFF
--- a/targets/subway-widget/_shared/BoardingIntents.swift
+++ b/targets/subway-widget/_shared/BoardingIntents.swift
@@ -2,6 +2,7 @@
 import ActivityKit
 import AppIntents
 import Foundation
+import os.log
 
 // LA 인터랙티브 프롬프트 piece ③ (#2439). 잠금화면 Live Activity 버튼에서 직접 실행되는
 // AppIntent 2종. `LiveActivityIntent` 채택(iOS 17+)이 핵심 — 이 프로토콜을 채택한 intent는
@@ -15,9 +16,16 @@ import Foundation
 //   value(JSON) = { id, tripToken, action, originStation, line, atMs }
 //     - id: "<tripToken>-<atMs>" — clear 시 대조용
 //     - action: "BOARDING_BOARDED" | "DISEMBARK_DISEMBARKED"
+//
+// 파일 위치 = `_shared/` (fix/#2444): @bacons/apple-targets는 이 디렉토리 파일을 main app
+// target과 widget extension target 양쪽에 자동 링크한다(SubwayActivityAttributes.swift와 동일
+// 패턴). widget 전용 폴더에만 있었을 때 버튼 탭이 perform()까지 도달하지 않는 증상이 있었다 —
+// Apple 개발자 포럼 다수 보고: LiveActivityIntent가 위젯 프로세스에서 직접 실행되긴 하지만 App
+// Intents 등록이 안정적으로 동작하려면 intent 정의가 main app target에도 포함돼야 한다.
 
 private let APP_GROUP = "group.com.subwaynow.app"
 private let PENDING_BOARDING_INTENT_KEY = "pendingBoardingIntent"
+private let intentLog = Logger(subsystem: "com.subwaynow.app.widget", category: "BoardingIntent")
 private let ACTION_BOARDING_BOARDED = "BOARDING_BOARDED"
 private let ACTION_DISEMBARK_DISEMBARKED = "DISEMBARK_DISEMBARKED"
 
@@ -92,6 +100,7 @@ struct BoardingConfirmIntent: LiveActivityIntent {
     }
 
     func perform() async throws -> some IntentResult {
+        intentLog.info("perform BOARDING tapped tripToken=\(tripToken, privacy: .public)")
         await markCurrentActivity(boardingPhase: PHASE_BOARDED)
         writePendingBoardingIntent(
             action: ACTION_BOARDING_BOARDED,
@@ -132,6 +141,7 @@ struct DisembarkConfirmIntent: LiveActivityIntent {
     }
 
     func perform() async throws -> some IntentResult {
+        intentLog.info("perform DISEMBARK tapped tripToken=\(tripToken, privacy: .public)")
         await markCurrentActivity(boardingPhase: PHASE_ARRIVAL)
         writePendingBoardingIntent(
             action: ACTION_DISEMBARK_DISEMBARKED,


### PR DESCRIPTION
## Summary
- Closes #2444
- 실기기 증상: LA 인터랙티브 버튼(`Button(intent: BoardingConfirmIntent)`)이 렌더되는데 탭해도 `perform()`이 안 돎(boardingPhase 시각 변화조차 없음).
- 근본 원인(assumed, device 미검증): `BoardingIntents.swift`가 `targets/subway-widget/` 루트(위젯 익스텐션 전용 폴더)에 있어 pbxproj `PBXFileSystemSynchronizedRootGroup` membership 규칙상 widget extension target에만 컴파일되고 main app target에는 미포함. Apple 개발자 포럼 다수 보고: `LiveActivityIntent`는 위젯 프로세스에서 직접 실행되지만, App Intents 등록이 안정적으로 동작하려면 intent 정의가 main app target에도 있어야 한다는 요구사항이 존재 — widget-only 배치 시 이 정확한 증상(perform 미도달)이 재현된다고 보고됨.
- 이 프로젝트는 이미 이 패턴을 알고 있었다: `SubwayActivityAttributes.swift`가 `_shared/`에 있고 pbxproj에 "Exceptions for subway-widget folder in subwaynow target"으로 main app target에도 명시적으로 링크되어 있음(@bacons/apple-targets가 `_shared/` 디렉토리를 main app + widget 양쪽에 자동 링크).

## Fix
- `targets/subway-widget/BoardingIntents.swift` → `targets/subway-widget/_shared/BoardingIntents.swift`로 이동. config plugin 불필요 — 기존 @bacons/apple-targets `_shared/` 규칙을 그대로 활용해 prebuild마다 자동으로 양쪽 target에 링크된다(prebuild drift 없음).
- 진단 로그 추가: 각 `perform()` 진입 시 `Logger(subsystem: "com.subwaynow.app.widget", category: "BoardingIntent")`로 "perform BOARDING/DISEMBARK tapped tripToken=..." — 다음 실기기 빌드에서 Console.app으로 탭 시 perform이 실제로 도는지 확인 가능.
- JS 폴링 확인(`useLiveActivityIntentBridge`): 마운트 + `usePolling`(interval + `AppState` 'active' 진입 시 즉시 재실행)으로 `readPendingBoardingIntent`를 정상 호출 중 — 이 경로는 문제 없음, 변경 없음.

## Wire-completion 5단
1. **Orphan 없음** — Swift 파일 이동만, JS export 변경 없음. `npm run lint:orphan` 대상 아님(JS 미변경).
2. **V/X dashboard** — Console.app(Mac, 기기 연결)에서 subsystem `com.subwaynow.app.widget` / category `BoardingIntent` 필터로 관측. `perform BOARDING tapped` / `perform DISEMBARK tapped` 로그 유무가 곧 V/X.
3. **의존 PR** — N/A. 이 저장소 안에서 완결.
4. **측정 plan** — 사용자 실기기 재빌드 후 LA 버튼 탭 1회 → Console 로그 확인 + boardingPhase 시각 전환(버튼 사라지고 다음 단계 UI로 전환) + App Group pending intent → JS 폴링이 읽어 `useBoardingLockStore`에 lock 생성되는지 DebugModal로 확인.
5. **Device verify = REQUIRED** — Swift target membership 변경은 CI(정적 검증만)로 검증 불가. **사용자가 로컬 Xcode 재빌드(prebuild 필요 — `_shared/` 신규 매핑 반영) 후 실기기에서 LA 버튼 탭 → Console 로그 확인 필수.**

## Test plan
- [x] `npx tsc --noEmit` 통과 (JS 변경 없음, 회귀 없음 확인용)
- [ ] 사용자: 로컬 prebuild + Release 빌드 → 실기기 LA 버튼 탭 → Console.app `BoardingIntent` 로그 확인
- [ ] 사용자: 탭 후 boardingPhase 전환 확인 + JS 쪽 lock 생성(DebugModal) 확인

**머지 금지 — 사용자 실기기 검증 후 판단.**

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9