### PR TITLE
fix(#2456): 잠실나루 redundant 탑승 프롬프트 — 같은 line transfer waypoint lock release 억제

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2301,6 +2301,48 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(await kv.get('progress:lock-tok')).toBeNull();
   });
 
+  // 잠실나루 redundant boarding prompt regression — transfer waypoint의 목적지 line이 현재
+  // boardingLock.line과 동일(같은 호선 내 잘못 라벨된 transfer)이면 lock을 release하면 안 된다.
+  // release되면 다음 cycle의 evaluateAndMaybeFireBoardingPrompt가 lock=inactive로 오판해
+  // "탑승했어요?" 프롬프트를 이미 탑승 중인 사용자에게 재발사한다.
+  it('실제 노선 변경 없는 transfer waypoint(같은 line) 통과 시 boardingLock 유지(release 억제)', async () => {
+    const kv = new InMemoryKV();
+    await runArrivedScenario(
+      kv,
+      {
+        waypoints: [
+          // 목적지 line이 lock.line('7')과 동일 — 같은 호선 내 waypoint가 transfer로 잘못
+          // 라벨/advance된 케이스. 실제 환승이 아니므로 lock을 유지해야 한다.
+          { stationName: '잠실나루', line: '7', kind: 'transfer' },
+          { stationName: '군자', line: '7', kind: 'destination' },
+        ],
+      },
+      '잠실나루',
+      'p-same-line-transfer',
+    );
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+    expect(stored.boardingLock).toBeDefined();
+    expect(stored.boardingLock.trainCode).toBe('7246');
+  });
+
+  // 대조군 — 목적지 line이 lock.line과 실제로 다르면(#864 원 시나리오) 기존대로 release돼야 한다.
+  it('실제 노선 변경 있는 transfer waypoint(다른 line) 통과 시 boardingLock release 유지', async () => {
+    const kv = new InMemoryKV();
+    await runArrivedScenario(
+      kv,
+      {
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+      },
+      '군자',
+      'p-diff-line-transfer',
+    );
+    const stored = JSON.parse((await kv.get('trip:lock-tok')) as string);
+    expect(stored.boardingLock).toBeUndefined();
+  });
+
   // #1438 (E5) — backend → device lock release sync. transfer waypoint advance 시 device로
   // silent push에 lockReleasedReason='transfer'를 실어 보내 로컬 useBoardingLockStore가 즉시 sync.
   it('#1438 (E5) — transfer release 시 silent push payload에 lockReleasedReason=transfer 포함', async () => {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3911,6 +3911,11 @@ export async function advanceBoardingLockWaypoint(
   // device가 사전 예약 큐와 diff하여 cron 1분 race로 누락된 station-passed를 backfill 발사한다
   // (S5 머지 후 후속 wiring PR). 본 PR은 backend → device 데이터 plumbing만.
   appendPassedStation(trip, waypoint.stationName);
+  // 잠실나루 redundant boarding prompt regression — slice 직전 다음 waypoint(새 leg 시작점)의
+  // line을 캡처. transfer waypoint 자체의 line은 "방금 통과한(=현재) leg"의 line이라 항상
+  // boardingLock.line과 같아 진짜 환승/같은 호선 오라벨을 구분하지 못한다. 실제 노선 변경
+  // 여부는 그 다음 waypoint의 line으로만 판별 가능.
+  const nextLegWaypoint = trip.waypoints[1];
   // ADR-017 T5 (#1558) — immutable slice 로 mutation race 방지 (.shift 는 in-place).
   trip.waypoints = trip.waypoints.slice(1);
   trip.lastTrackedArrivalEpoch = undefined;
@@ -3926,7 +3931,15 @@ export async function advanceBoardingLockWaypoint(
   // progress KV도 같이 정리 — 옛 trainCode + shiftedCount가 stale로 남으면 token-refresh race
   // (`useApnsTripRegistration` `latestInputsRef` 옛 lock 보유) 윈도우에서 client 옛 lock POST 시
   // `progressApplies=true` 분기로 진입해 옛 lock이 backend에 다시 active로 복원되는 회귀가 가능.
-  const lockReleasedOnTransfer = waypoint.kind === 'transfer' && trip.boardingLock !== undefined;
+  //
+  // 잠실나루 redundant boarding prompt regression — waypoint.kind==='transfer'라도 다음
+  // leg(nextLegWaypoint)의 line이 현재 boardingLock.line과 같으면(같은 호선 내 waypoint가
+  // transfer로 잘못 라벨/advance된 케이스) 실제 노선 변경이 아니므로 release하면 안 된다.
+  // release되면 다음 cycle에 isBoardingLockActive=false로 오판해 이미 탑승 중인 사용자에게
+  // "탑승했어요?" 프롬프트가 재발사된다(#864 원 목적인 진짜 환승 release는 그대로 유지).
+  const isRealLineChange = nextLegWaypoint?.line !== trip.boardingLock?.line;
+  const lockReleasedOnTransfer =
+    waypoint.kind === 'transfer' && trip.boardingLock !== undefined && isRealLineChange;
   // #1438 (E5) — release 직전 lock 스냅샷. 직후 fire에서 buildStationPassedImminentPayload가
   // line/trainCode self-describing 필드(boardingLine/trainCode)를 채우는 데 사용한다.
   const releasedLockSnapshot = lockReleasedOnTransfer ? trip.boardingLock : undefined;


### PR DESCRIPTION
## 증상
잠실나루에서 이미 탑승 중이고 boardingLock이 active인데도 "탑승했어요?" 프롬프트가 재발사됨.

## Root cause
boardingPrompt는 lock이 inactive일 때만 발사된다. mid-trip 유일한 force-release 경로는
`scheduled.ts`의 transfer waypoint advance 블록(#864):

```ts
const lockReleasedOnTransfer = waypoint.kind === 'transfer' && trip.boardingLock !== undefined;
```

waypoint.kind==='transfer'이기만 하면 다음 leg의 line이 현재 boardingLock.line과 같아도(같은
호선 내에서 transfer로 잘못 라벨/advance된 waypoint) lock을 release했다. release되면 다음
cron cycle이 isBoardingLockActive=false로 오판해 이미 탑승 중인 사용자에게 boardingPrompt가
재발사된다.

## Fix
`src/scheduled.ts` (~3913-3936) — slice 직전 다음 leg waypoint(`nextLegWaypoint = trip.waypoints[1]`)를
캡처해, 그 line이 현재 `trip.boardingLock.line`과 **실제로 다를 때만** release하도록 가드 추가.

비교 필드: `nextLegWaypoint.line`(다음 leg waypoint의 `line`) vs `trip.boardingLock.line`.
transfer waypoint 자기 자신의 `line`은 항상 "방금 통과한(=현재)" leg의 line이라 boardingLock.line과
비교해도 진짜 환승 여부를 구분할 수 없어서(둘 다 같은 값), 다음 leg waypoint의 line으로만 판별했다.

#864 원 목적(진짜 환승 시 release해서 옛 trainCode etaMissing 5회 death 방지)은 그대로 유지.

## Reproduce-first (TDD)
`src/__tests__/scheduled.test.ts`에 두 테스트 추가 (기존 #864 테스트 바로 다음):
- `실제 노선 변경 없는 transfer waypoint(같은 line) 통과 시 boardingLock 유지(release 억제)` —
  잠실나루(line 7) transfer, 다음 destination도 line 7 → RED(`expected undefined to be defined`)
  확인 후 fix로 GREEN.
- `실제 노선 변경 있는 transfer waypoint(다른 line) 통과 시 boardingLock release 유지` — 대조군
  (#864 원 시나리오, 군자 7→아차산 5), release 유지 회귀 없음 확인.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected). 신규 export 없음(내부 로컬 변수 + 테스트만 추가).
2. **V/X dashboard** — 이 신호는 `boardingLock` 존재 여부(KV `trip:<token>`)로만 관측됨. 별도 dashboard 노출 없음 — DebugModal의 lock 상태 표시가 device 측 확인 지점.
3. **의존 PR** — 없음 (N/A). scheduled.ts의 진행 중인 #2451/#2453과 다른 region(~3913-3936, transfer-release 블록)만 수정해 conflict 없음.
4. **측정 plan** — D1 `trip_events`에서 transfer-release(lockReleasedReason='transfer') 이벤트가 같은-line 케이스에서 더 이상 발생하지 않는지 1주 확인. 실탑승 시 잠실나루류 같은-line 구간에서 boardingPrompt 재발사 로그(D1/Sentry) 0건 목표.
5. **Device verify** — N/A — type+unit only (backend 로직 변경, 클라이언트 코드 변경 없음). backend cron 동작이므로 실기기 검증은 다음 실탑승에서 D1 trip_events로 간접 확인.

## Test plan
- [x] `npm test` (backend/alarm-worker) — 86 files / 3059 tests passed, coverage floor 통과
- [x] `npm run type-check` (backend/alarm-worker) — clean
- [x] `npm run lint:orphan` (root) — no orphan exports

Closes #2456

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9