### PR TITLE
fix(#2446): 2호선 순환선 탑승 방향 라벨 오표시(뚝섬 반대방향 유도) 수정

### DIFF
--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -18,7 +18,7 @@ import { formatClockTime } from '../../../shared/utils/formatTime';
 import { arrivalAt } from '../../../shared/utils/arrivalClock';
 import { isScheduleFallbackTrainCode } from '../utils/scheduleFallback';
 import { recordLockCorrection } from '../utils/lockCorrectionMetrics';
-import { buildDirectionMeta } from '../../route/utils/trainLineDirection';
+import { buildDirectionMeta, parseTrainLineDirection } from '../../route/utils/trainLineDirection';
 import { parseArrivalDistance } from '../../arrival/utils/arrivalStatusDistance';
 import { LINE_COLORS } from '../../../shared/constants/lineColors';
 import { buildFallbackSequenceLabel, buildPrevTrainLabel } from '../../../shared/constants/labels';
@@ -179,6 +179,16 @@ interface Props {
    * 상태와 동일한 기존 렌더 100% 보존.
    */
   consensusSuggestion?: { trainCode: string } | null;
+  /**
+   * #2446 — 이 집합에 속한 trainCode의 row는 nextStationLabel(route 진행 방향 라벨)을 적용하지
+   * 않고 그 열차 자신의 실제 방면(raw destination 기반)으로 라벨링한다.
+   *
+   * `useBoardingLockController`의 boardingListArrivals가 #1326 fallback으로 반대 방향 열차를
+   * 합쳐 노출할 때, route 방향 라벨("한양대방면" 등)이 실제로는 반대 방향(성수행)인 열차에
+   * 거짓으로 붙는 회귀를 차단한다 — 뚝섬 실탑승 mislabel 사고. 미전달/빈 집합이면 기존 동작
+   * 100% 보존(모든 row가 nextStationLabel 사용).
+   */
+  offRouteTrainCodes?: ReadonlySet<string>;
 }
 
 /**
@@ -226,6 +236,7 @@ export function BoardingTrainList({
   fallbackReason = null,
   prevTrain = null,
   consensusSuggestion = null,
+  offRouteTrainCodes,
 }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -348,7 +359,12 @@ export function BoardingTrainList({
     const isPendingBlocked = pendingTrainCode != null && !isPending;
     const disabled = unreachable || isPendingBlocked;
     // #792: 종착·방면 라벨을 i18n 정규화 + dedup. nextStationLabel 미전달이면 종착만.
-    const metaText = buildDirectionMeta(train.destination, nextStationLabel, allStations);
+    // #2446 — offRouteTrainCodes에 속한 row(#1326 fallback으로 합쳐진 반대 방향 열차)는
+    // route 방향 nextStationLabel을 적용하지 않고 그 열차 자신의 실제 방면으로 라벨링한다.
+    const isOffRoute = offRouteTrainCodes?.has(train.trainCode) ?? false;
+    const metaText = isOffRoute
+      ? parseTrainLineDirection(train.destination, allStations)
+      : buildDirectionMeta(train.destination, nextStationLabel, allStations);
     // #2330 — consensusSuggestion이 이 row와 매칭되면 하이라이트 + "추정" 배지 + "직접 선택" 병기.
     // "선택됨" 표기는 절대 사용하지 않는다(오토락 부활 오해 차단) — pending(탭 확정 진행 중)과
     // 시각적으로 구분되는 별개의 하이라이트 색(accent border, PENDING_BORDER_WIDTH보다 얇게).

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -307,6 +307,34 @@ describe('BoardingTrainList', () => {
     expect(getByTestId('boarding-train-meta-T-NEXT').props.children).toBe('중곡방면');
   });
 
+  it('#2446 offRouteTrainCodes에 속한 row는 nextStationLabel(route 방향) 대신 자신의 실제 방면으로 라벨링', () => {
+    // 뚝섬→신당 route로 nextStationLabel="한양대"가 내려온 상황을 재현. arrival.up(정방향)이
+    // 비어 #1326 fallback으로 반대 방향(성수행) 열차가 boardingListArrivals에 합쳐졌다면,
+    // 그 열차는 offRouteTrainCodes에 담겨 전달된다 — route 라벨("한양대방면")이 아니라 자신의
+    // 실제 방면("성수행")으로 표시되어야 사용자가 반대 방향임을 인지할 수 있다.
+    const correct = makeTrain({ trainCode: 'T-CORRECT', destination: '한양대행' });
+    const offRoute = makeTrain({ trainCode: 'T-OFFROUTE', destination: '성수행' });
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList
+        arrivals={[correct, offRoute]}
+        line="2"
+        onSelect={() => {}}
+        nextStationLabel="한양대"
+        offRouteTrainCodes={new Set(['T-OFFROUTE'])}
+      />,
+    );
+    expect(getByTestId('boarding-train-meta-T-CORRECT').props.children).toBe('한양대방면');
+    expect(getByTestId('boarding-train-meta-T-OFFROUTE').props.children).toBe('성수행');
+  });
+
+  it('#2446 offRouteTrainCodes 미전달이면 기존 동작 100% 보존(모든 row가 nextStationLabel 사용)', () => {
+    const train = makeTrain({ trainCode: 'T-DEFAULT', destination: '성수행' });
+    const { getByTestId } = renderWithTheme(
+      <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} nextStationLabel="한양대" />,
+    );
+    expect(getByTestId('boarding-train-meta-T-DEFAULT').props.children).toBe('한양대방면');
+  });
+
   it('#749 nextStationLabel null이면 종착만 표시 (방면 생략)', () => {
     const train = makeTrain({ trainCode: 'T-NO-NEXT', destination: '석남행', line: '7' });
     const { getByTestId } = renderWithTheme(

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -269,6 +269,63 @@ describe('useBoardingLockController', () => {
     });
   });
 
+  describe('offRouteTrainCodes (#2446)', () => {
+    // 뚝섬→신당 route에서 nextStationLabel이 "한양대"로 route 방향 표시될 때, arrival.up(정방향)
+    // 이 비어 #1326 fallback으로 arrival.down(성수행)이 합쳐진 케이스. 그 반대 방향 열차의
+    // trainCode가 offRouteTrainCodes에 담겨야 BoardingTrainList가 route 라벨을 붙이지 않는다.
+    it('방향 필터가 빈 쪽을 고르면 반대 방향(합쳐진 쪽) trainCode가 offRouteTrainCodes에 담긴다', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const onlyDown: StationArrival = { up: [], down: [downTrain] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: onlyDown }),
+      );
+      expect(result.current.boardingListArrivals).toEqual([downTrain]);
+      expect(result.current.offRouteTrainCodes).toEqual(new Set([downTrain.trainCode]));
+    });
+
+    it('방향 필터 결과가 있으면(merge 미발생) offRouteTrainCodes는 빈 집합', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      expect(result.current.offRouteTrainCodes).toEqual(new Set());
+    });
+
+    it('direction="down"일 때는 반대(arrival.up) 쪽 trainCode가 담긴다', () => {
+      mockResolveTripDirection.mockReturnValue('down');
+      const onlyUp: StationArrival = { up: [upTrain], down: [] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: onlyUp }),
+      );
+      expect(result.current.boardingListArrivals).toEqual([upTrain]);
+      expect(result.current.offRouteTrainCodes).toEqual(new Set([upTrain.trainCode]));
+    });
+
+    it('direction이 null(방향 미상)이면 "반대"가 정의되지 않아 offRouteTrainCodes는 빈 집합', () => {
+      mockResolveTripDirection.mockReturnValue(null);
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      expect(result.current.boardingListArrivals).toEqual([upTrain, downTrain]);
+      expect(result.current.offRouteTrainCodes).toEqual(new Set());
+    });
+
+    it('arrival null이면 offRouteTrainCodes는 빈 집합', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: null }),
+      );
+      expect(result.current.offRouteTrainCodes).toEqual(new Set());
+    });
+
+    it('폴백 시 반대 방향에서도 음수 arrivalSeconds(지나간 열차)는 제외', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const passed = makeTrain({ trainCode: 'PASSED', arrivalSeconds: -10 });
+      const future = makeTrain({ trainCode: 'FUTURE', arrivalSeconds: 180 });
+      const onlyDownMixed: StationArrival = { up: [], down: [passed, future] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: onlyDownMixed }),
+      );
+      expect(result.current.offRouteTrainCodes).toEqual(new Set(['FUTURE']));
+    });
+  });
+
   describe('createLockFromTrain', () => {
     beforeEach(() => {
       jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -76,6 +76,15 @@ export interface UseBoardingLockControllerResult {
    * 양쪽 모두 비어야 빈 목록. 빈 list "선택할 열차 없음" 회귀를 막되 Gate 1 엄격성은 건드리지 않는다.
    */
   boardingListArrivals: ArrivalInfo[];
+  /**
+   * #2446 — boardingListArrivals가 #1326 fallback으로 반대 방향 열차를 합쳐 넣은 경우, 그 반대
+   * 방향 열차들의 trainCode 집합. `BoardingTrainList`가 이 집합에 속한 row는 route 기준
+   * nextStationLabel을 적용하지 않고 그 열차 자신의 실제 방면(raw destination)으로 라벨링하도록
+   * 전달한다 — route 진행 방향(예: "한양대방면")을 반대 방향 열차(성수행)에 거짓으로 붙이는 회귀
+   * 차단(뚝섬 실탑승 mislabel 사고). direction이 null(방향 미상)이면 어느 쪽이 "반대"인지 정의할
+   * 수 없으므로 빈 집합 — 기존 동작(양쪽 모두 route 라벨 없이 노출) 그대로.
+   */
+  offRouteTrainCodes: ReadonlySet<string>;
   /** 사용자가 도착 list에서 열차 탭 시 호출. lock 생성을 위한 컨텍스트가 부족하면 no-op. */
   createLockFromTrain: (train: ArrivalInfo) => void;
   /**
@@ -340,6 +349,15 @@ export function useBoardingLockController({
     return [...arrival.up, ...arrival.down].filter(isReachable);
   }, [directionalArrivals, arrival]);
 
+  // #2446 — boardingListArrivals가 위 fallback으로 합쳐진 경우에만(directionalArrivals가 비어
+  // merge가 실제로 일어난 경우에만) 반대 방향 쪽 trainCode를 표시한다. direction이 null이면
+  // "반대"가 정의되지 않으므로 빈 집합.
+  const offRouteTrainCodes = useMemo<ReadonlySet<string>>(() => {
+    if (directionalArrivals.length > 0 || !arrival || direction === null) return new Set();
+    const oppositeSide = direction === 'up' ? arrival.down : arrival.up;
+    return new Set(oppositeSide.filter(isReachable).map((train) => train.trainCode));
+  }, [directionalArrivals, arrival, direction]);
+
   const createLockFromTrain = useCallback(
     (train: ArrivalInfo) => {
       if (!destinationId || !currentStation) return;
@@ -498,6 +516,7 @@ export function useBoardingLockController({
     lockSuggestion,
     directionalArrivals,
     boardingListArrivals,
+    offRouteTrainCodes,
     createLockFromTrain,
     hydrateLockFromCandidate,
     releaseLock: release,

--- a/src/features/route/components/MisBoardingReselectModal.tsx
+++ b/src/features/route/components/MisBoardingReselectModal.tsx
@@ -28,6 +28,11 @@ interface Props {
    * 호출자가 resolveNextAdjacentStationName으로 도출해 전달. null/미전달이면 종착만 노출.
    */
   nextStationLabel?: string | null;
+  /**
+   * #2446 — BoardingTrainList로 forward. #1326 fallback으로 합쳐진 반대 방향 열차 trainCode
+   * 집합. 해당 row는 route 방향 nextStationLabel 대신 자신의 실제 방면으로 라벨링된다.
+   */
+  offRouteTrainCodes?: ReadonlySet<string>;
 }
 
 /**
@@ -44,6 +49,7 @@ export function MisBoardingReselectModal({
   onSelect,
   onClose,
   nextStationLabel = null,
+  offRouteTrainCodes,
 }: Props) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -84,6 +90,7 @@ export function MisBoardingReselectModal({
               line={line}
               onSelect={onSelect}
               nextStationLabel={nextStationLabel}
+              offRouteTrainCodes={offRouteTrainCodes}
             />
           )}
         </View>

--- a/src/features/route/utils/__tests__/loopDirection.test.ts
+++ b/src/features/route/utils/__tests__/loopDirection.test.ts
@@ -1,4 +1,4 @@
-import { inferLoopDirection, parseTrainLineDirection } from '../loopDirection';
+import { inferLoopDirection, nextLoopAdjacentStationName, parseTrainLineDirection } from '../loopDirection';
 
 jest.mock('../../../../shared/utils/stationRoute', () => ({
   getStationsOnLine: (line: string) => {
@@ -98,6 +98,61 @@ describe('inferLoopDirection — 하이브리드 노선 (6호선 응암 루프, 
 
   it.each(cases)('%s', (_desc, from, to, expected) => {
     expect(inferLoopDirection('6', from, to)).toBe(expected);
+  });
+});
+
+describe('nextLoopAdjacentStationName (#2446)', () => {
+  // #649/#807 nextStationLabel의 loop fallback — resolveNextAdjacentStationName이 비단조
+  // 노선에서 inferLoopDirection으로 산출한 방향을 받아 실제 1-hop 인접역 이름을 계산한다.
+  describe('진짜 순환선(2호선) — modulo wrap', () => {
+    const cases: Array<[string, string, 'up' | 'down', string | null]> = [
+      ['시청 → down(외선) → 을지로입구(다음 idx)', '시청', 'down', '을지로입구'],
+      ['시청 → up(내선) → 왕십리(wrap, idx -1 → 마지막)', '시청', 'up', '왕십리'],
+      ['왕십리 → down(외선) → 시청(wrap, 마지막 idx → 0)', '왕십리', 'down', '시청'],
+      ['까치산(지선)은 main range 밖 — currentIdx 미발견 → null', '까치산', 'down', null],
+      ['존재하지 않는 역명 → null', '없는역', 'down', null],
+    ];
+    it.each(cases)('%s', (_desc, current, direction, expected) => {
+      expect(nextLoopAdjacentStationName('2', current, direction)).toBe(expected);
+    });
+  });
+
+  describe('하이브리드 노선(6호선 응암 루프) — wrap 없이 단순 ±1, 범위 밖은 null', () => {
+    const cases: Array<[string, string, 'up' | 'down', string | null]> = [
+      ['합정 → down(본선 forward) → 상수', '합정', 'down', '상수'],
+      ['합정 → up(본선 backward) → 망원', '합정', 'up', '망원'],
+      ['응암(idx 0) → up → 범위 밖(-1) → null', '응암', 'up', null],
+      ['공덕(fixture 마지막 idx) → down → 범위 밖 → null', '공덕', 'down', null],
+    ];
+    it.each(cases)('%s', (_desc, current, direction, expected) => {
+      expect(nextLoopAdjacentStationName('6', current, direction)).toBe(expected);
+    });
+  });
+
+  it('CLOSED_LOOPS 미포함 노선(3호선)은 null', () => {
+    expect(nextLoopAdjacentStationName('3', '대화', 'down')).toBeNull();
+  });
+
+  describe('empty/small loop guards', () => {
+    const stationRoute = jest.requireMock('../../../../shared/utils/stationRoute') as {
+      getStationsOnLine: (line: string) => Array<{ id: string; name: string; line: string }>;
+    };
+    const original = stationRoute.getStationsOnLine;
+
+    afterEach(() => {
+      stationRoute.getStationsOnLine = original;
+    });
+
+    it('순환선이지만 stations 빈 배열이면 null', () => {
+      stationRoute.getStationsOnLine = () => [];
+      expect(nextLoopAdjacentStationName('2', '시청', 'down')).toBeNull();
+    });
+
+    it('메인 루프 station이 1개 이하면 null', () => {
+      stationRoute.getStationsOnLine = (line: string) =>
+        line === '2' ? [{ id: '2-001', name: '시청', line: '2' }] : [];
+      expect(nextLoopAdjacentStationName('2', '시청', 'down')).toBeNull();
+    });
   });
 });
 

--- a/src/features/route/utils/__tests__/nextAdjacentStation.test.ts
+++ b/src/features/route/utils/__tests__/nextAdjacentStation.test.ts
@@ -17,8 +17,42 @@ describe('resolveNextAdjacentStationName', () => {
     expect(next).toBe(stations[yongmasanIdx - 1].name);
   });
 
-  it('비단조 노선(2호선 순환)은 null', () => {
-    expect(resolveNextAdjacentStationName('2', '강남', '잠실')).toBeNull();
+  describe('#2446 — 비단조 순환 노선(2호선)은 inferLoopDirection fallback으로 인접역 산출', () => {
+    // 뚝섬 실탑승 회귀(2026-08-31): resolveTravelDirection이 2호선(MONOTONIC_LINES 밖)에서
+    // null을 반환 → 이 함수도 null → 호출자(buildDirectionMeta)가 raw trainLineNm("성수행")을
+    // 그대로 노출해 반대 방향 라벨이 표시됐다. inferLoopDirection + nextLoopAdjacentStationName
+    // fallback으로 route 방향 기준 실제 다음 인접역을 산출한다.
+    it('뚝섬 → 신당(환승) 방향 → 한양대(1-hop 인접역, 내선)', () => {
+      // 뚝섬(2-010) → 신당(2-006) 진행 방향은 id 감소(내선/한양대 방면). resolveTripDirection과
+      // 동일하게 'up'을 산출해야 한다(회귀 방지 — tripDirection.test.ts에 동일 케이스 병행).
+      expect(resolveNextAdjacentStationName('2', '뚝섬', '신당')).toBe('한양대');
+    });
+
+    it('강남 → 잠실 방향 → 역삼(1-hop, id 감소 방향)', () => {
+      expect(resolveNextAdjacentStationName('2', '강남', '잠실')).toBe('역삼');
+    });
+
+    it('순환선 wrap 경계(신촌 → 시청) → 이대(wrap-aware 1-hop)', () => {
+      expect(resolveNextAdjacentStationName('2', '신촌', '시청')).toBe('이대');
+    });
+
+    it('지선(까치산)은 main range 밖 — resolveTravelDirection도 loop fallback도 null', () => {
+      expect(resolveNextAdjacentStationName('2', '까치산', '시청')).toBeNull();
+    });
+
+    it('toward가 2호선에 존재하지 않는 역명이면 inferLoopDirection도 null → 이 함수도 null', () => {
+      expect(resolveNextAdjacentStationName('2', '시청', '존재하지않는역명XYZ')).toBeNull();
+    });
+  });
+
+  describe('#2446 — 하이브리드 순환 노선(6호선 응암 루프)도 loop fallback으로 동작', () => {
+    it('합정 → 공덕 방향(본선 forward) → 상수(1-hop)', () => {
+      expect(resolveNextAdjacentStationName('6', '합정', '공덕')).toBe('상수');
+    });
+
+    it('합정 → 망원 방향(본선 backward) → 망원(1-hop, 종점 인접이라 그 자체가 다음역)', () => {
+      expect(resolveNextAdjacentStationName('6', '합정', '망원')).toBe('망원');
+    });
   });
 
   it('towardStation이 stations에 없으면 (확장 미반영 종점 등) null', () => {

--- a/src/features/route/utils/__tests__/tripDirection.test.ts
+++ b/src/features/route/utils/__tests__/tripDirection.test.ts
@@ -56,6 +56,27 @@ describe('resolveTripDirection', () => {
     expect(resolveTripDirection(route, '강남', '1-001')).toBe('down');
   });
 
+  describe('#2446 — 뚝섬 실탑승 회귀 재현: resolveTripDirection은 이미 정확한 방향을 산출한다', () => {
+    // 2026-08-31 실탑승: 뚝섬(2호선)→신당(6호선 환승)→석계 route에서 보딩 카드가 "성수행"
+    // (반대 방향)을 노출한 사고. 재현 조사 결과 이 함수(resolveTripDirection) 자체는 이미
+    // 정확히 'up'(한양대/내선 방향, 신당 방면)을 산출한다 — 근본 원인은 nextAdjacentStation.ts의
+    // 별도 resolver(resolveNextAdjacentStationName)가 비단조 노선에서 null을 반환해 라벨이
+    // route와 무관한 raw trainLineNm으로 fallback한 것이었다(#2446 R1a, 별도 fix).
+    // 이 테스트는 resolveTripDirection의 기존 정확성을 회귀 가드로 고정한다.
+    it('뚝섬(2호선, transfer leg) → 신당(환승 waypoint) = up (내선/한양대 방향)', () => {
+      const route = makeTransferRoute({
+        transferName: '신당',
+        fromLine: '2',
+        toLine: '6',
+        stopsToTransfer: 4,
+        stopsFromTransfer: 6,
+      });
+      // 뚝섬(2-010) 현재 위치, destination 석계(6호선) — direction은 첫 leg(2호선)의
+      // fromLine + transferName(신당) 기준으로 산출된다.
+      expect(resolveTripDirection(route, '석계', '2-010')).toBe('up');
+    });
+  });
+
   describe('#1922 — closed loop (2호선 환상선) direction', () => {
     // 2호선 본선 closed loop은 id 사전순 정렬이 wraparound와 일치하지 않을 수 있으므로
     // shortestLinePathIndices로 짧은 쪽 path를 산출해 방향 결정.

--- a/src/features/route/utils/loopDirection.ts
+++ b/src/features/route/utils/loopDirection.ts
@@ -81,6 +81,50 @@ export function parseTrainLineDirection(trainLineNm: string): TravelDirection | 
   return null;
 }
 
+/**
+ * 순환/하이브리드 노선에서 currentStationName 기준 direction(1역 前) 인접역 이름을 반환한다(#2446).
+ *
+ * `resolveNextAdjacentStationName`(nextAdjacentStation.ts)이 비단조 노선(2호선 순환 등)에서
+ * `resolveTravelDirection`이 null을 반환할 때 쓰는 fallback. `inferLoopDirection`으로 이미
+ * 산출한 방향을 받아 그 방향으로 한 칸 이동한 인접역만 계산한다(호 길이 비교는 하지 않음 —
+ * "다음 인접역"은 항상 1-hop이므로 wrap 여부만 판단하면 된다).
+ *
+ * - 진짜 순환선(2호선, `loopTailRange` 없음): mainIdRange 내에서 modulo wrap(양 끝 seam 연결).
+ * - 하이브리드 노선(6호선): 단방향 꼬리라 wrap 없이 단순 id ±1 (범위 밖이면 null — 종점 밖은
+ *   `resolveTravelDirection`/지선 영역이라 이 함수 책임 밖).
+ * - 대상 노선 아니거나 currentStationName이 main range에 없으면 null.
+ */
+export function nextLoopAdjacentStationName(
+  line: LineNumber,
+  currentStationName: string,
+  direction: TravelDirection,
+): string | null {
+  const meta = CLOSED_LOOPS[line];
+  if (!meta) return null;
+
+  const stations = getStationsOnLine(line);
+  if (stations.length === 0) return null;
+
+  const { firstId, lastId } = meta.mainIdRange;
+  const main = stations.filter((s) => s.id >= firstId && s.id <= lastId);
+  if (main.length < 2) return null;
+
+  const currentIdx = indexOf(main, currentStationName);
+  if (currentIdx === -1) return null;
+
+  const n = main.length;
+
+  if (meta.loopTailRange) {
+    const nextIdx = direction === 'down' ? currentIdx + 1 : currentIdx - 1;
+    if (nextIdx < 0 || nextIdx >= n) return null;
+    return main[nextIdx].name;
+  }
+
+  const step = direction === 'down' ? 1 : -1;
+  const nextIdx = (currentIdx + step + n) % n;
+  return main[nextIdx].name;
+}
+
 function indexOf(stations: ReadonlyArray<{ name: string }>, name: string): number {
   const exact = stations.findIndex((s) => s.name === name);
   if (exact !== -1) return exact;

--- a/src/features/route/utils/nextAdjacentStation.ts
+++ b/src/features/route/utils/nextAdjacentStation.ts
@@ -1,5 +1,6 @@
 import type { LineNumber } from '../../../shared/types/station';
 import { resolveTravelDirection } from './travelDirection';
+import { inferLoopDirection, nextLoopAdjacentStationName } from './loopDirection';
 import { getStationsOnLine, normalizeStationName } from '../../../shared/utils/stationRoute';
 
 /**
@@ -8,9 +9,14 @@ import { getStationsOnLine, normalizeStationName } from '../../../shared/utils/s
  * BoardingTrainList가 사용자에게 "다음 인접역 방면"으로 표기하기 위함 — 종착(석남) 대신
  * 다음 정거장(중곡) 같은 즉각적인 정보를 노출한다.
  *
- * 단조 노선(`lineTopology.json`의 monotonicLines)에 한해 동작. 비단조/순환 노선이거나
- * 현재역/방향역이 stations 리스트에서 매칭 안 되면 resolveTravelDirection이 null 반환 →
- * 본 함수도 null. 호출자는 fallback(종착 표기 등)을 선택한다.
+ * 단조 노선(`lineTopology.json`의 monotonicLines)이 우선. 비단조/순환 노선(2호선 본선, 6호선
+ * 응암 루프)은 resolveTravelDirection이 null을 반환하므로 `inferLoopDirection` +
+ * `nextLoopAdjacentStationName`(loopDirection.ts)으로 fallback한다(#2446 — 뚝섬에서 "성수행"
+ * 같은 raw headsign이 그대로 노출되던 회귀. resolveTravelDirection null → 이 함수도 null →
+ * 호출자가 route와 무관한 원본 trainLineNm으로 fallback했던 것이 근본 원인).
+ *
+ * 두 fallback 모두 실패(대상 노선 아님/역 미매칭/ambiguous)하면 null. 호출자는 기존과 동일하게
+ * 종착 표기 등으로 fallback한다.
  */
 export function resolveNextAdjacentStationName(
   line: LineNumber,
@@ -18,13 +24,18 @@ export function resolveNextAdjacentStationName(
   towardStationName: string,
 ): string | null {
   const resolution = resolveTravelDirection(line, currentStationName, towardStationName);
-  if (!resolution) return null;
-  // resolveTravelDirection이 같은 stations 캐시를 normalize로 매칭해 성공했으므로,
-  // 같은 캐시·같은 normalize로 currentIdx 재조회는 반드시 ≥0. 노선 종단점도 toward와 동일하지
-  // 않으므로 nextIdx는 항상 유효 범위 안.
-  const stations = getStationsOnLine(line);
-  const target = normalizeStationName(currentStationName);
-  const currentIdx = stations.findIndex((s) => normalizeStationName(s.name) === target);
-  const nextIdx = resolution.direction === 'down' ? currentIdx + 1 : currentIdx - 1;
-  return stations[nextIdx].name;
+  if (resolution) {
+    // resolveTravelDirection이 같은 stations 캐시를 normalize로 매칭해 성공했으므로,
+    // 같은 캐시·같은 normalize로 currentIdx 재조회는 반드시 ≥0. 노선 종단점도 toward와 동일하지
+    // 않으므로 nextIdx는 항상 유효 범위 안.
+    const stations = getStationsOnLine(line);
+    const target = normalizeStationName(currentStationName);
+    const currentIdx = stations.findIndex((s) => normalizeStationName(s.name) === target);
+    const nextIdx = resolution.direction === 'down' ? currentIdx + 1 : currentIdx - 1;
+    return stations[nextIdx].name;
+  }
+
+  const loopDirection = inferLoopDirection(line, currentStationName, towardStationName);
+  if (!loopDirection) return null;
+  return nextLoopAdjacentStationName(line, currentStationName, loopDirection);
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -745,6 +745,7 @@ export default function HomeScreen() {
     lock: boardingLock,
     lockSuggestion,
     boardingListArrivals,
+    offRouteTrainCodes,
     createLockFromTrain,
     hydrateLockFromCandidate,
     releaseLock: releaseBoardingLock,
@@ -1313,6 +1314,7 @@ export default function HomeScreen() {
         onSelect={handleMisBoardingReselect}
         onClose={handleMisBoardingModalClose}
         nextStationLabel={nextStationName}
+        offRouteTrainCodes={offRouteTrainCodes}
       />
       {/* #924 D1 — 환승 자동 detect 다중 후보 모달. F4 1탭 모달 인프라(#914) 재사용. */}
       <CurrentStationConfirmModal
@@ -1675,6 +1677,7 @@ export default function HomeScreen() {
                                 >
                                   <BoardingTrainList
                                     arrivals={boardingListArrivals}
+                                    offRouteTrainCodes={offRouteTrainCodes}
                                     // #797: approachLine 우선 — 환승역에서 effectiveOrigin.line이 trip 방향과
                                     // 어긋날 때 BoardingLock·route SSOT로 정확한 호선 표시.
                                     line={approachLine ?? effectiveOrigin.line}


### PR DESCRIPTION
## Summary

- 2026-08-31 실탑승: 뚝섬(2호선)→신당(6호선 환승)→석계 route에서 탑승 카드가 "성수행"(반대 방향)을 노출해 사용자가 반대 방향으로 탑승한 사고.
- Root cause (R1a, 확정): `resolveNextAdjacentStationName`이 비단조(순환) 노선에서 `resolveTravelDirection`(단조 전용) 사용 → 2호선/6호선에서 항상 `null` → `BoardingTrainList`가 route와 무관한 raw Seoul `trainLineNm`("성수행")을 그대로 표시.
- 2차 위험(R1b, 상호작용): #1326 fallback으로 `boardingListArrivals`에 반대 방향 열차가 합쳐진 경우, R1a fix만 있으면 그 반대 방향 열차에도 route 라벨이 거짓으로 붙을 수 있어 별도로 차단.
- 재현 조사 결과 `resolveTripDirection`(별도 resolver)은 뚝섬→신당에서 이미 정확한 방향(`'up'`)을 산출 — 해당 resolver 자체는 정상이라 변경하지 않음.

Closes #2446

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. 신규 export(`nextLoopAdjacentStationName`, `offRouteTrainCodes`)는 각각 `nextAdjacentStation.ts`, `HomeScreen.tsx`/`MisBoardingReselectModal.tsx`가 caller로 존재.
- [x] **2. V/X dashboard** — 별도 신규 관측 신호 없음(UI 라벨 로직 수정). 회귀 여부는 BoardingTrainList/BoardingLockHopCard의 방면 라벨 텍스트로 육안 확인 가능 (X: "성수행" 오라벨 재발, V: route 방향 정확 라벨 또는 반대방향 열차의 정직한 자기 방면 표시).
- [x] **3. 의존 PR** — N/A (device-only 로직 변경, backend/infra 변경 없음).
- [x] **4. 측정 plan** — 2호선/6호선 환승·순환 구간 실탑승 시 탑승 카드/목록 라벨이 route 진행 방향과 일치하는지 1주 내 재현 시나리오로 확인 (특히 뚝섬/강변/잠실나루/신촌 등 wrap 경계, 합정/새절 등 6호선 하이브리드 경계).
- [x] **5. Device verify** — 필요. 시나리오: (a) 2호선 뚝섬→신당 환승 route에서 탑승 카드가 "왕십리방면"/"한양대방면"으로 표시되는지, (b) #1326 fallback 발동 상황(방향 populated side가 일시적으로 빔)에서 반대 방향 열차가 섞이면 그 열차 행이 route 라벨이 아닌 자신의 실제 행선(raw destination)으로 표시되는지.

### V/X dashboard URL

N/A — 로그/telemetry 미변경. UI 라벨 텍스트 직접 확인.

### 의존 PR

N/A

---

## Test plan

- [x] `npm test` — 9870 tests, 100% coverage (lines/functions/branches/statements) pass
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass — "No orphan exports detected."
- [x] 뚝섬→신당(2호선, transfer leg) route에서 `resolveNextAdjacentStationName` red→green 재현 (`null` → `'한양대'`)
- [x] `resolveTripDirection` 뚝섬→신당 회귀 가드 테스트 추가(기존 정확성 문서화, green)
- [x] 2호선(wrap 경계 포함)/6호선(하이브리드) loop fixture 신규 테스트
- [x] `offRouteTrainCodes` red→green: #1326 fallback merge 발생 시 반대 방향 trainCode 집합화 + `BoardingTrainList` per-row 라벨 분기
- [x] #788/#1326/#1014/#1449/#1922/#1965 기존 fixture 전부 회귀 없이 green 유지 (unchanged)

## 변경 파일

- `src/features/route/utils/loopDirection.ts` — `nextLoopAdjacentStationName` 신규 export
- `src/features/route/utils/nextAdjacentStation.ts` — loop fallback 배선
- `src/features/alarm/hooks/useBoardingLockController.ts` — `offRouteTrainCodes` 파생값
- `src/features/alarm/components/BoardingTrainList.tsx` — per-row 라벨 분기(offRouteTrainCodes)
- `src/features/route/components/MisBoardingReselectModal.tsx`, `src/screens/HomeScreen.tsx` — prop wiring
- 관련 테스트 5개 파일