### PR TITLE
fix(#2454): 현재역 NAME/LINE 배지 불일치 (R2) — 이름이 실제 위치를 따르도록 수정

### DIFF
--- a/src/features/nearest-station/utils/__tests__/resolveDisplayOrigin.test.ts
+++ b/src/features/nearest-station/utils/__tests__/resolveDisplayOrigin.test.ts
@@ -1,0 +1,52 @@
+import { resolveDisplayOrigin } from '../resolveDisplayOrigin';
+import type { Station } from '../../../../shared/types/station';
+
+const ddukseom: Station = {
+  id: '0210',
+  name: '뚝섬',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.53,
+  lng: 127.04,
+};
+
+const jamsil: Station = {
+  id: '0216',
+  name: '잠실',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.51,
+  lng: 127.1,
+};
+
+describe('resolveDisplayOrigin', () => {
+  // R2 repro (corrected direction, #2454): fused cascade `result` is stuck at the trip
+  // origin(뚝섬) — off-arc, currentStationDisplayDemoted=true — while raw GPS liveResult
+  // reports the user's real position(잠실). The displayed name must follow reality(잠실),
+  // not freeze at the stale cascade value.
+  it('follows raw-GPS reality (liveStation) when the cascade is demoted (stuck/off-arc)', () => {
+    const result = resolveDisplayOrigin(ddukseom, jamsil, true, false);
+    expect(result).toEqual(jamsil);
+  });
+
+  it('falls back to null (honesty placeholder) when demoted and no live GPS reality is available', () => {
+    const result = resolveDisplayOrigin(ddukseom, null, true, false);
+    expect(result).toBeNull();
+  });
+
+  // Must-not-regress: normal on-route trip — cascade not stuck, name tracks effectiveOrigin
+  // (the fused/fire-path SSOT) exactly as before, no flicker to raw GPS.
+  it('uses effectiveOrigin unchanged when the cascade is not demoted', () => {
+    const result = resolveDisplayOrigin(jamsil, ddukseom, false, false);
+    expect(result).toEqual(jamsil);
+  });
+
+  it('always uses effectiveOrigin for a custom (user-picked) origin, ignoring live GPS and demote state', () => {
+    const result = resolveDisplayOrigin(ddukseom, jamsil, true, true);
+    expect(result).toEqual(ddukseom);
+  });
+
+  it('returns null when effectiveOrigin is null and not demoted', () => {
+    expect(resolveDisplayOrigin(null, jamsil, false, false)).toBeNull();
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/resolveOriginLineVariants.test.ts
+++ b/src/features/nearest-station/utils/__tests__/resolveOriginLineVariants.test.ts
@@ -1,0 +1,58 @@
+import { resolveOriginLineVariants } from '../resolveOriginLineVariants';
+import type { Station } from '../../../../shared/types/station';
+
+const ddukseom: Station = {
+  id: '0210',
+  name: '뚝섬',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.53,
+  lng: 127.04,
+};
+
+const jamsilLine2: Station = {
+  id: '0216',
+  name: '잠실',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.51,
+  lng: 127.1,
+};
+
+const jamsilLine8: Station = {
+  id: '0817',
+  name: '잠실',
+  line: '8',
+  lineColor: '#E6186C',
+  lat: 37.51,
+  lng: 127.1,
+};
+
+describe('resolveOriginLineVariants', () => {
+  // R2 repro: fused pipeline stalled → effectiveOrigin fell back to trip origin(뚝섬)
+  // while raw GPS variants still report live position(잠실, 2·8호선 transfer).
+  it('demotes to a single effectiveOrigin-line badge when raw variants belong to a different station', () => {
+    const result = resolveOriginLineVariants(ddukseom, [jamsilLine2, jamsilLine8], false);
+    expect(result).toEqual([ddukseom]);
+    expect(result.some((s) => s.line === '8')).toBe(false);
+  });
+
+  it('keeps the full multi-line transfer badges when raw variants match effectiveOrigin (no regression)', () => {
+    const result = resolveOriginLineVariants(jamsilLine2, [jamsilLine2, jamsilLine8], false);
+    expect(result).toEqual([jamsilLine2, jamsilLine8]);
+  });
+
+  it('returns just effectiveOrigin when raw variants has 0 or 1 entries (non-transfer station)', () => {
+    expect(resolveOriginLineVariants(ddukseom, [], false)).toEqual([ddukseom]);
+    expect(resolveOriginLineVariants(ddukseom, [ddukseom], false)).toEqual([ddukseom]);
+  });
+
+  it('always uses effectiveOrigin alone for custom origin, ignoring raw variants entirely', () => {
+    const result = resolveOriginLineVariants(jamsilLine2, [jamsilLine2, jamsilLine8], true);
+    expect(result).toEqual([jamsilLine2]);
+  });
+
+  it('returns an empty array when effectiveOrigin is null', () => {
+    expect(resolveOriginLineVariants(null, [jamsilLine2, jamsilLine8], false)).toEqual([]);
+  });
+});

--- a/src/features/nearest-station/utils/resolveDisplayOrigin.ts
+++ b/src/features/nearest-station/utils/resolveDisplayOrigin.ts
@@ -1,0 +1,29 @@
+import type { Station } from '../../../shared/types/station';
+
+/**
+ * 현재역 표시명이 고착된 fused cascade가 아니라 실제 위치를 따르도록 한다 (#2454, R2).
+ *
+ * 사용자가 route arc를 벗어나면 fused cascade(`effectiveOrigin`의 상위 원천인 `result`)는
+ * off-arc 위치를 reconcile하지 못해 trip origin(예: 뚝섬)에 stuck된다. 이때
+ * `currentStationDisplayDemoted`(#2125)가 true가 되어 표시 계층에 "cascade를 신뢰할 수
+ * 없다"는 신호를 준다. 기존에는 이 신호를 정직 강등(placeholder 텍스트)에만 썼는데, 그
+ * 결과 화면에는 STALE한 이름(뚝섬)은 안 보이지만 실제 위치(잠실) 정보도 함께 사라졌다.
+ *
+ * raw GPS `liveResult`(sticky/cascade 개입 없는 실제 최근접, #1568)는 바로 이 순간에도
+ * 사용자의 실제 위치(잠실)를 정확히 반영한다. cascade가 demoted 상태일 때는 표시명이
+ * liveResult를 따라가도록 해 "이름=실제위치"가 되게 한다 — LINE 배지는 이미 raw GPS
+ * variants를 쓰므로 이름이 여기 합류하면 자연히 같은 역을 가리키게 된다.
+ *
+ * fire path(SSOT: `effectiveOrigin`/`result`) 자체는 건드리지 않는다 — 알람/도착정보/경로
+ * 계산은 여전히 기존 fallback chain을 그대로 쓴다. 이 함수는 표시 전용이다.
+ */
+export function resolveDisplayOrigin(
+  effectiveOrigin: Station | null,
+  liveStation: Station | null,
+  isDemoted: boolean,
+  isCustomOrigin: boolean,
+): Station | null {
+  if (isCustomOrigin) return effectiveOrigin;
+  if (isDemoted) return liveStation;
+  return effectiveOrigin;
+}

--- a/src/features/nearest-station/utils/resolveOriginLineVariants.ts
+++ b/src/features/nearest-station/utils/resolveOriginLineVariants.ts
@@ -1,0 +1,26 @@
+import type { Station } from '../../../shared/types/station';
+
+/**
+ * 현재역 NAME과 LINE 배지의 정합성을 보장한다 (#2454, R2).
+ *
+ * `rawVariants`(useFusedNearestStation의 `variants`, 즉 raw GPS `useNearestStation`
+ * 출력)는 fused 파이프라인과 독립적으로 매 polling마다 live 위치를 반영해 갱신된다.
+ * fused 파이프라인이 stall되어 표시용 `effectiveOrigin`이 lock/tripOrigin 등 stale
+ * fallback으로 물러나면, rawVariants는 여전히 다른(live) 역을 가리켜 NAME(예: 뚝섬)과
+ * LINE 배지(예: 잠실의 2·8호선)가 서로 다른 역을 가리키는 모순이 생긴다.
+ *
+ * rawVariants가 effectiveOrigin과 같은 역(정확히 같은 name — findNearestStation의
+ * variants도 `s.name === result.station.name`으로 grouping)일 때만 원본 다중 노선
+ * 배지를 쓰고, 다르면 effectiveOrigin 단일 노선으로 강등해 배지가 항상 표시된 NAME과
+ * 같은 역을 가리키도록 보장한다.
+ */
+export function resolveOriginLineVariants(
+  effectiveOrigin: Station | null,
+  rawVariants: Station[],
+  isCustomOrigin: boolean,
+): Station[] {
+  if (!effectiveOrigin) return [];
+  if (isCustomOrigin || rawVariants.length <= 1) return [effectiveOrigin];
+  if (rawVariants[0].name !== effectiveOrigin.name) return [effectiveOrigin];
+  return rawVariants;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
 import { useFusedNearestStation } from '../features/nearest-station/hooks/useFusedNearestStation';
 import { resolveOriginLineVariants } from '../features/nearest-station/utils/resolveOriginLineVariants';
+import { resolveDisplayOrigin } from '../features/nearest-station/utils/resolveDisplayOrigin';
 import { useV1MismatchDetector } from '../features/nearest-station/hooks/useV1MismatchDetector';
 import { useStationMismatchDetector } from '../features/nearest-station/hooks/useStationMismatchDetector';
 import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
@@ -502,6 +503,15 @@ export default function HomeScreen() {
     boardingLockStation ??
     tripOrigin ??
     null;
+  // #2454 (R2) — cascade가 off-arc로 stuck되면(currentStationDisplayDemoted) 표시명은
+  // stale한 effectiveOrigin이 아니라 raw GPS 실제 위치(liveResult)를 따라간다. 표시 전용 —
+  // 알람/도착정보/경로 계산(fire path)은 계속 effectiveOrigin을 그대로 쓴다.
+  const displayOrigin = resolveDisplayOrigin(
+    effectiveOrigin,
+    liveResult?.station ?? null,
+    currentStationDisplayDemoted,
+    isCustomOrigin,
+  );
   useTripOrigin(destination, effectiveOrigin, setTripOrigin, tripOrigin);
   const handleSameOriginToastDismiss = useCallback(() => setSameOriginToast(null), []);
   const handleShortRouteToastDismiss = useCallback(() => setShortRouteToast(null), []);
@@ -557,10 +567,13 @@ export default function HomeScreen() {
   }, [refresh, refetchArrival]);
 
   // 환승역이면 모든 호선 변형에서 경로 계산 → 출발역 환승 없는 최적 경로 자동 선택
-  // #2454 (R2) — rawVariants(GPS live)가 effectiveOrigin(fused stall 시 stale fallback)과
-  // 다른 역을 가리키면 "NAME=A + LINE 배지=B" 모순을 막기 위해 단일 노선으로 강등한다.
+  // fire path(route 계산)라 effectiveOrigin 기준 그대로 — displayOrigin(표시 전용)과 분리.
   const originVariants = resolveOriginLineVariants(effectiveOrigin, variants, isCustomOrigin);
   const variantIds = originVariants.map((v) => v.id).join(',');
+  // #2454 (R2) — LINE 배지 표시 전용. displayOrigin(이름과 동일 소스)과 raw variants가
+  // 다른 역을 가리키면 "이름=A + 배지=B" 모순을 막기 위해 단일 노선으로 강등한다. 정상 시
+  // (demoted 아님) displayOrigin===effectiveOrigin이라 기존 동작과 동일.
+  const displayLineVariants = resolveOriginLineVariants(displayOrigin, variants, isCustomOrigin);
 
   // #1883 (RC-11) — 마지막으로 route를 계산한 trip session id (`${destinationId}|${routePreference}`).
   // trip session이 같으면 effectiveOrigin / variants 갱신으로 인한 mid-trip route mutation을 차단.
@@ -1402,11 +1415,13 @@ export default function HomeScreen() {
                   ]}
                   testID="home-origin-station-name"
                 >
-                  {/* #2125 — 현재역 표시 고착 정직 강등. 역명 표시만 대체 — effectiveOrigin
-                      자체(journey/도착정보/알람 SSOT)는 무변경. */}
-                  {currentStationDisplayDemoted
-                    ? t('home.originStaleDemote')
-                    : getStationDisplayName(effectiveOrigin)}
+                  {/* #2125/#2454 — cascade가 off-arc로 stuck되면 displayOrigin이 raw GPS
+                      실제 위치를 따라간다(resolveDisplayOrigin). 실제 위치조차 없을 때만
+                      정직 강등 placeholder. effectiveOrigin 자체(journey/도착정보/알람
+                      SSOT)는 무변경. */}
+                  {displayOrigin
+                    ? getStationDisplayName(displayOrigin)
+                    : t('home.originStaleDemote')}
                 </Text>
                 <TouchableOpacity
                   onPress={() =>
@@ -1423,11 +1438,14 @@ export default function HomeScreen() {
                 </TouchableOpacity>
               </View>
               <View style={styles.metaRow}>
-                {originVariants.length > 0 ? (
-                  originVariants.map((v) => <LineBadge key={v.id} line={v.line} />)
-                ) : (
-                  <LineBadge line={effectiveOrigin.line} />
-                )}
+                {/* #2454 — badge는 항상 위 이름(displayOrigin)과 같은 역을 가리킨다. 실제
+                    위치조차 없어 이름이 placeholder일 때는 badge도 렌더하지 않는다. */}
+                {displayOrigin &&
+                  (displayLineVariants.length > 0 ? (
+                    displayLineVariants.map((v) => <LineBadge key={v.id} line={v.line} />)
+                  ) : (
+                    <LineBadge line={displayOrigin.line} />
+                  ))}
                 {/* #446: source==='gps'일 때만 user↔station 거리/도보시간이 의미 있음.
                     fusion 추정(positionTrain/arrival/route) 결과의 거리는 user↔추정역
                     직선거리라 도보 안내로 표시하면 잘못된 정보가 됨 → 숨김. */}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
 import { useFusedNearestStation } from '../features/nearest-station/hooks/useFusedNearestStation';
+import { resolveOriginLineVariants } from '../features/nearest-station/utils/resolveOriginLineVariants';
 import { useV1MismatchDetector } from '../features/nearest-station/hooks/useV1MismatchDetector';
 import { useStationMismatchDetector } from '../features/nearest-station/hooks/useStationMismatchDetector';
 import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
@@ -553,7 +554,9 @@ export default function HomeScreen() {
   }, [refresh, refetchArrival]);
 
   // 환승역이면 모든 호선 변형에서 경로 계산 → 출발역 환승 없는 최적 경로 자동 선택
-  const originVariants = !isCustomOrigin && variants.length > 1 ? variants : effectiveOrigin ? [effectiveOrigin] : [];
+  // #2454 (R2) — rawVariants(GPS live)가 effectiveOrigin(fused stall 시 stale fallback)과
+  // 다른 역을 가리키면 "NAME=A + LINE 배지=B" 모순을 막기 위해 단일 노선으로 강등한다.
+  const originVariants = resolveOriginLineVariants(effectiveOrigin, variants, isCustomOrigin);
   const variantIds = originVariants.map((v) => v.id).join(',');
 
   // #1883 (RC-11) — 마지막으로 route를 계산한 trip session id (`${destinationId}|${routePreference}`).


### PR DESCRIPTION
## 요약 (방향 정정)
draft #2458의 첫 버전은 방향이 반대였다 — badge(잠실=실제 위치, raw GPS)를 name(뚝섬=stale cascade)에 맞춰 강등했는데, 실제로는 뚝섬이 틀린 값이고 잠실이 진짜 사용자 위치였다. 그 fix는 유일하게 맞는 신호(배지)를 가리는 결과였다.

**근본 원인**: 사용자가 route arc를 벗어나면 fused cascade(`result`)가 off-arc 위치를 reconcile하지 못해 trip origin(뚝섬)에 stuck된다 → `effectiveOrigin`이 이 stale 값에 고착. 반면 raw GPS `liveResult`/`variants`는 계속 실제 위치(잠실)를 정확히 반영한다.

**정정된 방향**: cascade가 stuck 상태(`currentStationDisplayDemoted`, #2125)일 때 표시 이름이 stale cascade가 아니라 raw GPS 실제 위치를 따라가도록 한다. 배지는 그대로 두고, 이름이 배지(현실)에 합류한다.

## 변경
- `src/features/nearest-station/utils/resolveDisplayOrigin.ts` 신규 — `currentStationDisplayDemoted`일 때 `liveResult?.station`(raw GPS 실제 위치)을, 아니면 `effectiveOrigin`을 반환하는 pure helper. custom origin은 항상 `effectiveOrigin` 우선. 실제 위치 신호조차 없을 때만 정직 강등 placeholder 유지. 100% 커버리지 5개 테스트.
- `src/screens/HomeScreen.tsx`: `displayOrigin`(표시 전용)을 신설해 이름(~1420)과 배지(~1440) 둘 다 여기서 파생. **fire path(`effectiveOrigin`, `originVariants`/route 계산, 알람, 도착정보)는 완전히 무변경** — displayOrigin은 표시 레이어에만 분리 적용.
- 기존 `resolveOriginLineVariants`(R2 첫 버전에서 만든 helper)는 dead code 처리하지 않고 `displayOrigin` 기준으로 재배선 — 정상적으로 demoted 아닐 때(=displayOrigin===effectiveOrigin) 기존 동작과 동일하며, 잔여 mismatch 케이스에 대한 defense-in-depth로 유지.

## Reproduce-first (TDD)
`src/features/nearest-station/utils/__tests__/resolveDisplayOrigin.test.ts` (5 tests, 100% coverage):
- **핵심 repro**: `effectiveOrigin`=뚝섬(stale), `liveStation`=잠실(reality), demoted=true → 반환값이 잠실(실제 위치를 따름), 뚝섬 아님
- demoted=true인데 liveStation도 null → null 반환 (정직 강등 placeholder 유지)
- **회귀 없음**: demoted=false(정상 trip) → `effectiveOrigin` 그대로 반환, name/badge가 기존처럼 fused 값을 tracking
- custom origin(사용자가 직접 선택) → demoted/liveStation과 무관하게 항상 `effectiveOrigin`
- `effectiveOrigin` null + not demoted → null

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — 순수 함수 로직으로 UI 렌더 직결(`home-origin-station-name` 텍스트 + 옆 `LineBadge` 리스트); 유닛 테스트로 관측, 별도 로그 신호 없음. 회귀 재발 시 `resolveDisplayOrigin.test.ts`가 즉시 RED
3. **의존 PR** — N/A (backend/device/infra 의존 없음, frontend-only pure function)
4. **측정 plan** — 실기기 관측: off-arc(경로 이탈) 상황에서 currentStationDisplayDemoted가 true가 되는 지점부터 현재역 카드 이름이 실제 GPS 위치(예: 잠실)로 전환되는지 육안 확인. Fusion debug log의 `display-demote` 항목과 함께 대조
5. **Device verify** — N/A — type+unit only (screens 레이어는 coverage 제외, 로직 100% 커버된 pure helper로 분리해 검증 완료). 실기기 off-arc 시나리오 최종 확인은 사용자 판단

## 검증
- `npm run type-check` — pass
- `npm test` — 468/468 suites, 9913/9913 tests, 100% coverage
- `npm run lint:orphan` — 0 orphan

Closes #2454