### PR TITLE
perf(#2449): /position KV write throttle — Free-plan quota 소진 방지

### DIFF
--- a/backend/alarm-worker/src/__tests__/accelSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/accelSeries.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ACCEL_SERIES_WRITE_MIN_INTERVAL_MS,
   ACCEL_WINDOW_MS,
   appendAccelSample,
   clearAccelSeries,
@@ -34,14 +35,20 @@ describe('accelSeries — KV roundtrip', () => {
   });
 
   it('90개를 넘어가면 oldest sample이 ring으로 잘림', async () => {
+    // write throttle(ACCEL_SERIES_WRITE_MIN_INTERVAL_MS) 간격보다 넉넉히 벌려서
+    // 매 sample이 실제로 write되도록 함 (ring-trim 자체를 검증하는 테스트).
     const kv = new InMemoryKV() as unknown as KVNamespace;
     for (let i = 0; i < 100; i++) {
-      await appendAccelSample(kv, 'tok', sample({ startTs: i, endTs: i + 1 }));
+      await appendAccelSample(
+        kv,
+        'tok',
+        sample({ startTs: i * 60_000, endTs: i * 60_000 + 1 }),
+      );
     }
     const series = await readAccelSeries(kv, 'tok');
     expect(series).toHaveLength(90);
-    expect(series[0].startTs).toBe(10);
-    expect(series[89].startTs).toBe(99);
+    expect(series[0].startTs).toBe(10 * 60_000);
+    expect(series[89].startTs).toBe(99 * 60_000);
   });
 
   it('clearAccelSeries → readAccelSeries 빈 배열', async () => {
@@ -73,6 +80,40 @@ describe('accelSeries — KV roundtrip', () => {
     await kv.put('accel:tok', invalid);
     const series = await readAccelSeries(kv, 'tok');
     expect(series).toHaveLength(1);
+  });
+});
+
+describe('appendAccelSample — write throttle (KV quota #2439-ish)', () => {
+  it('cold start(series 비어있음)는 항상 write', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const series = await appendAccelSample(kv, 'tok', sample({ endTs: 1000 }));
+    expect(series).toHaveLength(1);
+    expect(await readAccelSeries(kv, 'tok')).toHaveLength(1);
+  });
+
+  it('간격 미달(직전 sample.endTs 대비 interval 미만) → put skip', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await appendAccelSample(kv, 'tok', sample({ endTs: 0 }));
+    const result = await appendAccelSample(
+      kv,
+      'tok',
+      sample({ endTs: ACCEL_SERIES_WRITE_MIN_INTERVAL_MS - 1 }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].endTs).toBe(0);
+    expect(await readAccelSeries(kv, 'tok')).toHaveLength(1);
+  });
+
+  it('간격 충족(정확히 interval) → write 진행', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await appendAccelSample(kv, 'tok', sample({ endTs: 0 }));
+    const result = await appendAccelSample(
+      kv,
+      'tok',
+      sample({ endTs: ACCEL_SERIES_WRITE_MIN_INTERVAL_MS }),
+    );
+    expect(result).toHaveLength(2);
+    expect(await readAccelSeries(kv, 'tok')).toHaveLength(2);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/motionState.test.ts
+++ b/backend/alarm-worker/src/__tests__/motionState.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   MOTION_MIN_SAMPLES,
   MOTION_WINDOW_MS,
+  SSOT_MOTION_WRITE_MIN_INTERVAL_MS,
   computeMotionState,
   emitMotionTransitionBreadcrumb,
   hasArvlcdTrainProgress,
@@ -9,6 +10,7 @@ import {
   updateSsotMotion,
 } from '../motionState';
 import {
+  DEVICE_SYNC_STALE_THRESHOLD_MS,
   seedSsot,
   readSsot,
   writeSsot,
@@ -412,4 +414,124 @@ describe('updateSsotMotion — POST /position 수신 path', () => {
       JSON.stringify({ from: 'moving', to: 'stationary' }),
     );
   });
+});
+
+describe('updateSsotMotion — write throttle (KV quota #2439-ish)', () => {
+  let kv: InMemoryKV;
+
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('motionEvidence가 out-of-order(최신 evidence가 배열 뒤쪽 아님)여도 최신 ts 기준으로 스로틀 판단', async () => {
+    // #newestDevicePositionEvidenceTs 분기 커버 — 두 번째 device-position entry의 ts가
+    // 첫 번째보다 작은(과거) 경우에도 max(ts)를 정확히 찾아야 함 + non-device-position 소스는
+    // 스킵되어야 함.
+    const ssot = makeSsot({
+      tripToken: 'tok-order',
+      motionEvidence: [
+        gpsEvidence(37.5, 127.0, 100_000),
+        gpsEvidence(37.5, 127.0, 50_000),
+        arvlcdEvidence('0228', 90_000),
+      ],
+    });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    // now - newest(100_000) = 30_000 ≥ SSOT_MOTION_WRITE_MIN_INTERVAL_MS(25_000) → write 진행
+    const now = 130_000;
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-order',
+      makePosition({ ts: now }),
+      now,
+    );
+    expect(result?.motionEvidence).toHaveLength(4);
+  });
+
+  it('cold start(evidence 없음)는 항상 write', async () => {
+    await seedSsot(kv as unknown as KVNamespace, 'tok-cold', '0228');
+    const pos = makePosition({ ts: 1_000_000 });
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-cold',
+      pos,
+      1_000_000,
+    );
+    expect(result?.motionEvidence).toHaveLength(1);
+    const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-cold');
+    expect(persisted?.motionEvidence).toHaveLength(1);
+  });
+
+  it('직전 evidence로부터 간격 미달 → evidence push/write 둘 다 skip', async () => {
+    await seedSsot(kv as unknown as KVNamespace, 'tok-skip', '0228');
+    await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-skip',
+      makePosition({ ts: 0 }),
+      0,
+    );
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-skip',
+      makePosition({ ts: SSOT_MOTION_WRITE_MIN_INTERVAL_MS - 1 }),
+      SSOT_MOTION_WRITE_MIN_INTERVAL_MS - 1,
+    );
+    // skip이므로 evidence는 여전히 1건, lastDeviceSyncAt도 첫 write 시점(0)에 머무름.
+    expect(result?.motionEvidence).toHaveLength(1);
+    expect(result?.lastDeviceSyncAt).toBe(0);
+    const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-skip');
+    expect(persisted?.motionEvidence).toHaveLength(1);
+  });
+
+  it('간격 충족(정확히 interval) → write 진행 (evidence 2건)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, 'tok-write', '0228');
+    await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-write',
+      makePosition({ ts: 0 }),
+      0,
+    );
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-write',
+      makePosition({ ts: SSOT_MOTION_WRITE_MIN_INTERVAL_MS }),
+      SSOT_MOTION_WRITE_MIN_INTERVAL_MS,
+    );
+    expect(result?.motionEvidence).toHaveLength(2);
+    expect(result?.lastDeviceSyncAt).toBe(SSOT_MOTION_WRITE_MIN_INTERVAL_MS);
+  });
+
+  it(
+    'lastDeviceSyncAt은 25s 스로틀 cadence에서도 DEVICE_SYNC_STALE_THRESHOLD_MS(5min) ' +
+      '안에서 항상 신선 (자명 — write 자체가 최소 25s마다 일어남)',
+    () => {
+      expect(SSOT_MOTION_WRITE_MIN_INTERVAL_MS).toBeLessThan(
+        DEVICE_SYNC_STALE_THRESHOLD_MS,
+      );
+    },
+  );
+
+  it(
+    '#1 우선순위 — 25s 스로틀 cadence로 5분 시뮬레이션(디바이스는 10s마다 호출, ' +
+      "motion='unknown' + 무변위 GPS) → evidence 버퍼가 MOTION_MIN_SAMPLES 이상 쌓여 " +
+      "computeMotionState가 'stationary'로 수렴 (버퍼 starvation이면 'unknown' 고착 → " +
+      '#2433 motion-gate blindspot류 회귀 재현 방지)',
+    async () => {
+      await seedSsot(kv as unknown as KVNamespace, 'tok-density', '0228');
+      const startNow = 1_000_000;
+      const totalMs = MOTION_WINDOW_MS; // 5분
+      const deviceCallIntervalMs = 10_000; // 실제 디바이스 POST /position 주기
+      let result: TripPositionSSoT | null = null;
+      for (let elapsed = 0; elapsed <= totalMs; elapsed += deviceCallIntervalMs) {
+        const now = startNow + elapsed;
+        const pos = makePosition({ motion: 'unknown', ts: now });
+        result = await updateSsotMotion(kv as unknown as KVNamespace, 'tok-density', pos, now);
+      }
+      expect(result).not.toBeNull();
+      const deviceEvidence = result!.motionEvidence.filter(
+        (e) => e.source === 'device-position',
+      );
+      expect(deviceEvidence.length).toBeGreaterThanOrEqual(MOTION_MIN_SAMPLES);
+      expect(result!.motionState).toBe('stationary');
+    },
+  );
 });

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -10,6 +10,7 @@ import {
   evaluateWindow,
   haversineKm,
   pickMotionMode,
+  POSITION_SERIES_WRITE_MIN_INTERVAL_MS,
   POSITION_WINDOW_MS,
   readSeries,
 } from '../positionSeries';
@@ -37,14 +38,16 @@ describe('positionSeries — KV roundtrip', () => {
   });
 
   it('30개를 넘어가면 oldest sample이 ring으로 잘림', async () => {
+    // write throttle(POSITION_SERIES_WRITE_MIN_INTERVAL_MS) 간격보다 넉넉히 벌려서
+    // 매 point가 실제로 write되도록 함 (ring-trim 자체를 검증하는 테스트).
     const kv = new InMemoryKV() as unknown as KVNamespace;
     for (let i = 0; i < 40; i++) {
-      await appendPositionPoint(kv, 'tok', point({ ts: i }));
+      await appendPositionPoint(kv, 'tok', point({ ts: i * 40_000 }));
     }
     const series = await readSeries(kv, 'tok');
     expect(series).toHaveLength(30);
-    expect(series[0].ts).toBe(10);
-    expect(series[29].ts).toBe(39);
+    expect(series[0].ts).toBe(10 * 40_000);
+    expect(series[29].ts).toBe(39 * 40_000);
   });
 
   it('clearSeries → readSeries 빈 배열', async () => {
@@ -76,6 +79,51 @@ describe('positionSeries — KV roundtrip', () => {
     await kv.put('pos:tok', invalid);
     const series = await readSeries(kv, 'tok');
     expect(series).toHaveLength(1);
+  });
+});
+
+describe('appendPositionPoint — write throttle (KV quota #2439-ish)', () => {
+  it('cold start(series 비어있음)는 항상 write', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const series = await appendPositionPoint(kv, 'tok', point({ ts: 1000 }));
+    expect(series).toHaveLength(1);
+    expect(await readSeries(kv, 'tok')).toHaveLength(1);
+  });
+
+  it('간격 미달(직전 point 대비 interval 미만) → put skip, 메모리 append도 skip', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await appendPositionPoint(kv, 'tok', point({ ts: 0 }));
+    const result = await appendPositionPoint(
+      kv,
+      'tok',
+      point({ ts: POSITION_SERIES_WRITE_MIN_INTERVAL_MS - 1 }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].ts).toBe(0);
+    const persisted = await readSeries(kv, 'tok');
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].ts).toBe(0);
+  });
+
+  it('간격 충족(정확히 interval) → write 진행', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await appendPositionPoint(kv, 'tok', point({ ts: 0 }));
+    const result = await appendPositionPoint(
+      kv,
+      'tok',
+      point({ ts: POSITION_SERIES_WRITE_MIN_INTERVAL_MS }),
+    );
+    expect(result).toHaveLength(2);
+    const persisted = await readSeries(kv, 'tok');
+    expect(persisted).toHaveLength(2);
+  });
+
+  it('역행/동시 ts(clock skew) → skip (throttle과 동일 취급)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await appendPositionPoint(kv, 'tok', point({ ts: 100_000 }));
+    const result = await appendPositionPoint(kv, 'tok', point({ ts: 50_000 }));
+    expect(result).toHaveLength(1);
+    expect(result[0].ts).toBe(100_000);
   });
 });
 

--- a/backend/alarm-worker/src/accelSeries.ts
+++ b/backend/alarm-worker/src/accelSeries.ts
@@ -15,6 +15,15 @@ const MAX_SERIES_SAMPLES = 90;
 const SERIES_TTL_SEC = 60 * 60;
 /** evaluateAccelWindow 기본 window — 60s, positionSeries POSITION_WINDOW_MS와 정합. */
 export const ACCEL_WINDOW_MS = 60_000;
+/**
+ * KV write 최소 간격 (ms) — CF Free tier 1,000 writes/day quota 소진 방지
+ * (positionSeries.POSITION_SERIES_WRITE_MIN_INTERVAL_MS와 동일 정책).
+ *
+ * E2 Kalman/E3 phase 감지는 아직 이 series를 게이트 입력으로 소비하지 않으므로(수집 전용
+ * 단계, 모듈 헤더 참고) window당 최소 point 수 제약이 없다 — 55s로 여유 있게 스로틀.
+ * cold start(series 비어있음)는 항상 write.
+ */
+export const ACCEL_SERIES_WRITE_MIN_INTERVAL_MS = 55_000;
 
 /**
  * 디바이스 토큰의 가속도 series에 새 요약값을 append하고 저장.
@@ -26,6 +35,15 @@ export async function appendAccelSample(
   sample: AccelSummary,
 ): Promise<AccelSummary[]> {
   const series = await readAccelSeries(kv, token);
+  // #KV quota — 마지막 저장 sample이 ACCEL_SERIES_WRITE_MIN_INTERVAL_MS 미만 전이면 put skip
+  // (cold start, 즉 series 비어있으면 항상 write).
+  const newestEndTs = series.length > 0 ? series[series.length - 1].endTs : null;
+  if (
+    newestEndTs !== null &&
+    sample.endTs - newestEndTs < ACCEL_SERIES_WRITE_MIN_INTERVAL_MS
+  ) {
+    return series;
+  }
   series.push(sample);
   while (series.length > MAX_SERIES_SAMPLES) series.shift();
   await kv.put(seriesKey(token), JSON.stringify(series), { expirationTtl: SERIES_TTL_SEC });

--- a/backend/alarm-worker/src/motionState.ts
+++ b/backend/alarm-worker/src/motionState.ts
@@ -51,6 +51,28 @@ export const MOTION_STATIONARY_DISPLACEMENT_M = 10;
 export const MOTION_MOVING_DISPLACEMENT_M = 50;
 
 /**
+ * SSOT write 최소 간격 (ms) — CF Free tier 1,000 writes/day quota 소진 방지.
+ *
+ * POST /position은 10s마다 호출되지만 evidence push + writeSsot는 이 간격으로 스로틀한다:
+ * 최근 'device-position' evidence가 이 값보다 어리면(now 기준) push/write 둘 다 skip.
+ * 5분 윈도우(MOTION_WINDOW_MS)에 25s 간격이면 ~12 sample — MOTION_MIN_SAMPLES(10) 대비
+ * 20% 여유. token의 첫 evidence(cold start)는 항상 write.
+ */
+export const SSOT_MOTION_WRITE_MIN_INTERVAL_MS = 25_000;
+
+/** motionEvidence 중 최신 'device-position' sample의 ts. 없으면 null. */
+function newestDevicePositionEvidenceTs(
+  evidence: readonly MotionEvidence[],
+): number | null {
+  let newest: number | null = null;
+  for (const e of evidence) {
+    if (e.source !== 'device-position') continue;
+    if (newest === null || e.ts > newest) newest = e.ts;
+  }
+  return newest;
+}
+
+/**
  * SSOT.motionEvidence 중 'device-position' source의 GPS sample 쌍 최대 displacement (m).
  *
  * signal payload는 `{ lat: number; lng: number; ... }` 형태로 stamp되어 들어온다고 가정 —
@@ -177,6 +199,15 @@ export async function updateSsotMotion(
 ): Promise<TripPositionSSoT | null> {
   const ssot = await readSsot(kv, token);
   if (!ssot) return null;
+
+  // #KV quota — 최근 device-position evidence가 SSOT_MOTION_WRITE_MIN_INTERVAL_MS 미만
+  // 전이면 evidence push + writeSsot 둘 다 skip (cold start는 항상 진행).
+  // lastDeviceSyncAt은 write가 실제로 일어날 때만 갱신되지만, 그 write 자체가 최소
+  // 이 간격으로는 돌기 때문에 DEVICE_SYNC_STALE_THRESHOLD_MS(5min) 안에서는 항상 신선하다.
+  const lastEvidenceTs = newestDevicePositionEvidenceTs(ssot.motionEvidence);
+  if (lastEvidenceTs !== null && now - lastEvidenceTs < SSOT_MOTION_WRITE_MIN_INTERVAL_MS) {
+    return ssot;
+  }
 
   // #2321 (O1-B) — device sync freshness anchor. POST /position 수신 = device가 살아있다는
   // 직접 증거이므로 매 호출마다 stamp. 게이트들이 motionState/lastAdvanceAt을 신뢰할지

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -18,6 +18,16 @@ const MAX_SERIES_POINTS = 30;
 const SERIES_TTL_SEC = 60 * 60;
 /** motion 최빈값 계산용 윈도우 (최근 sample 개수). ADR Section 6 step 6. */
 const MOTION_RECENT_COUNT = 6;
+/**
+ * KV write 최소 간격 (ms) — CF Free tier 1,000 writes/day quota 소진 방지.
+ *
+ * 디바이스는 POST /position을 10s마다 호출하지만 series KV put은 이 간격으로 스로틀한다
+ * (신규 point의 `ts`가 저장된 마지막 point보다 이 값 미만 차이면 put skip, 메모리 append도 skip).
+ * `evaluateWindow`는 `[now-60s, now]`에서 hop 쌍(gpsAvgKmh)과 방향(cosineDirection)에 최소
+ * 2개의 distinct sample이 필요 — 30s 이하로 두면 60s 윈도우 안에 항상 ≥2 point가 보장된다.
+ * cold start(series 비어있음)는 항상 write.
+ */
+export const POSITION_SERIES_WRITE_MIN_INTERVAL_MS = 30_000;
 /** 게이트 #3 / 평균속도 산출에서 컷오프할 accuracy (meters). */
 export const ACCURACY_CUTOFF_M = 50;
 
@@ -57,6 +67,12 @@ export async function appendPositionPoint(
   point: PositionPoint,
 ): Promise<PositionPoint[]> {
   const series = await readSeries(kv, token);
+  // #KV quota — 마지막 저장 point가 POSITION_SERIES_WRITE_MIN_INTERVAL_MS 미만 전이면
+  // put 자체를 skip (cold start, 즉 series 비어있으면 항상 write).
+  const newestTs = series.length > 0 ? series[series.length - 1].ts : null;
+  if (newestTs !== null && point.ts - newestTs < POSITION_SERIES_WRITE_MIN_INTERVAL_MS) {
+    return series;
+  }
   series.push(point);
   // 오래된 쪽부터 제거 (push 후 잘림).
   while (series.length > MAX_SERIES_POINTS) series.shift();


### PR DESCRIPTION
## Summary

CF Free-plan KV write-quota(1,000 writes/day) 소진 확정 회귀 fix. `POST /position`이 10초마다 호출되지만 `appendPositionPoint`/`appendAccelSample`/`updateSsotMotion→writeSsot`가 매 호출 무조건 KV write — 분당 12~18 write로 ~1시간 탑승만으로 quota 소진 → `/trips`, `/position` 500.

시간 코얼레싱 write-skip 스로틀 도입 (KV 키/스키마 변경 없음, cold-start는 항상 write):

- **ssot** (`motionState.ts`): `SSOT_MOTION_WRITE_MIN_INTERVAL_MS = 25_000`. 최신 `device-position` evidence가 25s 미만이면 evidence push + writeSsot 둘 다 skip.
- **pos** (`positionSeries.ts`): `POSITION_SERIES_WRITE_MIN_INTERVAL_MS = 30_000`. 최신 저장 point가 30s 미만이면 put skip.
- **accel** (`accelSeries.ts`): `ACCEL_SERIES_WRITE_MIN_INTERVAL_MS = 55_000`. 동일 패턴.

## 안전 검증 (핵심)

- **ssot density red-first 테스트** (`motionState.test.ts`) — 25s 스로틀 cadence로 5분 시뮬레이션(디바이스 10s 호출, motion='unknown', 무변위 GPS) → evidence 버퍼가 `MOTION_MIN_SAMPLES`(10) 이상(실측 11건) 쌓여 `computeMotionState`가 `'stationary'`로 수렴함을 검증. 버퍼 starvation이면 motionState가 `'unknown'`에 고착되어 `advanceTripPosition`의 stationary 게이트가 무력화되는 **#2433류(지하 motion-gate blindspot) 회귀** 재현 방지가 목적.
- **pos consumer tolerance** — `evaluateWindow`(hop 쌍 gpsAvgKmh)와 `cosineDirection`(방향)은 `[now-60s, now]` 윈도우 안에 최소 2개 distinct point가 필요. `MIN_WINDOW_SAMPLES`(boardingPrompt.ts)는 현재 1로 완화되어 있어(#1886 RC-2) N≥3 요구는 없음. `POSITION_SERIES_WRITE_MIN_INTERVAL_MS=30_000`(≤30s)로 60s 윈도우에 항상 ≥2 point 보장.
  - **writes/day 산술**: 3시간 탑승 기준 pos만 `3*3600/30 = 360` writes — 예산 목표(~850/day) 대비 넉넉한 마진. (참고: accel `3*3600/55≈196`, ssot `3*3600/25=432` — 세 series 합산도 하루 총 quota 1,000 안에서 `/trips`+cron 여유를 남김)
- **lastDeviceSyncAt 신선도** — write 자체가 최소 25s마다 일어나므로 `DEVICE_SYNC_STALE_THRESHOLD_MS`(5min) 안에서 항상 신선 (테스트로 상수 비교 명시).

## Wire-completion 5단

1. **Orphan 없음** — 신규 export(3개 interval 상수)는 각 모듈 내부 함수에서만 소비, 외부 caller 불필요(`index.ts` 기존 호출부는 시그니처 변경 없이 그대로 동작).
2. **V/X dashboard** — CF Dashboard KV 탭(TRIPS namespace) write 카운트로 감소 관측 가능. 별도 in-app dashboard 신호 아님.
3. **의존 PR** — N/A.
4. **측정 plan** — 머지 후 1주 CF Dashboard KV write/day 추이 관측 + `/trips`,`/position` 500 재발 0건 확인.
5. **Device verify** — N/A — backend unit only. **주의**: ssot 25s interval은 진행 중인 지하 motion-gate 조사(#2433류)와 실기기 co-verify 필요 — 이 PR은 write 횟수만 줄이고 판정 로직(computeMotionState)은 변경하지 않으나, evidence 밀도가 실제 지하 라이드에서도 위 테스트 가정(고정 GPS, motion='unknown')과 유사하게 유지되는지는 다음 실탑승에서 확인 필요.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test` — 3070 tests pass, coverage threshold(lines/branches/statements 97%, functions 98%) 충족, `motionState.ts`/`accelSeries.ts` 100% coverage
- [x] 기존 ring-trim 테스트(positionSeries/accelSeries) 40/100회 연속 append 테스트를 interval보다 넉넉한 ts 간격으로 갱신 (throttle과 분리해 ring-trim 자체만 검증)
- [ ] 실기기: N/A — 사용자 판단

Closes #2449