### PR TITLE
feat(#2448): 지하 매역 진입(ENTERING) 알림 — arvlCd 기반 copy 분기 + fire-once phase 분리

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -7,7 +7,9 @@ import type { WindowedMetrics } from '../positionSeries';
 import {
   ARVLCD_FIRE_DEDUP_TTL_SEC,
   ARVLCD_FIRE_KEY_PREFIX,
-  ARVLCD_FIRE_ONCE_CYCLE_SLOT,
+  ARVLCD_FIRE_ONCE_ENTERING_BUCKET,
+  ARVLCD_FIRE_ONCE_ARRIVED_BUCKET,
+  arvlCdFireOnceBucket,
   hasArrivedSignal,
   SAME_PHASE_STATION_DEDUP_WINDOW_MS,
   FALLBACK_ADVANCE_GRACE_CYCLES,
@@ -8622,6 +8624,118 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     });
   });
 
+  // #2448 — 지하 매역 "곧 진입"(ENTERING) 알림. arvlCd=ENTERING(0) 시점엔 새 approaching copy,
+  // arvlCd=ARRIVED(1) 시점엔 기존 "역 통과" copy 를 유지한다(회귀 없음). 두 알림은 별 dedup
+  // bucket 이라 같은 트립·같은 역에서 순차로 각각 1회씩 발사된다(triple-fire 는 발생하지 않음 —
+  // 동일 arvlCd 반복 관측은 fire-once TTL 로 계속 skip 된다).
+  describe('#2448 매역 "곧 진입"(ENTERING) copy 분기', () => {
+    it('arvlCd=ENTERING(0) → "곧 진입" copy 발사, arvlCd=ARRIVED(1) → 기존 "역 통과" copy 유지, 동일 arvlCd 재관측은 재발사 X', async () => {
+      const mod = await import('../arvlcdFireOnceTtl');
+      const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockResolvedValue(true);
+      try {
+        const kv = new InMemoryKV();
+        const trip = makeLockTrip();
+        await putTrip(kv as unknown as KVNamespace, trip);
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        const commonInputs = {
+          trip,
+          waypoint: trip.waypoints[0],
+          lock: trip.boardingLock!,
+          env: makeEnv(kv),
+          deps: {
+            seoul: makeArrivalSeoul('중곡', 0, 0),
+            apnsConfig,
+            apnsHosts: APNS_HOSTS,
+            fetchImpl: apnsFetch as unknown as typeof fetch,
+            now: () => NOW,
+          },
+          now: NOW,
+          log: () => undefined,
+          generatePushId: () => 'p-approaching-1',
+        };
+
+        // 1) ENTERING(0) — 신규 "곧 진입" copy.
+        const statsEntering = makeFullEmptyStats();
+        await fireArvlCdStationPush({ ...commonInputs, stats: statsEntering, arvlCd: 0 });
+        expect(statsEntering.arvlCdFireSuccess).toBe(1);
+        {
+          const call = getStationPassedCalls(apnsFetch)[0];
+          const parsed = JSON.parse(call[1].body as string) as {
+            aps: { alert: { title: string; body: string } };
+          };
+          expect(parsed.aps.alert.title).toBe('곧 진입');
+          expect(parsed.aps.alert.body).toBe('곧 중곡역에 진입해요');
+        }
+
+        // 2) 같은 station 에서 ENTERING(0) 재관측 — 재발사 X (storm 회귀 차단).
+        const statsEnteringRepeat = makeFullEmptyStats();
+        await fireArvlCdStationPush({ ...commonInputs, stats: statsEnteringRepeat, arvlCd: 0 });
+        expect(statsEnteringRepeat.arvlCdFireSuccess).toBe(0);
+        expect(statsEnteringRepeat.arvlCdFireOnceSkipped).toBe(1);
+        expect(getStationPassedCalls(apnsFetch)).toHaveLength(1);
+
+        // 3) ARRIVED(1) — 별 bucket 이라 fire, 기존 "역 통과" copy 유지(회귀 없음).
+        const statsArrived = makeFullEmptyStats();
+        await fireArvlCdStationPush({ ...commonInputs, stats: statsArrived, arvlCd: 1 });
+        expect(statsArrived.arvlCdFireSuccess).toBe(1);
+        {
+          const calls = getStationPassedCalls(apnsFetch);
+          expect(calls).toHaveLength(2);
+          const parsed = JSON.parse(calls[1][1].body as string) as {
+            aps: { alert: { title: string; body: string } };
+          };
+          expect(parsed.aps.alert.title).toBe('역 통과');
+          expect(parsed.aps.alert.body).toBe('중곡역을 지나고 있어요');
+        }
+
+        // 4) 같은 station 에서 ARRIVED(1) 재관측 — 재발사 X (triple-fire 방지).
+        const statsArrivedRepeat = makeFullEmptyStats();
+        await fireArvlCdStationPush({ ...commonInputs, stats: statsArrivedRepeat, arvlCd: 1 });
+        expect(statsArrivedRepeat.arvlCdFireSuccess).toBe(0);
+        expect(statsArrivedRepeat.arvlCdFireOnceSkipped).toBe(1);
+        expect(getStationPassedCalls(apnsFetch)).toHaveLength(2);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('transfer/destination kind는 arvlCd=ENTERING이어도 기존 "임박" copy 유지 (intermediate 전용 분기)', async () => {
+      // #2448 approaching copy는 kind==='intermediate' 전용 — transfer/destination은 fireArvlCdStationPush를
+      // 직접 호출해(게이트 우회, buildStationNotifContent 분기만 격리 검증) arvlCd=ENTERING이어도 기존
+      // "환승 임박" copy가 그대로 유지되는지 확인한다.
+      const trip = makeLockTrip();
+      const transferWaypoint: Waypoint = { ...trip.waypoints[0], kind: 'transfer' };
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      await fireArvlCdStationPush({
+        trip,
+        waypoint: transferWaypoint,
+        lock: trip.boardingLock!,
+        arvlCd: 0,
+        env: makeEnv(kv),
+        deps: {
+          seoul: makeArrivalSeoul('중곡', 0, 0),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        },
+        stats: makeFullEmptyStats(),
+        now: NOW,
+        log: () => undefined,
+        generatePushId: () => 'p-approaching-transfer',
+      });
+      // getStationPassedCalls 는 kind∈{intermediate,destination}만 필터하므로(#917 helper) transfer는
+      // apnsFetch mock call을 직접 읽는다.
+      const call = (apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>)[0];
+      const parsed = JSON.parse(call[1].body as string) as {
+        aps: { alert: { title: string; body: string } };
+      };
+      expect(parsed.aps.alert.title).toBe('환승 임박');
+    });
+  });
+
   it('arvlCd=1이지만 lock 만료된 trip은 lockMissing 게이트로 차단 (fire 경로 미진입)', async () => {
     const { stats, apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
@@ -8810,11 +8924,13 @@ describe('runScheduled — #2343 cron-fire-attempt D1 로그', () => {
  * 블록은 `vi.spyOn` 으로 flag=ON 을 강제 → 동일 (trip, station, cycle) 조합의 2회 이상 fire 가
  * 차단되는지 검증 (spy 방식은 KV 시드와 무관하게 격리 유지 목적으로 존속).
  */
-describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
+describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985) → #2448 phase bucket 확장', () => {
   const TOKEN = 'arvl-fireonce-tok';
   const makeLockTrip = (overrides: Partial<Trip> = {}) => makeLockTripFixture(TOKEN, overrides);
   const makeArrivalSeoul = makeArvlCdFireSeoul;
   const getStationPassedCalls = getArvlCdStationPassedCalls;
+  // makeArvlCdFireSeoul('중곡', 0, 1) === arvlCd:1(ARRIVED) 고정 신호 → ARRIVED bucket.
+  const ARRIVED_BUCKET = ARVLCD_FIRE_ONCE_ARRIVED_BUCKET;
 
   async function runWithFlagOn(opts: {
     seoul: SeoulArrivalClient;
@@ -8867,7 +8983,7 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
     // fire-once 게이트는 flag=OFF 이므로 관여 X — 카운터 0.
     expect(stats.arvlCdFireOnceSkipped).toBe(0);
     // fireOnce KV key 도 stamp 되지 않음.
-    expect(await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT))).toBeNull();
+    expect(await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARRIVED_BUCKET))).toBeNull();
   });
 
   it('flag=ON, 첫 관측 → fire 진행 + fireOnce KV stamp', async () => {
@@ -8879,18 +8995,18 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
     expect(stats.arvlCdFireOnceSkipped).toBe(0);
     expect(getStationPassedCalls(apnsFetch)).toHaveLength(1);
     // 5분 TTL stamp 확인 (InMemoryKV 는 value 를 그대로 보존).
-    const stamped = await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT));
+    const stamped = await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARRIVED_BUCKET));
     expect(stamped).toBe(String(NOW));
   });
 
-  it('flag=ON, 같은 (trip, station, cycle) 2회 fire → 2번째는 skip (arvlCdFireOnceSkipped++)', async () => {
+  it('flag=ON, 같은 (trip, station, arvlCd bucket) 2회 fire → 2번째는 skip (arvlCdFireOnceSkipped++)', async () => {
     const { stats, apnsFetch } = await runWithFlagOn({
       seoul: makeArrivalSeoul('중곡', 0, 1),
       pushId: 'p-fireonce-dup',
       seedKv: async (kv) => {
-        // 이전 cycle 에서 이미 fire-once stamp 된 상태.
+        // 같은 bucket(ARRIVED)에서 이미 fire-once stamp 된 상태.
         await kv.put(
-          arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT),
+          arvlCdFireOnceKey(TOKEN, '중곡', ARRIVED_BUCKET),
           String(NOW - 30_000),
           { expirationTtl: ARVLCD_FIRE_ONCE_TTL_SEC },
         );
@@ -8902,13 +9018,50 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
     expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
   });
 
-  it('flag=ON, arvlCd=0 fire 후 같은 cycle 이내 arvlCd=1 재관측 → 통합 게이트 skip', async () => {
-    // 기존 `arvlCdFireKey` dedup 은 arvlCd=0 과 arvlCd=1 을 별 entry 로 stamp 해 둘 다 fire 하지만,
-    // fire-once TTL 은 cycle 통합 → 같은 (trip, station, cycle) 조합은 통합 skip.
-    // 이는 어린이대공원 반복 4회 fire (#1980) 회귀 차단의 핵심 정책.
-    //
-    // 검증 방식: `fireArvlCdStationPush` 를 직접 호출 (waypoint advance 부작용 격리) — 첫 호출 =
-    // arvlCd=0 fire + fire-once stamp, 두 번째 호출 = arvlCd=1 통합 skip.
+  // #2448 — 어린이대공원 storm(#1980/#2200) 회귀 차단의 핵심 불변식: 같은 (station, arvlCd)
+  // 재관측은 여전히 skip 된다. 이 테스트가 그 보장의 직접 회귀 테스트.
+  it('flag=ON, 같은 station 에서 arvlCd=0(ENTERING) 재관측 → 2번째는 skip (storm 회귀 차단 유지)', async () => {
+    const mod = await import('../arvlcdFireOnceTtl');
+    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockResolvedValue(true);
+    try {
+      const kv = new InMemoryKV();
+      const trip = makeLockTrip();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const commonInputs = {
+        trip,
+        waypoint: trip.waypoints[0],
+        lock: trip.boardingLock!,
+        env: makeEnv(kv),
+        deps: {
+          seoul: makeArrivalSeoul('중곡', 0, 0),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        },
+        now: NOW,
+        log: () => undefined,
+        generatePushId: () => 'p-direct-repeat',
+      };
+      const statsFirst = makeFullEmptyStats();
+      await fireArvlCdStationPush({ ...commonInputs, stats: statsFirst, arvlCd: 0 });
+      expect(statsFirst.arvlCdFireSuccess).toBe(1);
+      // 같은 cron tick 반복 관측(Seoul API 갱신 지연 등)으로 다시 arvlCd=0 이 들어와도 재발사 X.
+      const statsSecond = makeFullEmptyStats();
+      const { dirty } = await fireArvlCdStationPush({ ...commonInputs, stats: statsSecond, arvlCd: 0 });
+      expect(statsSecond.arvlCdFireSuccess).toBe(0);
+      expect(statsSecond.arvlCdFireOnceSkipped).toBe(1);
+      expect(dirty).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // #2448 — 신규 동작: ENTERING("곧 진입")과 ARRIVED("역 통과")는 별 bucket 이라 같은 station 에서
+  // 둘 다 각각 1회씩 발사된다(합 최대 2회/5분). #1985 당시엔 이 둘을 하나로 묶어 ARRIVED 를
+  // 억제했지만, #2448 목표(진입 알림 신설)상 이제는 의도된 동작이다.
+  it('flag=ON, arvlCd=0(ENTERING) fire 후 arvlCd=1(ARRIVED) 재관측 → 별 bucket 이라 각각 fire', async () => {
     const mod = await import('../arvlcdFireOnceTtl');
     const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockResolvedValue(true);
     try {
@@ -8936,28 +9089,30 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
       await fireArvlCdStationPush({ ...commonInputs, stats: statsFirst, arvlCd: 0 });
       expect(statsFirst.arvlCdFireSuccess).toBe(1);
       expect(statsFirst.arvlCdFireOnceSkipped).toBe(0);
-      // fire-once stamp 확인.
+      // ENTERING bucket stamp 확인.
       expect(
-        await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT)),
+        await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_ENTERING_BUCKET)),
       ).toBe(String(NOW));
-      // 두 번째 호출: 같은 station 에서 arvlCd=1 재관측 (cycle 안 monotone 진행).
+      // 두 번째 호출: 같은 station 에서 arvlCd=1 재관측 (cycle 안 monotone 진행) — 다른 bucket이라 fire.
       const statsSecond = makeFullEmptyStats();
       const { dirty } = await fireArvlCdStationPush({
         ...commonInputs,
         stats: statsSecond,
         arvlCd: 1,
       });
-      // arvlCd=1 은 fire-once TTL 로 통합 skip — push 미발사.
-      expect(statsSecond.arvlCdFireSuccess).toBe(0);
-      expect(statsSecond.arvlCdFireOnceSkipped).toBe(1);
-      expect(dirty).toBe(false);
+      expect(statsSecond.arvlCdFireSuccess).toBe(1);
+      expect(statsSecond.arvlCdFireOnceSkipped).toBe(0);
+      expect(dirty).toBe(true);
+      expect(
+        await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARRIVED_BUCKET)),
+      ).toBe(String(NOW));
     } finally {
       spy.mockRestore();
     }
   });
 
   it('flag=ON, cross-trip 격리 — trip A stamp 는 trip B fire 를 차단하지 X', async () => {
-    // 두 사용자가 같은 station 을 같은 cycle 에 통과. token 이 key 에 포함되므로 각 trip 이 각각 fire.
+    // 두 사용자가 같은 station 을 같은 bucket 에 통과. token 이 key 에 포함되므로 각 trip 이 각각 fire.
     const { stats, apnsFetch } = await runWithFlagOn({
       seoul: makeArrivalSeoul('중곡', 0, 1),
       trip: makeLockTrip({ token: 'user-a' }),
@@ -8989,7 +9144,7 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
       seedKv: async (kv) => {
         // 이전 station(건대입구) fire-once 는 stamp 되어 있어도 중곡 fire 는 진행 가능해야 함.
         await kv.put(
-          arvlCdFireOnceKey(TOKEN, '건대입구', ARVLCD_FIRE_ONCE_CYCLE_SLOT),
+          arvlCdFireOnceKey(TOKEN, '건대입구', ARRIVED_BUCKET),
           String(NOW - 30_000),
           { expirationTtl: ARVLCD_FIRE_ONCE_TTL_SEC },
         );
@@ -8999,11 +9154,11 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
     expect(stats.arvlCdFireOnceSkipped).toBe(0);
     // 중곡은 새로 stamp.
     expect(
-      await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT)),
+      await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARRIVED_BUCKET)),
     ).toBe(String(NOW));
     // 건대입구 stamp 는 그대로 유지.
     expect(
-      await kv.get(arvlCdFireOnceKey(TOKEN, '건대입구', ARVLCD_FIRE_ONCE_CYCLE_SLOT)),
+      await kv.get(arvlCdFireOnceKey(TOKEN, '건대입구', ARRIVED_BUCKET)),
     ).toBe(String(NOW - 30_000));
   });
 
@@ -9016,7 +9171,7 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
       await putTrip(kv as unknown as KVNamespace, makeLockTrip());
       // 5분+1ms 전 stamp — 만료된 상태.
       await kv.put(
-        arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT),
+        arvlCdFireOnceKey(TOKEN, '중곡', ARRIVED_BUCKET),
         String(NOW - ARVLCD_FIRE_ONCE_TTL_SEC * 1000 - 1),
         { expirationTtl: 1 }, // 즉시 만료 처리 (Date.now() > expiresAt).
       );
@@ -9046,9 +9201,22 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
   });
 });
 
-describe('ARVLCD_FIRE_ONCE_CYCLE_SLOT (#1985)', () => {
-  it('is 0 — 현재는 미래-확장 slot placeholder (5분 TTL 이 cycle 경계 처리)', () => {
-    expect(ARVLCD_FIRE_ONCE_CYCLE_SLOT).toBe(0);
+describe('arvlCdFireOnceBucket (#2448)', () => {
+  it('intermediate + ENTERING(0) → ENTERING bucket', () => {
+    expect(arvlCdFireOnceBucket('intermediate', 0)).toBe(ARVLCD_FIRE_ONCE_ENTERING_BUCKET);
+  });
+  it('intermediate + ARRIVED(1) 및 그 외 값 → ARRIVED bucket (2-way 이상으로 늘지 않음)', () => {
+    expect(arvlCdFireOnceBucket('intermediate', 1)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
+    expect(arvlCdFireOnceBucket('intermediate', 2)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
+    expect(arvlCdFireOnceBucket('intermediate', 5)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
+  });
+  // #2200 뚝섬 storm 회귀 차단 — transfer/destination 은 arvlCd 값과 무관하게 항상 단일 bucket.
+  // arvlCd 별 copy 분기가 없는 kind 에서 bucket 을 나누면 같은 문구가 두 번 발사된다(재발 금지).
+  it('transfer/destination 은 arvlCd 값과 무관하게 항상 단일(ARRIVED) bucket', () => {
+    expect(arvlCdFireOnceBucket('transfer', 0)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
+    expect(arvlCdFireOnceBucket('transfer', 1)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
+    expect(arvlCdFireOnceBucket('destination', 0)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
+    expect(arvlCdFireOnceBucket('destination', 1)).toBe(ARVLCD_FIRE_ONCE_ARRIVED_BUCKET);
   });
 });
 

--- a/backend/alarm-worker/src/arvlcdFireOnceTtl.ts
+++ b/backend/alarm-worker/src/arvlcdFireOnceTtl.ts
@@ -17,13 +17,16 @@
  *
  * ## 정책
  *
- * 같은 (`tripToken`, `stationName`) 에서 한 arvlCd cycle (0진입→1도착→2출발→5전역도착 monotone
- * 시퀀스) 동안 fire 를 **1회로 강제**. 5분 TTL 로 자연 회수 — TTL 만료 시 다음 관측이 새 cycle
- * 시작 (train 이 물리적으로 같은 station 을 5분 안에 재방문할 수 없음).
+ * 같은 (`tripToken`, `stationName`, `cycle`) 조합에서 fire 를 **1회로 강제**. 5분 TTL 로 자연
+ * 회수 — TTL 만료 시 다음 관측이 새 cycle 시작 (train 이 물리적으로 같은 station 을 5분 안에
+ * 재방문할 수 없음).
  *
- * `cycle` 파라미터는 미래-확장 slot — 현재는 `0` 고정 상수 caller 가 전달. 5분 TTL 이 사실상
- * cycle 경계를 처리하므로 stateful cycle counter 는 불필요. 후속 PR 에서 cross-cron cycle
- * 추적이 필요해지면 slot 을 활용해 정수 카운터로 확장 가능.
+ * `cycle` 파라미터는 애초 "미래-확장 slot"으로 설계되어 caller 가 `0` 고정값을 전달했다
+ * (arvlCd 0→1→2→5 전체 monotone 시퀀스를 단일 fire 이벤트로 통합 — 어린이대공원 반복 storm
+ * 차단, #1985/#2200). #2448 에서 그 확장 slot 을 실제로 활용 — caller(`fireArvlCdStationPush`)
+ * 가 `arvlCdFireOnceBucket(arvlCd)`(`scheduled.ts`)로 ENTERING(0)/그 외 2-way bucket 값을
+ * 계산해 전달한다. 이 helper 자체는 bucket 의 의미를 모른다 — 여전히 순수 (token, station,
+ * cycle) 3-tuple key 저장소일 뿐이며, storm 방지(같은 3-tuple 무제한 재발사 차단)는 그대로다.
  *
  * ## Feature flag
  *

--- a/backend/alarm-worker/src/i18n.ts
+++ b/backend/alarm-worker/src/i18n.ts
@@ -65,6 +65,14 @@ interface I18nStrings {
   /** #2063 — 매역 알림(station-notif) body. kind별 분기 + station 삽입. */
   stationNotifBody: (kind: StationNotifKind, stationName: string) => string;
   /**
+   * #2448 — intermediate waypoint에 arvlCd=ENTERING(0)으로 진입할 때 전용 title.
+   * `stationNotifTitle('intermediate')`("역 통과")와 별개 — 열차가 아직 역에 도착하지
+   * 않고 진입 중인 순간에만 쓴다. ARRIVED(1)는 기존 stationNotifTitle을 그대로 사용.
+   */
+  stationNotifApproachingTitle: string;
+  /** #2448 — intermediate ENTERING 전용 body. 고정 lead time을 약속하지 않는다("곧"). */
+  stationNotifApproachingBody: (stationName: string) => string;
+  /**
    * #2157 — eta-missing lock detach 시 재확인 alert push title. trip을 강제 종료하는 대신
    * lock만 해제하고 사용자에게 재선택(boardingPrompt/직접 탭)을 유도한다.
    */
@@ -108,6 +116,9 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `곧 ${stationName}에 도착합니다. 환승 준비하세요!`;
       return `곧 ${stationName}에 도착합니다. 하차 준비하세요!`;
     },
+    // #2448 — intermediate ENTERING 전용. 정확한 lead time을 약속하지 않는다.
+    stationNotifApproachingTitle: '곧 진입',
+    stationNotifApproachingBody: (stationName) => `곧 ${stationName}역에 진입해요`,
     trainReconfirmTitle: '탑승 열차를 찾을 수 없어요',
     trainReconfirmBody: '다시 확인해주세요',
   },
@@ -137,6 +148,9 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `Arriving at ${stationName} — transfer soon!`;
       return `Arriving at ${stationName} — exit soon!`;
     },
+    // #2448 — intermediate ENTERING only. No fixed lead time promised.
+    stationNotifApproachingTitle: 'Approaching',
+    stationNotifApproachingBody: (stationName) => `Approaching ${stationName} soon`,
     trainReconfirmTitle: "We couldn't find your train",
     trainReconfirmBody: 'Please check again',
   },
@@ -166,6 +180,9 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `まもなく${stationName}に到着します。乗換の準備をしてください!`;
       return `まもなく${stationName}に到着します。下車の準備をしてください!`;
     },
+    // #2448 — intermediate ENTERING 専用。固定リードタイムは約束しない。
+    stationNotifApproachingTitle: 'まもなく進入',
+    stationNotifApproachingBody: (stationName) => `まもなく${stationName}駅に進入します`,
     trainReconfirmTitle: '乗車列車が見つかりません',
     trainReconfirmBody: 'もう一度ご確認ください',
   },
@@ -195,6 +212,9 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `即将到达${stationName}。请准备换乘!`;
       return `即将到达${stationName}。请准备下车!`;
     },
+    // #2448 — intermediate ENTERING 专用。不承诺固定提前时间。
+    stationNotifApproachingTitle: '即将进站',
+    stationNotifApproachingBody: (stationName) => `即将进入${stationName}站`,
     trainReconfirmTitle: '未能找到您的乘车列车',
     trainReconfirmBody: '请重新确认',
   },

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1802,14 +1802,36 @@ export const SAME_PHASE_STATION_DEDUP_WINDOW_MS = 45_000;
 export const ARVLCD_FIRE_KEY_PREFIX = 'arvlcd-fire:';
 
 /**
- * ADR-022 Phase 1-1 (#1985) — fire-once TTL key 의 cycle slot 값.
+ * ADR-022 Phase 1-1 (#1985) → #2448 확장 — fire-once TTL key 의 cycle slot 값.
  *
- * arvlCd cycle 은 (0진입→1도착→2출발→5전역도착) monotone 시퀀스로 한 pass 를 이룬다. 현재
- * backend cron 은 stateful cycle counter 를 유지하지 않고 5분 TTL 로 cycle 경계를 자연 처리
- * 하므로, key 의 cycle slot 은 미래-확장 자리 표시자로 `0` 고정. 후속 PR 에서 cross-cron
- * cycle 추적이 필요해지면 slot 을 정수 카운터로 확장 가능하다.
+ * arvlCd cycle 은 (0진입→1도착→2출발→5전역도착) monotone 시퀀스로 한 pass 를 이룬다. 원래는
+ * 이 cycle 전체를 하나의 slot(`0` 고정)으로 묶어 station 당 1회로 강제했다(어린이대공원
+ * 13:31/13:32/13:37 반복 storm, #1980/#2200 차단). #2448에서 "곧 진입"(ENTERING) 알림을
+ * "역 통과"(ARRIVED)와 별도로 발사하기 위해 slot 을 arvlCd 값 기반 2-way bucket 으로 넓힌다 —
+ * ENTERING 1회 + ARRIVED 1회(합 최대 2회/5분 TTL)까지만 허용하고, 같은 (station, bucket)
+ * 재관측은 여전히 storm 방지 정책 그대로 skip 한다.
+ *
+ * `arvlCdFireOnceBucket`가 실제 bucket 계산을 담당 — 이 두 상수는 KV key 조립/테스트에서
+ * 값을 직접 참조할 때 쓰는 명시적 별칭이다.
  */
-export const ARVLCD_FIRE_ONCE_CYCLE_SLOT = 0;
+export const ARVLCD_FIRE_ONCE_ENTERING_BUCKET = 0;
+export const ARVLCD_FIRE_ONCE_ARRIVED_BUCKET = 1;
+
+/**
+ * #2448 — (waypoint kind, arvlCd) 조합을 fire-once TTL bucket 으로 매핑.
+ *
+ * `kind==='intermediate'`일 때만 ENTERING(0) 전용 bucket 을 분리한다 — `buildStationNotifContent`가
+ * 새 "곧 진입" copy 를 렌더하는 대상이 intermediate 뿐이기 때문. transfer/destination 은 arvlCd
+ * 0/1 모두 여전히 같은 "임박" copy 를 렌더하므로(#2063, 미변경) bucket 을 나누면 **같은 문구가
+ * 두 번 발사**되는 storm 회귀가 재발한다(2026-08-07 뚝섬 evidence, #2200/`replay_20260807_storm.test.ts`)
+ * — 그래서 non-intermediate 는 기존과 동일하게 단일 bucket 으로 유지한다.
+ */
+export function arvlCdFireOnceBucket(waypointKind: Waypoint['kind'], arvlCd: number): number {
+  if (waypointKind === 'intermediate' && arvlCd === ARRIVAL_CODE.ENTERING) {
+    return ARVLCD_FIRE_ONCE_ENTERING_BUCKET;
+  }
+  return ARVLCD_FIRE_ONCE_ARRIVED_BUCKET;
+}
 
 /**
  * dedup KV key 빌더. arvlCd 0(ENTERING) vs 1(ARRIVED)은 별 entry로 분리(둘 다 신호).
@@ -2092,12 +2114,24 @@ export const STATION_NOTIF_EXPIRATION_MS = 90 * 1000;
  *
  * arvlCd 기반 매역 fire는 항상 phase='imminent' — `i18n.ts`의 `stationNotifTitle`/`stationNotifBody`도
  * 그에 맞춰 kind 단일 분기만 제공한다(early phase 없음).
+ *
+ * #2448 — `kind==='intermediate'`이고 발사 시점 arvlCd가 ENTERING(0)이면 "곧 진입" 전용 copy로
+ * 분기한다. ARRIVED(1)는 기존 "역 통과" copy 유지 — arvlCd는 optional: 호출자가 arvlCd를
+ * 모르는 경로(`fireVanishFallbackStationPush`/`maybeFireSleepAlarm`은 vanish/target 판정이라
+ * "방금 진입"이 아님)는 인자를 생략해 기존 ARRIVED-copy 분기로 자연 fallback한다.
  */
 function buildStationNotifContent(
   waypoint: Waypoint,
   locale: SupportedLocale | undefined,
+  arvlCd?: number,
 ): { title: string; body: string } {
   const strings = t(locale);
+  if (waypoint.kind === 'intermediate' && arvlCd === ARRIVAL_CODE.ENTERING) {
+    return {
+      title: strings.stationNotifApproachingTitle,
+      body: strings.stationNotifApproachingBody(waypoint.stationName),
+    };
+  }
   return {
     title: strings.stationNotifTitle(waypoint.kind),
     body: strings.stationNotifBody(waypoint.kind, waypoint.stationName),
@@ -2468,12 +2502,14 @@ export async function fireArvlCdStationPush(
     });
     return { dirty: false };
   }
-  // ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트.
-  // flag=ON 시 같은 (tripToken, stationName, arvlCd cycle) 조합에서 5분 이내 이미 fire 된 경우
-  // skip. arvlCd 0/1 을 별 entry 로 stamp 하던 기존 `arvlCdFireKey` dedup 과 달리, cycle 전체
-  // (0→1→2→5) 를 하나의 fire 이벤트로 통합 — 어린이대공원 반복 4회 fire (#1980) 회귀 차단.
+  // ADR-022 Phase 1-1 (#1985) → #2448 확장 — arvlCd fire-once TTL 게이트.
+  // flag=ON 시 같은 (tripToken, stationName, arvlCd bucket) 조합에서 5분 이내 이미 fire 된 경우
+  // skip. #2448 이전에는 cycle 전체(0→1→2→5)를 단일 bucket 으로 묶어 어린이대공원 반복 4회
+  // fire(#1980) 회귀를 차단했다 — 이제는 ENTERING(0)과 그 외(주로 ARRIVED=1)를 별 bucket 으로
+  // 나눠 "곧 진입" + "역 통과" 둘 다 1회씩 발사되도록 하되, 같은 bucket 재관측은 여전히 storm
+  // 방지 정책대로 skip 한다(무제한 재발사는 여전히 불가능).
   // flag=OFF (default, Phase 0 #1982 미머지 상태) 에서는 조기 return 으로 무영향.
-  const fireOnceCycle = ARVLCD_FIRE_ONCE_CYCLE_SLOT;
+  const fireOnceCycle = arvlCdFireOnceBucket(waypoint.kind, arvlCd);
   if (await isSimpleArchEnabled(env)) {
     const alreadyFired = await checkArvlCdFireOnce(
       env.TRIPS,
@@ -2583,7 +2619,7 @@ export async function fireArvlCdStationPush(
   // #2092 — contentAvailable:true를 병기해 alert와 동시에 device background task
   // (handleSilentPush)를 깨운다. station kind는 배너 no-op(#2088)이라 이중 배너 없이 SSoT
   // mirror(persistBackendSsotMirror)·BG 위젯 갱신(updateWidgetFromSilentPush)만 수행한다.
-  const stationNotifContent = buildStationNotifContent(waypoint, trip.locale);
+  const stationNotifContent = buildStationNotifContent(waypoint, trip.locale, arvlCd);
   const heal = await sendWithEnvHeal(
     (host) =>
       sendAlertPush({
@@ -4550,6 +4586,15 @@ export async function runLocklessIntermediate(
   // 이동(walking/automotive)을 positive하게 보일 때만 advance를 허용 — 정적/저신뢰(stationary/
   // unknown, 샘플 없음 포함)는 보류해 false positive(정적 false advance + 알림 레이스)를 차단한다.
   // #1386 — lock-active vanish fallback도 같은 헬퍼(`isAdvanceAllowedByMotion`)를 공유한다.
+  //
+  // #2448 — 이 게이트가 lockless(C 토글) 매역 "곧 진입"(ENTERING) fire 를 locked 경로와
+  // 동급으로 만들지 못하는 지점이다. CMMotionActivity 는 지하에서 5~10분 간헐 신호라
+  // (memory: lesson_motion_activity_intermittent_signal) motion 이 stationary/unknown 으로
+  // 잘못 분류되면 이 게이트가 정당한 ENTERING 순간도 보류시킨다. `fireArvlCdStationPush`
+  // (lock 활성 경로)는 이 motion 게이트가 없어 지하에서도 100% 동작하지만, lockless는
+  // best-effort — 사용자 명시 의향 trip(C 토글 ON)이 lock 활성과 동급 정확도 보장을 받아야
+  // 한다는 원칙(ADR-014, memory: feedback_user_intent_equal_protection)에 아직 미달한다.
+  // 근본 해소는 이 게이트 완화/대체가 아니라 트립을 lock 상태로 승격하는 별도 트랙 과제.
   if (!isAdvanceAllowedByMotion(fusion.posMetrics.motion)) {
     stats.locklessMotionGateBlocked += 1;
     log('lockless: motion gate blocked (no trainCode, not moving)', {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "Currently at {{name}}",
     "approximateDistance": "~{{m}}m",
     "stationPassed": "Arrived at {{name}}",
+    "intermediateApproachingTitle": "Approaching",
+    "intermediateApproachingBody": "Approaching {{name}} soon",
     "boardingPromptTitle": "Are you on board?",
     "boardingPromptBody": "You're near {{originStation}} station ({{line}}).",
     "tripEndedArrivedTitle": "Arrived at destination",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "現在 {{name}}",
     "approximateDistance": "約{{m}}m",
     "stationPassed": "{{name}}駅に到着",
+    "intermediateApproachingTitle": "まもなく進入",
+    "intermediateApproachingBody": "まもなく{{name}}駅に進入します",
     "boardingPromptTitle": "ご乗車されましたか?",
     "boardingPromptBody": "{{originStation}}駅付近です({{line}})。",
     "tripEndedArrivedTitle": "目的地に到着",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "현재 {{name}}역",
     "approximateDistance": "약 {{m}}m",
     "stationPassed": "{{name}}역 도착",
+    "intermediateApproachingTitle": "곧 진입",
+    "intermediateApproachingBody": "곧 {{name}}역에 진입해요",
     "boardingPromptTitle": "탑승하셨나요?",
     "boardingPromptBody": "{{line}} {{originStation}}역 근처예요.",
     "tripEndedArrivedTitle": "목적지 도착",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -274,6 +274,8 @@
     "atCurrentStation": "当前 {{name}}",
     "approximateDistance": "约{{m}}m",
     "stationPassed": "已到达{{name}}",
+    "intermediateApproachingTitle": "即将进站",
+    "intermediateApproachingBody": "即将进入{{name}}站",
     "boardingPromptTitle": "您已乘车了吗?",
     "boardingPromptBody": "您在{{originStation}}站附近({{line}})。",
     "tripEndedArrivedTitle": "已到达目的地",


### PR DESCRIPTION
## Summary
- `buildStationNotifContent`(`backend/alarm-worker/src/scheduled.ts`)가 `kind==='intermediate'`이고 발사 시점 arvlCd가 ENTERING(0)일 때 신규 "곧 진입" copy를 렌더한다. ARRIVED(1)는 기존 "역 통과" copy를 그대로 유지(회귀 없음).
- `src/i18n.ts`에 `stationNotifApproachingTitle`/`stationNotifApproachingBody` 4언어(ko/en/ja/zh) 추가. device i18n(`src/shared/i18n/locales/{ko,en,ja,zh}.json`)에 `route.intermediateApproachingTitle`/`Body`로 byte-identical 미러(#2063 copy-parity 컨벤션).
- `arvlCdFireOnceBucket(waypointKind, arvlCd)`: fire-once TTL bucket을 station 단일 bucket에서 (station, arvlCd-phase) 단위로 확장. **`kind==='intermediate'`일 때만** ENTERING(0)/그 외 2-way bucket으로 분리 — transfer/destination은 arvlCd 값과 무관하게 여전히 단일 bucket(둘 다 같은 "임박" copy를 렌더하므로, bucket을 나누면 같은 문구가 두 번 발사되는 2026-08-07 뚝섬 storm(#2200) 회귀가 재발한다 — `replay_20260807_storm.test.ts`가 이 불변식을 고정).

## 지하 지원 범위 (locked vs lockless)
- **`fireArvlCdStationPush`(lock 활성 경로)**: GPS/motion 게이트가 없다 — arvlCd는 서버측 열차 위치 신호라 지하에서도 100% 동일 동작. "곧 진입" 알림이 지하에서도 완전히 지원된다.
- **`runLocklessIntermediate`(C 토글, lockless 경로)**: 기존 `isAdvanceAllowedByMotion` motion 게이트(#1315)가 여전히 존재 — CMMotionActivity가 지하에서 5~10분 간헐 신호라 이 게이트가 정당한 ENTERING 순간도 보류시킬 수 있다. 코드 주석(`scheduled.ts` motion gate 직전)으로 명시: 이 경로는 lock 활성과 동급 정확도(ADR-014)에 아직 미달하는 best-effort다. 근본 해소는 이 PR 범위 밖 — 별도 트랙(lock 승격) 필요.

## Test plan
- [x] TDD red→green: ENTERING → "곧 진입" copy 발사 / ARRIVED → 기존 "역 통과" copy 유지 / 동일 arvlCd 반복 관측은 재발사 안함(storm 회귀 차단 유지) — `scheduled.test.ts` `#2448 매역 "곧 진입"(ENTERING) copy 분기`
- [x] transfer/destination은 arvlCd=ENTERING이어도 기존 "임박" copy 유지(intermediate 전용 분기 확인)
- [x] `arvlCdFireOnceBucket` 단위 테스트(intermediate 2-way / transfer·destination 단일 bucket)
- [x] 기존 `replay_20260807_storm.test.ts`(뚝섬 storm 회귀 테스트) 그대로 green 유지
- [x] `npm run type-check` (backend `tsc --noEmit` + repo root)
- [x] backend `npm test` — 3062 tests pass, coverage ratchet floor(97/96/98/97) 상회(97.4/96.3/98.56/97.4)
- [x] `npm run lint:orphan` — clean

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export(`arvlCdFireOnceBucket`, `ARVLCD_FIRE_ONCE_ENTERING_BUCKET`, `ARVLCD_FIRE_ONCE_ARRIVED_BUCKET`)는 `scheduled.ts` 내부 caller + test import로 소비됨.
2. **V/X dashboard** — dump `## Notifications fired` 섹션에서 ENTERING-kind "곧 진입" alert 확인(device 실기기). backend 측은 wrangler tail의 `arvlcd-fire: station-passed push` 로그(`kind`/`arvlCd` 필드)로 관측 가능.
3. **의존 PR** — N/A. 기존 fire path(`fireArvlCdStationPush`)를 재사용, 신규 emitter 없음.
4. **측정 plan** — memory 진입점(`project_2026_08_31_trips500_freetier_la_interactive`)에 기록된 backend KV quota 이슈(/trips 500) 해소 후, 실기기 지하 탑승에서 dump `## Notifications fired`에 ENTERING-kind 알림이 나타나는지 1주 관찰.
5. **Device verify** — 필요. 실기기 지하 탑승 시나리오(터널 구간 진입 시 "곧 진입" 알림 수신 + 뒤이은 "역 통과" 알림 둘 다 정상 발사, triple-fire 없음). 코드-only 검증(type-check + unit)은 이 PR에서 완료했으나 실제 지하 무선 환경에서의 사용자 체감은 실기기 검증 전까지 미확정.

## 알려진 잔여 갭
- lockless(C 토글) 경로는 motion gate로 인해 지하에서 best-effort — 코드 주석으로 명시(위 "지하 지원 범위" 참고).
- Lead time은 정확한 초 단위를 약속하지 않는다("곧 진입") — cron 60s + Seoul API 15-30s 갱신 지연으로 ENTERING→ARRIVED가 한 tick에 몰릴 수 있음.

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9