### PR TITLE
perf(#2452): cron listTrips() list-quota 게이트 — 2nd Free-plan quota fix

### DIFF
--- a/backend/alarm-worker/src/__tests__/activeTripsGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/activeTripsGate.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ACTIVE_TRIPS_MARKER_KEY,
+  hasActiveTripsMarker,
+  markTripRegistered,
+  refreshActiveTripsMarker,
+} from '../activeTripsGate';
+import { CRON_READ_CACHE_TTL_SEC } from '../kvConsistency';
+import { InMemoryKV } from './inMemoryKv';
+import type { Trip } from '../types';
+
+function makeTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: 'tok-1',
+    createdAt: 1_700_000_000_000,
+    expiresAt: 1_700_000_000_000 + 60 * 60 * 1000,
+    waypoints: [],
+    ...overrides,
+  } as Trip;
+}
+
+describe('activeTripsGate (#2452 — cron listTrips list-quota idle gate)', () => {
+  let kv: InMemoryKV;
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  describe('hasActiveTripsMarker', () => {
+    it('returns false when no marker was ever stamped (진짜 idle → listTrips skip 대상)', async () => {
+      expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(false);
+    });
+
+    it('returns true right after markTripRegistered', async () => {
+      await markTripRegistered(kv as unknown as KVNamespace, NOW + 60_000, NOW);
+      expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(true);
+    });
+
+    it('returns false when kv is undefined', async () => {
+      expect(await hasActiveTripsMarker(undefined)).toBe(false);
+    });
+
+    it('returns true (보수적 — listTrips 강행, 실 라이더 miss 불허) when kv.get throws', async () => {
+      const throwingKv = {
+        get: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      expect(await hasActiveTripsMarker(throwingKv)).toBe(true);
+    });
+
+    it('reads with explicit cacheTtl (kvConsistency 컨벤션)', async () => {
+      const spy = vi.spyOn(kv, 'get');
+      await hasActiveTripsMarker(kv as unknown as KVNamespace);
+      expect(spy).toHaveBeenCalledWith(ACTIVE_TRIPS_MARKER_KEY, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+    });
+  });
+
+  describe('markTripRegistered', () => {
+    it('stamps marker with TTL aligned to trip.expiresAt (no fixed constant)', async () => {
+      const expiresAt = NOW + 90 * 60 * 1000; // 90분 뒤
+      await markTripRegistered(kv as unknown as KVNamespace, expiresAt, NOW);
+      const entry = kv.store.get(ACTIVE_TRIPS_MARKER_KEY);
+      expect(entry).toBeDefined();
+      expect(entry?.expiresAt).toBeGreaterThan(Date.now());
+      // 90분 TTL 근방(계산 오차 허용) — 최소 60s 하한보다 훨씬 큼.
+      expect(entry?.expiresAt).toBeGreaterThan(Date.now() + 89 * 60 * 1000);
+    });
+
+    it('TTL floors at 60s even if expiresAt is already past/near', async () => {
+      await markTripRegistered(kv as unknown as KVNamespace, NOW + 1_000, NOW);
+      const entry = kv.store.get(ACTIVE_TRIPS_MARKER_KEY);
+      expect(entry?.expiresAt).toBeGreaterThanOrEqual(Date.now() + 59_000);
+    });
+
+    it('propagates kv.put failure (자가치유 지점이 아니므로 호출부가 로깅하도록 rethrow)', async () => {
+      const throwingKv = {
+        put: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(markTripRegistered(throwingKv, NOW + 60_000, NOW)).rejects.toThrow('kv down');
+    });
+  });
+
+  describe('refreshActiveTripsMarker', () => {
+    it('trips 존재 → marker를 최대 expiresAt 기준으로 재stamp', async () => {
+      const trips = [
+        makeTrip({ token: 'a', expiresAt: NOW + 10 * 60 * 1000 }),
+        makeTrip({ token: 'b', expiresAt: NOW + 40 * 60 * 1000 }),
+      ];
+      await refreshActiveTripsMarker(kv as unknown as KVNamespace, trips, NOW);
+      const entry = kv.store.get(ACTIVE_TRIPS_MARKER_KEY);
+      expect(entry).toBeDefined();
+      expect(entry?.expiresAt).toBeGreaterThan(Date.now() + 39 * 60 * 1000);
+    });
+
+    it('trips 비어있음(stale marker) → marker delete, 이후 idle tick skip 재개', async () => {
+      await markTripRegistered(kv as unknown as KVNamespace, NOW + 60_000, NOW);
+      expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(true);
+
+      await refreshActiveTripsMarker(kv as unknown as KVNamespace, [], NOW);
+      expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(false);
+    });
+
+    it('graceful when kv.delete throws', async () => {
+      const throwingKv = {
+        delete: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(refreshActiveTripsMarker(throwingKv, [], NOW)).resolves.toBeUndefined();
+    });
+
+    it('graceful when kv.put throws', async () => {
+      const throwingKv = {
+        put: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(
+        refreshActiveTripsMarker(throwingKv, [makeTrip()], NOW),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/inMemoryKv.ts
+++ b/backend/alarm-worker/src/__tests__/inMemoryKv.ts
@@ -1,4 +1,5 @@
 import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
+import { ACTIVE_TRIPS_MARKER_KEY } from '../activeTripsGate';
 
 /**
  * Cloudflare KVNamespace의 in-memory test double.
@@ -46,6 +47,24 @@ export class InMemoryKV {
       ? Date.now() + options.expirationTtl * 1000
       : undefined;
     this.store.set(key, { value, expiresAt });
+    // #2452 — 프로덕션에서 `trip:` 키는 항상 `POST /trips` 등록(activeTripsGate.markTripRegistered
+    // 가 stamp)을 거쳐 존재하므로 cron listTrips 게이트 마커가 함께 있다. 이 테스트 더블은
+    // 수백 개 기존 테스트가 registration 경로 없이 putTrip으로 trip을 직접 시드하므로, 그
+    // 불변식을 여기서 흡수해 마커를 함께 stamp한다. `this.store`를 직접 조작(= `this.put()`
+    // 재귀호출 아님)해 `vi.spyOn(kv, 'put')` 호출 횟수 assertion에 잡히지 않는다 — 이 stamp는
+    // 순수 테스트 인프라 편의이지 관측 대상 동작이 아니다.
+    if (key.startsWith('trip:')) {
+      let markerTtlMs = 60 * 60 * 1000;
+      try {
+        const parsed = JSON.parse(value) as { expiresAt?: unknown };
+        if (typeof parsed.expiresAt === 'number') {
+          markerTtlMs = Math.max(60_000, parsed.expiresAt - Date.now());
+        }
+      } catch {
+        // 손상된 payload는 기본 TTL로 stamp.
+      }
+      this.store.set(ACTIVE_TRIPS_MARKER_KEY, { value: '1', expiresAt: Date.now() + markerTtlMs });
+    }
   }
 
   async delete(key: string): Promise<void> {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -54,6 +54,11 @@ import {
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { ARVLCD_FIRE_ONCE_TTL_SEC, arvlCdFireOnceKey } from '../arvlcdFireOnceTtl';
 import { stampPushActivity, readPushActivityRecent } from '../cronIdleGate';
+import {
+  ACTIVE_TRIPS_MARKER_KEY,
+  hasActiveTripsMarker,
+  markTripRegistered,
+} from '../activeTripsGate';
 import { JITTER_SAMPLE_EVERY_N_TICKS, readJitterSamples } from '../cronJitterAggregate';
 import { putTrip } from '../trips';
 import { pendingKey, putPending } from '../pendingPushes';
@@ -11585,7 +11590,7 @@ describe('runScheduled — #2073 listTrips 병합 (Issue B)', () => {
 });
 
 describe('runScheduled — #2073 진짜 idle skip 게이트 (Issue A)', () => {
-  it('idle tick(활성 trip 0 + marker 없음) — kv.list 1회, kv.put 0회, pendingActivityPossible=false', async () => {
+  it('idle tick(활성 trip 0 + marker 없음) — kv.list 0회(#2452 list-quota 게이트), kv.put 0회, pendingActivityPossible=false', async () => {
     const kv = new InMemoryKV();
     // heartbeat가 이번 tick에 발화하지 않도록 직전 heartbeat를 미리 stamp(첫 진입 heartbeat put을
     // "idle write 0" 검증에서 배제 — 이슈 본문도 heartbeat 시간당 1 put은 예외로 명시).
@@ -11601,7 +11606,10 @@ describe('runScheduled — #2073 진짜 idle skip 게이트 (Issue A)', () => {
     });
     expect(stats.scanned).toBe(0);
     expect(stats.pendingActivityPossible).toBe(false);
-    expect(listSpy).toHaveBeenCalledTimes(1);
+    // #2452 — cron:has-active-trips 마커가 없으므로 listTrips(kv.list) 자체가 이번 tick엔
+    // 호출되지 않는다(list quota 보호가 이 테스트의 신규 관측 대상. 구 #2073 idle-gate는
+    // pending/retry list만 gating했고 이 main listTrips는 무조건 실행했었다).
+    expect(listSpy).not.toHaveBeenCalled();
     expect(putSpy).not.toHaveBeenCalled();
   });
 
@@ -11631,6 +11639,74 @@ describe('runScheduled — #2073 진짜 idle skip 게이트 (Issue A)', () => {
     });
     expect(stats.scanned).toBe(0);
     expect(stats.pendingActivityPossible).toBe(true);
+  });
+});
+
+describe('runScheduled — #2452 listTrips() list-quota 게이트', () => {
+  it('마커 有 + 활성 trip 有 — listTrips 실행되고 trip이 실제로 처리된다(라이더 절대 skip 안 됨)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip();
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // #2452 — InMemoryKV.put(trip:*)이 테스트 편의상 마커를 자동 stamp하므로(inMemoryKv.ts 참조)
+    // 명시적으로 markTripRegistered를 다시 호출해 "REGISTER 경로가 실제로 마커를 남긴다"는
+    // 계약 자체도 별도로 검증한다.
+    await markTripRegistered(kv as unknown as KVNamespace, trip.expiresAt, NOW);
+    const listSpy = vi.spyOn(kv, 'list');
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(listSpy).toHaveBeenCalled();
+    expect(stats.scanned).toBe(1);
+  });
+
+  it('마커 GET이 throw — listTrips를 강행한다(보수적, 실 라이더 miss 불허)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip();
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const getSpy = vi
+      .spyOn(kv, 'get')
+      .mockImplementation(async (key: string) => {
+        if (key === ACTIVE_TRIPS_MARKER_KEY) throw new Error('kv down');
+        return InMemoryKV.prototype.get.call(kv, key);
+      });
+    const listSpy = vi.spyOn(kv, 'list');
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(listSpy).toHaveBeenCalled();
+    expect(stats.scanned).toBe(1);
+    getSpy.mockRestore();
+  });
+
+  it('마커 有 but listTrips 결과 0건(stale marker) — 마커를 delete해 다음 idle tick부터 skip 재개', async () => {
+    const kv = new InMemoryKV();
+    await markTripRegistered(kv as unknown as KVNamespace, NOW + 60_000, NOW);
+    expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(true);
+
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(false);
+  });
+
+  it('POST /trips REGISTER(markTripRegistered)가 마커를 stamp — cron이 그걸 보고 listTrips를 실행', async () => {
+    const kv = new InMemoryKV();
+    expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(false);
+    await markTripRegistered(kv as unknown as KVNamespace, NOW + 30 * 60 * 1000, NOW);
+    expect(await hasActiveTripsMarker(kv as unknown as KVNamespace)).toBe(true);
   });
 });
 

--- a/backend/alarm-worker/src/activeTripsGate.ts
+++ b/backend/alarm-worker/src/activeTripsGate.ts
@@ -1,0 +1,99 @@
+/**
+ * #2452 — cron `listTrips()` list-quota 게이트 (PR #2450 write-throttle의 짝).
+ *
+ * 배경: `runScheduled`가 매 cron tick(1분 = 1,440회/일) `listTrips(env.TRIPS)`(`kv.list()`)를
+ * 무조건 호출한다. Cloudflare Free plan에서 LIST는 read/write와 별도 quota 버킷(상한
+ * 1,000/일)이라 하루 중 tick ~1000(대략 16:40 UTC)부터 자정까지 `kv.list()`가 실패 → cron이
+ * trip을 못 찾아 advance/SSoT/fire가 그 시간대 전체 전멸한다. #2073 idle-gate
+ * (`cronIdleGate.ts`)는 pending/retry `kv.list()`만 게이팅하고 이 main `listTrips`는
+ * 게이팅하지 않는다 — 이 모듈이 그 잔여 취약점을 막는다.
+ *
+ * 해법: "활성 trip이 하나라도 있는가"를 값싼 KV GET 마커(read quota 100k/일, 사실상 무제한)로
+ * 먼저 판정하고, 마커가 없을 때만 `listTrips` 호출 자체를 skip한다.
+ *   - 마커는 `POST /trips` REGISTER 성공 시(`index.ts`, putTrip 직후) 1회 stamp된다.
+ *     `POST /position`에서는 절대 stamp하지 않는다 — PR #2450의 write throttle을 되돌리지
+ *     않기 위함.
+ *   - TTL은 고정 상수 없이 trip 자신의 `expiresAt` 기준으로 계산한다(putTrip과 동일 방식) —
+ *     실제 trip 수명과 항상 정렬된다.
+ *   - cron이 마커를 발견해 `listTrips`를 실행한 tick마다, 실제 결과로 마커를 조정한다:
+ *     trips가 비었으면(stale marker) 즉시 delete해 다음 idle tick부터 skip이 재개되게 하고,
+ *     trips가 있으면 남은 trip 중 최대 `expiresAt`으로 재stamp해 연속 tick 동안 생존시킨다.
+ *
+ * 보수 정책(#2073 `readPushActivityRecent`와 동일) — 마커 GET이 실패(KV 장애)하면
+ * "활성 trip이 있을 수 있음"으로 간주해 `listTrips`를 강행한다. 실 라이더의 fire를 놓치는
+ * 것은 불허 — 가끔의 낭비 list 호출은 감수한다.
+ */
+
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+import type { Trip } from './types';
+
+export const ACTIVE_TRIPS_MARKER_KEY = 'cron:has-active-trips';
+
+/** KV `expirationTtl` 최소 제약(60s) 준수 — `putTrip`(trips.ts)과 동일 계산. */
+const MIN_MARKER_TTL_SEC = 60;
+
+function ttlSecFromExpiresAt(expiresAt: number, now: number): number {
+  return Math.max(MIN_MARKER_TTL_SEC, Math.floor((expiresAt - now) / 1000));
+}
+
+/**
+ * `POST /trips` REGISTER 성공(생성/업데이트 공통 putTrip 직후) 시 1회 stamp.
+ *
+ * 이 write가 유실되면(예: KV 장애) cron이 이 trip을 listTrips로 영영 발견 못 할 위험이 있다
+ * — cron 쪽 `refreshActiveTripsMarker`는 마커가 이미 있을 때만 동작하므로 자가치유 지점이
+ * 아니다. 그래서 이 함수는 다른 마커 write(예: `refreshActiveTripsMarker`, `cronIdleGate`)와
+ * 달리 실패를 삼키지 않고 그대로 throw한다 — 호출부(`index.ts`)가 register 응답을 막지 않는
+ * 선에서 로깅하도록 위임한다.
+ */
+export async function markTripRegistered(
+  kv: KVNamespace,
+  expiresAt: number,
+  now: number,
+): Promise<void> {
+  await kv.put(ACTIVE_TRIPS_MARKER_KEY, '1', {
+    expirationTtl: ttlSecFromExpiresAt(expiresAt, now),
+  });
+}
+
+/**
+ * cron이 `listTrips` 실행 *후* 실 결과로 마커를 조정한다. 마커가 없어 `listTrips` 자체를
+ * skip한 tick에는 호출하지 않는다(불필요한 delete write를 피함 — 호출부 책임).
+ */
+export async function refreshActiveTripsMarker(
+  kv: KVNamespace,
+  trips: readonly Trip[],
+  now: number,
+): Promise<void> {
+  if (trips.length === 0) {
+    try {
+      await kv.delete(ACTIVE_TRIPS_MARKER_KEY);
+    } catch {
+      // silent — TTL 자연만료가 백업.
+    }
+    return;
+  }
+  const maxExpiresAt = trips.reduce((max, trip) => Math.max(max, trip.expiresAt), 0);
+  try {
+    await kv.put(ACTIVE_TRIPS_MARKER_KEY, '1', {
+      expirationTtl: ttlSecFromExpiresAt(maxExpiresAt, now),
+    });
+  } catch {
+    // silent.
+  }
+}
+
+/**
+ * marker 존재 여부(= `listTrips`를 실행해야 하는가).
+ * KV 미바인딩 → false(binding 자체가 없으면 마커 개념이 무의미). read 실패 → true(보수적 —
+ * `listTrips` 강행, 위 모듈 헤더 정책 참조).
+ */
+export async function hasActiveTripsMarker(kv: KVNamespace | undefined): Promise<boolean> {
+  if (!kv) return false;
+  try {
+    assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+    const raw = await kv.get(ACTIVE_TRIPS_MARKER_KEY, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+    return raw !== null;
+  } catch {
+    return true;
+  }
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -19,6 +19,7 @@ import {
   validateBoardingPromptOutcome,
 } from './boardingPromptOutcome';
 import { stampPushActivity } from './cronIdleGate';
+import { markTripRegistered } from './activeTripsGate';
 import { runFallbackPushes } from './fallback';
 import { runRetryPushes } from './retryPushes';
 import {
@@ -963,6 +964,24 @@ app.post('/trips', async (c) => {
       : baseTrip;
 
       await putTrip(c.env.TRIPS, trip);
+
+      // #2452 — cron listTrips() list-quota 게이트 마커. REGISTER 성공(생성/업데이트 공통)
+      // 시에만 stamp한다 — POST /position에서는 절대 stamp하지 않는다(#2450 write throttle을
+      // 되돌리지 않기 위함). TTL은 trip.expiresAt에 정렬(activeTripsGate.ts 참조). KV write
+      // 실패는 graceful하지만 register 응답 차단 없이 관측 가능하도록 로그를 남긴다 — 이 마커가
+      // 유실되면 cron이 이 trip을 영영 스캔하지 못할 수 있는 유일한 실패 지점이기 때문
+      // (cron 쪽 refreshActiveTripsMarker는 마커가 이미 있을 때만 동작).
+      try {
+        await markTripRegistered(c.env.TRIPS, trip.expiresAt, Date.now());
+      } catch (e) {
+        console.log(
+          JSON.stringify({
+            msg: 'active-trips marker stamp on register failed (#2452)',
+            tokenPrefix: tokenPrefix(trip.token),
+            error: String(e),
+          }),
+        );
+      }
 
       // #2175 — deviceToken 역인덱스를 이번에 확정된 trip.token으로 갱신. ADR-025(#2194) 하에서
       // 신원=deviceToken이라 이 값은 항상 trip.token 자기 자신을 가리키지만(#2196), APNs token

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -125,6 +125,7 @@ import {
   stampHeartbeat,
 } from './cronJitterAggregate';
 import { readPushActivityRecent, stampPushActivity } from './cronIdleGate';
+import { hasActiveTripsMarker, refreshActiveTripsMarker } from './activeTripsGate';
 import { hasRescheduleFired, markRescheduleFired } from './rescheduleDedup';
 import { cleanupTripEvents, recordTripEvent } from './tripEventLog';
 import { hashTripToken } from './sentry';
@@ -1176,9 +1177,17 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
   // #2073 (Issue B) — listTrips 3중 호출(collectActiveLines/collectActiveStations/main loop 각자)을
   // 1회 병합. 전체 trip을 배열로 확보해 아래 파생 함수 + main loop가 모두 이 배열을 재사용한다.
   // 감축: list 5→3/tick, 활성 시 trip get 3N→N.
+  // #2452 — listTrips(kv.list())는 Free plan LIST quota(1,000/일) 소진 대상(read/write와 별도
+  // 버킷). 1,440 tick/일 무조건 호출하면 하루 중 특정 시각부터 자정까지 list가 실패해 cron이
+  // 활성 trip을 아예 못 찾는다. 값싼 KV GET 마커로 "활성 trip이 있을 수 있는가"를 먼저 판정해
+  // 마커 부재(진짜 idle)일 때만 listTrips 호출 자체를 skip한다. 마커 GET 실패는 보수적으로
+  // listTrips를 강행(activeTripsGate.ts 헤더 참조) — 실 라이더 miss는 불허.
+  const mayHaveActiveTrips = await hasActiveTripsMarker(env.TRIPS);
   const scannedTrips: Trip[] = [];
-  for await (const trip of listTrips(env.TRIPS)) {
-    scannedTrips.push(trip);
+  if (mayHaveActiveTrips) {
+    for await (const trip of listTrips(env.TRIPS)) {
+      scannedTrips.push(trip);
+    }
   }
   // #2175 — register-time deviceToken 역인덱스 merge/cleanup(#2184 리뷰 P1)에 대한 cron
   // 안전망. KV eventual consistency 등으로 같은 deviceToken의 active trip이 순간적으로 2개 이상
@@ -1186,6 +1195,12 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
   // 하는 중복 발송을 막기 위해 매 tick 최신(createdAt) trip만 처리 대상으로 남긴다. deviceToken이
   // 없는(legacy) trip은 그대로 통과.
   const trips: Trip[] = dedupeTripsByDeviceToken(scannedTrips);
+  // #2452 — listTrips를 실제로 실행한 tick에서만 마커를 실 결과로 조정한다(mayHaveActiveTrips가
+  // false였던 tick은 scannedTrips가 항상 []이므로, 여기서 delete를 또 부르면 부재 마커에 대한
+  // 낭비 write가 매 idle tick 반복된다 — 그 write는 스킵한다).
+  if (mayHaveActiveTrips) {
+    await refreshActiveTripsMarker(env.TRIPS, trips, now);
+  }
 
   // #2073 (Issue A) — 진짜 idle 판정. 활성 trip이 하나도 없고, 직전 tick 근방 fire/retry 기록도
   // 없으면 pending/retry push가 존재할 수 없다(모든 fire 경로가 trip 기반이므로 trip 부재 tick엔


### PR DESCRIPTION
## Summary

- **문제**: `runScheduled`가 매 cron tick(1분 = 1,440회/일) `listTrips(env.TRIPS)`(`kv.list()`)를 무조건 호출. Cloudflare Free plan에서 LIST는 read/write와 **별도 quota 버킷**(상한 1,000/일)이라 1,440 > 1,000 → 하루 중 tick ~1000(≈16:40 UTC)부터 자정까지 `kv.list()` 실패 → 그 시간대 backend advance/SSoT/fire 전멸. PR #2450(write-quota throttle, `POST /position`)과는 다른 버킷이라 별개 수정.
- **해법**: `listTrips`를 값싼 KV GET 마커(`cron:has-active-trips`, read quota 100k/일 사실상 무제한) 뒤에 게이팅.
  - `src/activeTripsGate.ts`(신규): 마커는 `POST /trips` REGISTER 성공 시(`putTrip` 직후, **`POST /position`은 절대 아님** — #2450 throttle 유지) 1회 stamp. TTL은 trip 자신의 `expiresAt` 기준(고정 상수 없이 실제 trip 수명과 정렬).
  - cron: 마커 GET → 있으면 `listTrips` 실행, 0건이면 마커 delete(cleanup), >0건이면 활성 trip 중 최대 `expiresAt`으로 재stamp(연속 tick 생존). 마커 없으면 `listTrips` 자체를 skip.
  - 마커 GET 실패(KV 장애) → `listTrips` 강행(보수적, #2073 `readPushActivityRecent`와 동일 정책 — 실 라이더 miss 불허).
- 부수: `markTripRegistered`의 KV write 실패는 조용히 삼키지 않고 로그(register 응답은 차단 안 함) — 이 write가 cron 재발견의 유일한 진입점이라 다른 마커 write(silent)와 다르게 관측 가능해야 함.

## Marker / TTL / 측정

- 마커 키: `cron:has-active-trips`
- TTL: 고정 상수 없음 — `Math.max(60, floor((expiresAt - now)/1000))` (`putTrip`과 동일 계산 방식, trip 실제 수명에 항상 정렬)
- list ops/day: **1,440(매 tick) → 활성 trip이 있는 tick 수만** (현재 실사용 기준 하루 수십 분 수준, 1,000 미만으로 안전 복귀)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` clean.
2. **V/X dashboard** — `wrangler tail`에서 idle tick의 `kv.list` 호출 자체가 사라짐(기존 cron 로그 패턴 대비 관측 가능). `markTripRegistered` 실패 시 `active-trips marker stamp on register failed (#2452)` 로그로 관측.
3. **의존 PR** — N/A. PR #2451(진입 alert, arvlCd fire path)과는 다른 영역(`runScheduled` listTrips ~1180 + `POST /trips` index.ts)만 건드려 merge conflict 없음.
4. **측정 plan** — 배포 후 wrangler tail로 idle tick에 `kv.list` 미호출 확인 + Cloudflare Dashboard KV Analytics에서 LIST 연산/일 1,000 이하로 감소 확인(1주).
5. **Device verify** — N/A — type+unit only (backend cron 로직, device 코드 변경 없음).

## Test plan

- [x] `npm test` — 3073 passed, coverage 아그리게이트 floor(stmts 97/branches 96/funcs 98/lines 97) 충족 (97.34/96.29/99.1/97.34)
- [x] `npm run type-check` clean
- [x] `npm run lint:orphan` clean
- [x] RED→GREEN: `activeTripsGate.test.ts`(12 tests) + `scheduled.test.ts` #2452 mechanism 4 tests(마커 有+trip 有→list 실행, GET throw→강행, stale marker→delete, register→marker stamp) + 구 #2073 idle-tick 테스트를 신 동작(list 0회)으로 갱신

Closes #2452