### PR TITLE
feat(#2455): 반대 방향 탑승 감지 (Phase B, foreground)

### DIFF
--- a/src/features/route/components/MisBoardingBanner.tsx
+++ b/src/features/route/components/MisBoardingBanner.tsx
@@ -3,21 +3,28 @@ import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing } from '../../../shared/theme';
 import { ActionBanner } from '../../../shared/ui/ActionBanner';
 
+/** 배너가 뜬 이유 — 'absent'(기존, trainCode 미관측) / 'wrong-direction'(#2455, 반대 방향 탑승). */
+export type MisBoardingBannerReason = 'absent' | 'wrong-direction';
+
 interface Props {
   onReselect: () => void;
+  /** 미전달 시 기존 'absent' copy 유지 (하위호환). */
+  reason?: MisBoardingBannerReason;
 }
 
 /**
- * BoardingLock의 trainCode가 실시간 위치 API에서 사라졌을 때 노출되는 경고 배너 (#584 PR D3).
+ * BoardingLock의 trainCode가 실시간 위치 API에서 사라졌거나(absent), 반대 방향으로 진행 중인
+ * 열차가 관측됐을 때(wrong-direction, #2455 Phase B) 노출되는 경고 배너 (#584 PR D3).
  *
  * 표시 조건/감지 로직은 useMisBoardingDetector가 담당 — 이 컴포넌트는 순수 표시 + 액션.
- * 공통 레이아웃은 ActionBanner 슬롯 패턴으로 위임.
+ * 공통 레이아웃은 ActionBanner 슬롯 패턴으로 위임. reason에 따라 라벨/본문/a11y copy만 분기.
  *
  * a11y(#1077 후속): ActionBanner의 a11y props로 alert role + 액션 라벨/힌트 주입.
  */
-export function MisBoardingBanner({ onReselect }: Props) {
+export function MisBoardingBanner({ onReselect, reason = 'absent' }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const isWrongDirection = reason === 'wrong-direction';
   return (
     <ActionBanner
       accent={colors.warn}
@@ -26,13 +33,21 @@ export function MisBoardingBanner({ onReselect }: Props) {
       onActionPress={onReselect}
       actionTestID="mis-boarding-reselect"
       marginBottom={spacing.md}
-      accessibilityLabel={t('a11y.route.misBoardingBannerLabel')}
+      accessibilityLabel={
+        isWrongDirection
+          ? t('a11y.route.misBoardingWrongDirectionBannerLabel')
+          : t('a11y.route.misBoardingBannerLabel')
+      }
       actionAccessibilityLabel={t('a11y.route.misBoardingReselectLabel')}
       actionAccessibilityHint={t('a11y.route.misBoardingReselectHint')}
     >
-      <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 미확인</Text>
+      <Text style={[typography.label, { color: colors.warn }]}>
+        {isWrongDirection ? '반대 방향으로 가고 있어요' : '탑승 열차 미확인'}
+      </Text>
       <Text style={[typography.body, { color: colors.muted }]}>
-        선택한 열차를 찾을 수 없어요. 다른 열차였다면 다시 선택해주세요.
+        {isWrongDirection
+          ? '반대 방향으로 가고 계신 것 같아요. 다음 역에서 내려 반대편에서 타세요.'
+          : '선택한 열차를 찾을 수 없어요. 다른 열차였다면 다시 선택해주세요.'}
       </Text>
     </ActionBanner>
   );

--- a/src/features/route/components/MisBoardingReselectModal.tsx
+++ b/src/features/route/components/MisBoardingReselectModal.tsx
@@ -12,6 +12,7 @@ import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 import { BoardingTrainList } from '../../alarm/components/BoardingTrainList';
 import type { ArrivalInfo } from '../../../shared/types/arrival';
 import type { LineNumber } from '../../../shared/types/station';
+import type { MisBoardingBannerReason } from './MisBoardingBanner';
 
 interface Props {
   visible: boolean;
@@ -28,10 +29,12 @@ interface Props {
    * 호출자가 resolveNextAdjacentStationName으로 도출해 전달. null/미전달이면 종착만 노출.
    */
   nextStationLabel?: string | null;
+  /** 모달을 띄운 원인(#2455, Phase B). 미전달 시 기존 'absent' copy 유지(하위호환). */
+  reason?: MisBoardingBannerReason;
 }
 
 /**
- * 잘못 탑승 감지 시 노출되는 재선택 모달 (#603).
+ * 잘못 탑승 감지 시 노출되는 재선택 모달 (#603, #2455 반대 방향 탑승 확장).
  *
  * BoardingTrainList를 재사용해 현재역 도착 list를 다시 노출. 사용자가 train 탭 →
  * onSelect 콜백 → caller가 createLockFromTrain 호출 + 모달 close 처리.
@@ -44,9 +47,11 @@ export function MisBoardingReselectModal({
   onSelect,
   onClose,
   nextStationLabel = null,
+  reason = 'absent',
 }: Props) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const headerTitle = reason === 'wrong-direction' ? '반대 방향 — 열차 재선택' : '탑승 열차 재선택';
 
   return (
     <Modal
@@ -64,7 +69,7 @@ export function MisBoardingReselectModal({
           ]}
         >
           <View style={[styles.header, { borderBottomColor: colors.hair }]}>
-            <Text style={[typography.label, { color: colors.warn }]}>탑승 열차 재선택</Text>
+            <Text style={[typography.label, { color: colors.warn }]}>{headerTitle}</Text>
             <Pressable
               onPress={onClose}
               testID="mis-boarding-reselect-close"

--- a/src/features/route/components/__tests__/MisBoardingBanner.test.tsx
+++ b/src/features/route/components/__tests__/MisBoardingBanner.test.tsx
@@ -35,4 +35,26 @@ describe('MisBoardingBanner', () => {
     expect(action.props.accessibilityLabel).toBe('탑승 열차 재선택');
     expect(action.props.accessibilityHint).toBe('탑승 열차 선택 화면을 다시 엽니다');
   });
+
+  // 반대 방향 탑승 감지 (#2455, Phase B) — 기존 absent copy와 구분되는 별도 라벨/본문.
+  it('reason="wrong-direction" → 반대 방향 경고 copy 렌더', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <MisBoardingBanner onReselect={() => {}} reason="wrong-direction" />,
+    );
+    expect(getByTestId('mis-boarding-banner')).toBeTruthy();
+    expect(getByText('반대 방향으로 가고 있어요')).toBeTruthy();
+    expect(
+      getByText('반대 방향으로 가고 계신 것 같아요. 다음 역에서 내려 반대편에서 타세요.'),
+    ).toBeTruthy();
+  });
+
+  it('reason="wrong-direction" → a11y 라벨도 반대 방향 전용 copy', () => {
+    const { getByTestId } = renderWithTheme(
+      <MisBoardingBanner onReselect={() => {}} reason="wrong-direction" />,
+    );
+    const banner = getByTestId('mis-boarding-banner');
+    expect(banner.props.accessibilityLabel).toBe(
+      '반대 방향으로 가고 계신 것 같아요. 다시 선택하세요.',
+    );
+  });
 });

--- a/src/features/route/components/__tests__/MisBoardingReselectModal.test.tsx
+++ b/src/features/route/components/__tests__/MisBoardingReselectModal.test.tsx
@@ -95,4 +95,20 @@ describe('MisBoardingReselectModal', () => {
     );
     expect(getByTestId('boarding-train-meta-C').props.children).toBe('사가정방면');
   });
+
+  // 반대 방향 탑승 감지 (#2455, Phase B) — absent 케이스와 구분되는 헤더 copy.
+  it('reason="wrong-direction" → 헤더가 반대 방향 전용 copy로 렌더', () => {
+    const { getByText, queryByText } = renderWithTheme(
+      <MisBoardingReselectModal
+        visible
+        arrivals={[makeTrain()]}
+        line="2"
+        onSelect={() => {}}
+        onClose={() => {}}
+        reason="wrong-direction"
+      />,
+    );
+    expect(getByText('반대 방향 — 열차 재선택')).toBeTruthy();
+    expect(queryByText('탑승 열차 재선택')).toBeNull();
+  });
 });

--- a/src/features/route/hooks/__tests__/useMisBoardingDetector.test.tsx
+++ b/src/features/route/hooks/__tests__/useMisBoardingDetector.test.tsx
@@ -6,6 +6,9 @@ import {
 } from '../useMisBoardingDetector';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
+import type { Route } from '../../../../shared/utils/stationRoute';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
 
 const baseLock: BoardingLock = {
   destinationId: 'd',
@@ -216,5 +219,191 @@ describe('useMisBoardingDetector', () => {
       MIS_BOARDING_MISS_THRESHOLD,
     );
     expect(result.current.detected).toBe(true);
+  });
+});
+
+// 반대 방향 탑승 감지 (#2455, Phase B). route/destinationName 전달 시에만 활성화되므로
+// 실제 stations.json 데이터(뚝섬→신당, 2호선)로 direction 판정을 재현한다.
+describe('useMisBoardingDetector — wrongDirectionDetected (#2455)', () => {
+  const ddukseom = findStationByNameAndLine(canonicalStationName('뚝섬', '2'), '2')!;
+  const sindangName = canonicalStationName('신당', '2');
+  const directRoute: Route = { type: 'direct', stops: 4, line: '2', travelSeconds: 240 };
+  const directionLock: BoardingLock = {
+    destinationId: 'd',
+    trainCode: 'T-LOCK',
+    boardingStationId: ddukseom.id,
+    boardingLine: '2',
+    boardedAt: 1_000_000,
+    expectedDurationMs: 1_800_000,
+  };
+  const afterDirectionGraceNow = () => directionLock.boardedAt + MIS_BOARDING_GRACE_MS + 1;
+
+  function positionsAt(statnNm: string): LinePositions {
+    return { line: '2', trains: [{ ...train('T-LOCK'), statnNm }] };
+  }
+
+  const wrongDirectionPositions = positionsAt('성수');
+  const correctDirectionPositions = positionsAt('한양대');
+
+  function mountDirection(initial: Partial<Props> = {}): RenderHookResult<Result, Props> {
+    return renderHook((props: Props) => useMisBoardingDetector(props), {
+      initialProps: {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+        ...initial,
+      },
+    });
+  }
+
+  it('route/destinationName 미전달 시 wrong-direction 관측이어도 wrongDirectionDetected 항상 false (기존 absent 동작 불변)', () => {
+    const { result, rerender } = renderHook((props: Props) => useMisBoardingDetector(props), {
+      initialProps: {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        now: afterDirectionGraceNow,
+      },
+    });
+    rerenderTimes(
+      rerender,
+      { lock: directionLock, positions: wrongDirectionPositions, now: afterDirectionGraceNow },
+      MIS_BOARDING_MISS_THRESHOLD + 5,
+    );
+    expect(result.current.wrongDirectionDetected).toBe(false);
+    // route 없이는 detectMisBoarding이 항상 'present'(trainNo 매칭됨) → absent 카운터도 안 오른다.
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('grace 이후 wrong-direction threshold회 누적되면 wrongDirectionDetected=true', () => {
+    const { result, rerender } = mountDirection();
+    rerenderTimes(
+      rerender,
+      {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
+    );
+    expect(result.current.wrongDirectionDetected).toBe(true);
+    // wrong-direction과 absent(=detected)는 배타적 — 동시에 true가 될 수 없다.
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('grace 내 wrong-direction은 카운터 미증가', () => {
+    const inGraceNow = () => directionLock.boardedAt + 100;
+    const { result, rerender } = mountDirection({ now: inGraceNow });
+    rerenderTimes(
+      rerender,
+      {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: inGraceNow,
+      },
+      MIS_BOARDING_MISS_THRESHOLD + 5,
+    );
+    expect(result.current.wrongDirectionDetected).toBe(false);
+  });
+
+  it('정방향(한양대) 관측이 들어오면 wrongDirectionDetected reset', () => {
+    const { result, rerender } = mountDirection();
+    rerenderTimes(
+      rerender,
+      {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
+    );
+    expect(result.current.wrongDirectionDetected).toBe(true);
+
+    act(() =>
+      rerender({
+        lock: directionLock,
+        positions: correctDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      }),
+    );
+    expect(result.current.wrongDirectionDetected).toBe(false);
+  });
+
+  it('absent(다른 trainCode)가 들어오면 wrongDirectionDetected reset되고 detected 카운터가 누적된다', () => {
+    const { result, rerender } = mountDirection();
+    rerenderTimes(
+      rerender,
+      {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
+    );
+    expect(result.current.wrongDirectionDetected).toBe(true);
+
+    const absentDirectionPositions: LinePositions = { line: '2', trains: [train('T-OTHER')] };
+    act(() =>
+      rerender({
+        lock: directionLock,
+        positions: absentDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      }),
+    );
+    expect(result.current.wrongDirectionDetected).toBe(false);
+    expect(result.current.detected).toBe(false); // 1회차라 threshold 미도달
+
+    rerenderTimes(
+      rerender,
+      {
+        lock: directionLock,
+        positions: absentDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+  });
+
+  it('lock → null이면 wrongDirectionDetected도 reset', () => {
+    const { result, rerender } = mountDirection();
+    rerenderTimes(
+      rerender,
+      {
+        lock: directionLock,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      },
+      MIS_BOARDING_MISS_THRESHOLD - 1,
+    );
+    expect(result.current.wrongDirectionDetected).toBe(true);
+
+    act(() =>
+      rerender({
+        lock: null,
+        positions: wrongDirectionPositions,
+        route: directRoute,
+        destinationName: sindangName,
+        now: afterDirectionGraceNow,
+      }),
+    );
+    expect(result.current.wrongDirectionDetected).toBe(false);
   });
 });

--- a/src/features/route/hooks/useMisBoardingDetector.ts
+++ b/src/features/route/hooks/useMisBoardingDetector.ts
@@ -1,6 +1,7 @@
 import { type MutableRefObject, useEffect, useRef, useState } from 'react';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LinePositions } from '../../../shared/types/position';
+import type { Route } from '../../../shared/utils/stationRoute';
 import { detectMisBoarding } from '../utils/detectMisBoarding';
 
 /**
@@ -24,8 +25,15 @@ export const MIS_BOARDING_MISS_THRESHOLD = 3;
 
 export interface UseMisBoardingDetectorInputs {
   lock: BoardingLock | null;
-  /** lock.boardingLine의 위치 데이터. lock이 없거나 호출자가 polling 안 하면 null. */
+  /** lock.boardingLine의 위치 데이터. lock이 없거나 호출자가 폴링 안 하면 null. */
   positions: LinePositions | null;
+  /**
+   * 현재 leg의 route. 반대 방향 탑승 감지(#2455, Phase B)용 — 미전달 시 detectMisBoarding이
+   * 방향 검사를 skip해 wrongDirectionDetected는 항상 false로 남는다(기존 absent 감지만 동작).
+   */
+  route?: Route;
+  /** trip(또는 현재 leg) 목적지명. route와 함께 있어야 방향 검사가 활성화된다. */
+  destinationName?: string | null;
   /** 테스트용 주입. 미전달 시 Date.now(). */
   now?: () => number;
 }
@@ -33,61 +41,96 @@ export interface UseMisBoardingDetectorInputs {
 export interface UseMisBoardingDetectorResult {
   /** absent threshold 도달 시 true. lock 해제/교체 시 false로 reset. */
   detected: boolean;
+  /**
+   * wrong-direction observation이 threshold 도달 시 true (#2455, Phase B). detected와 서로
+   * 배타적 — 같은 lockKey에서 absent와 wrong-direction 카운터는 독립적으로 관리되고, 다른
+   * observation이 들어오면(present 또는 서로 다른 observation) 각자의 카운터만 reset된다.
+   */
+  wrongDirectionDetected: boolean;
 }
 
 /**
  * BoardingLock에 명시된 trainCode가 실시간 위치 API에서 사라졌는지 감지 (#584 PR D3).
  *
- * - lock 생성 직후 grace 동안은 absent여도 무시 (positionApi 캐시/주기와 정합).
+ * - lock 생성 직후 grace 동안은 absent/wrong-direction이어도 무시 (positionApi 캐시/주기와 정합).
  * - absent 관측이 threshold 회 연속이면 detected=true 한 번 발생.
- * - present가 한 번이라도 들어오면 카운터 reset, detected=false.
- * - lock의 trainCode 또는 boardedAt이 바뀌면 (=새 lock) 카운터+detected reset.
+ * - wrong-direction 관측이 threshold 회 연속이면 wrongDirectionDetected=true 한 번 발생
+ *   (#2455, Phase B — route/destinationName 미전달이면 detectMisBoarding이 항상 'present'/'absent'
+ *   만 내므로 이 카운터는 계속 0에 머문다. 기존 absent 경로에 영향 없음).
+ * - present가 한 번이라도 들어오면 두 카운터 모두 reset, 두 detected 모두 false.
+ * - absent와 wrong-direction은 서로 다른 observation이므로 한쪽이 관측되면 다른 쪽 카운터도
+ *   reset된다 — 두 상태가 동시에 true가 될 수 없다.
+ * - lock의 trainCode 또는 boardedAt이 바뀌면 (=새 lock) 카운터+detected 전부 reset.
  *
- * detected 상태는 ref + state 이중관리 — ref는 effect 내 분기에 쓰고, state는 외부 노출용.
+ * detected 상태들은 ref + state 이중관리 — ref는 effect 내 분기에 쓰고, state는 외부 노출용.
  * detected를 effect deps에 두면 setDetected 호출 시 stale closure 경유로 카운터가 의도와 다르게
  * 흐를 수 있어 ref로 분리한다.
  */
 export function useMisBoardingDetector({
   lock,
   positions,
+  route = null,
+  destinationName = null,
   now = Date.now,
 }: UseMisBoardingDetectorInputs): UseMisBoardingDetectorResult {
   const [detected, setDetectedState] = useState(false);
   const detectedRef = useRef(false);
   const consecutiveAbsentRef = useRef(0);
+  const [wrongDirectionDetected, setWrongDirectionDetectedState] = useState(false);
+  const wrongDirectionDetectedRef = useRef(false);
+  const consecutiveWrongDirectionRef = useRef(0);
   const trackedLockKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     const updateDetected = (next: boolean): void =>
       setDetectedSynced(detectedRef, setDetectedState, next);
+    const updateWrongDirectionDetected = (next: boolean): void =>
+      setDetectedSynced(wrongDirectionDetectedRef, setWrongDirectionDetectedState, next);
     // 새 lock(=trainCode + boardedAt 조합 변화) → 카운터/감지 reset.
     // 같은 trainCode 재선택 시에도 boardedAt이 갱신되어 grace가 다시 적용된다.
     const lockKey = lock ? `${lock.trainCode}:${lock.boardedAt}` : null;
     if (trackedLockKeyRef.current !== lockKey) {
       trackedLockKeyRef.current = lockKey;
       consecutiveAbsentRef.current = 0;
+      consecutiveWrongDirectionRef.current = 0;
       updateDetected(false);
+      updateWrongDirectionDetected(false);
     }
 
     if (!lock || !positions) return;
 
-    const observation = detectMisBoarding(lock, positions);
+    const observation = detectMisBoarding(lock, positions, route, destinationName);
     if (observation === 'no-signal') return;
 
     if (observation === 'present') {
       consecutiveAbsentRef.current = 0;
+      consecutiveWrongDirectionRef.current = 0;
       updateDetected(false);
+      updateWrongDirectionDetected(false);
       return;
     }
 
-    // absent. grace 통과 후에만 카운터 증가.
+    // absent/wrong-direction 둘 다 grace 통과 후에만 카운터 증가.
     if (now() - lock.boardedAt < MIS_BOARDING_GRACE_MS) return;
 
+    if (observation === 'wrong-direction') {
+      consecutiveAbsentRef.current = 0;
+      updateDetected(false);
+      consecutiveWrongDirectionRef.current += 1;
+      if (consecutiveWrongDirectionRef.current >= MIS_BOARDING_MISS_THRESHOLD) {
+        updateWrongDirectionDetected(true);
+      }
+      return;
+    }
+
+    // absent.
+    consecutiveWrongDirectionRef.current = 0;
+    updateWrongDirectionDetected(false);
     consecutiveAbsentRef.current += 1;
     if (consecutiveAbsentRef.current >= MIS_BOARDING_MISS_THRESHOLD) {
       updateDetected(true);
     }
-  }, [lock, positions, now]);
+  }, [lock, positions, route, destinationName, now]);
 
-  return { detected };
+  return { detected, wrongDirectionDetected };
 }

--- a/src/features/route/utils/__tests__/detectMisBoarding.test.ts
+++ b/src/features/route/utils/__tests__/detectMisBoarding.test.ts
@@ -1,7 +1,10 @@
 import { detectMisBoarding } from '../detectMisBoarding';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
+import type { Route } from '../../../../shared/utils/stationRoute';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
 import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
 
 const lock: BoardingLock = {
   destinationId: 'd',
@@ -73,5 +76,234 @@ describe('detectMisBoarding', () => {
       detectMisBoarding(pendingLock, positions({ trains: [train({ trainNo: 'T-OTHER' })] })),
     ).toBe('no-signal');
     expect(detectMisBoarding(pendingLock, positions({ trains: [] }))).toBe('no-signal');
+  });
+});
+
+// 반대 방향 탑승 감지 (Phase B, foreground, #2455). 실제 stations.json 좌표/id를 사용해
+// resolveTripDirection 기반 방향 판정을 검증한다 — 가짜 id('s'/'d')로는 방향을 산출할 수 없다.
+describe('detectMisBoarding — wrong-direction (#2455)', () => {
+  const ddukseom = findStationByNameAndLine(canonicalStationName('뚝섬', '2'), '2')!;
+  const sindangName = canonicalStationName('신당', '2');
+  const directRoute: Route = { type: 'direct', stops: 4, line: '2', travelSeconds: 240 };
+  const wrongDirectionLock: BoardingLock = {
+    destinationId: 'd',
+    trainCode: 'T-LOCK',
+    boardingStationId: ddukseom.id,
+    boardingLine: '2',
+    boardedAt: 1_000_000,
+    expectedDurationMs: 1_800_000,
+  };
+
+  // reproduce-first: 뚝섬(2호선)에서 신당 방향(내선/한양대 방면, 'up')으로 가야 하는데
+  // 성수 방면(외선, 'down') 열차에 탑승 — 기존 trainNo 매칭만으로는 'present'로 오판했다.
+  it('뚝섬→신당 route인데 성수(외선) 방면에서 관측 → wrong-direction', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '성수' })] }),
+      directRoute,
+      sindangName,
+    );
+    expect(result).toBe('wrong-direction');
+  });
+
+  it('건대입구(더 먼 외선)에서 관측해도 wrong-direction', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '건대입구' })] }),
+      directRoute,
+      sindangName,
+    );
+    expect(result).toBe('wrong-direction');
+  });
+
+  it('한양대(내선, 정방향)에서 관측 → present (오탐 아님)', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '한양대' })] }),
+      directRoute,
+      sindangName,
+    );
+    expect(result).toBe('present');
+  });
+
+  it('아직 탑승역(뚝섬)에 머무는 중 → present (이동 전, 판정 불가)', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: ddukseom.name })] }),
+      directRoute,
+      sindangName,
+    );
+    expect(result).toBe('present');
+  });
+
+  it('route 미전달 → 방향 검사 skip, present (기존 2-arg 호출 하위호환)', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '성수' })] }),
+    );
+    expect(result).toBe('present');
+  });
+
+  it('destinationName 미전달 → 방향 검사 skip, present', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '성수' })] }),
+      directRoute,
+      null,
+    );
+    expect(result).toBe('present');
+  });
+
+  it('lock.boardingStationId가 stations.json에 없으면(getStationById 실패) present (판정 불가)', () => {
+    const unknownOriginLock: BoardingLock = { ...wrongDirectionLock, boardingStationId: 'unknown-id' };
+    const result = detectMisBoarding(
+      unknownOriginLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '성수' })] }),
+      directRoute,
+      sindangName,
+    );
+    expect(result).toBe('present');
+  });
+
+  it('destinationName이 boardingLine 위에 없으면(resolveTripDirection null) present', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '성수' })] }),
+      directRoute,
+      '존재하지않는역',
+    );
+    expect(result).toBe('present');
+  });
+
+  it('관측된 열차 statnNm이 boardingLine 위에 없으면(observedStation lookup 실패) present', () => {
+    const result = detectMisBoarding(
+      wrongDirectionLock,
+      positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '존재하지않는역' })] }),
+      directRoute,
+      sindangName,
+    );
+    expect(result).toBe('present');
+  });
+
+  // resolveTripDirection은 route.line(또는 leg의 fromLine)만 보고 방향을 산출하는 반면
+  // directionOnLine은 lock.boardingLine으로 별도 조회한다 — 데이터 불일치(예: lock.boardingLine이
+  // route가 실제로 매칭한 leg의 line과 다름)로 expectedDirection은 resolve되는데
+  // directionOnLine의 fromStationId 조회만 실패하는 경우를 재현해 line 69(actualDirection null)
+  // 분기를 커버한다. currentStation(뚝섬, 2호선)이 route.fromLine('2')과 일치해 첫 leg가 선택되고
+  // expectedDirection은 정상 resolve되지만, lock.boardingLine을 의도적으로 '7'로 불일치시켜
+  // directionOnLine('7', 뚝섬.id, ...)의 fromIdx 조회가 실패한다.
+  it('expectedDirection은 resolve되지만 directionOnLine fromId 조회 실패 → present', () => {
+    const transferRouteForMismatch: Route = {
+      type: 'transfer',
+      transferName: canonicalStationName('건대입구', '7'),
+      fromLine: '2',
+      toLine: '7',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 1,
+      secondsToTransfer: 120,
+      secondsFromTransfer: 60,
+    };
+    const mismatchedLock: BoardingLock = { ...wrongDirectionLock, boardingLine: '7' };
+    const result = detectMisBoarding(
+      mismatchedLock,
+      { line: '7', trains: [train({ trainNo: 'T-LOCK', statnNm: '청담' })] },
+      transferRouteForMismatch,
+      sindangName,
+    );
+    expect(result).toBe('present');
+  });
+
+  // 환승 leg 경계 — lock.boardingStationId는 PR E 정책상 leg마다 새 lock으로 교체되어
+  // 이미 "현재 leg" 시작역이다. 전체 trip origin(2호선)이 아니라 환승 후 leg(7호선) 기준으로
+  // 판정되어야 한다.
+  describe('환승 leg 경계 (whole-trip origin이 아닌 현재 leg 기준)', () => {
+    const line7 = '7' as const;
+    const transferOrigin = findStationByNameAndLine(canonicalStationName('건대입구', line7), line7)!;
+    const transferRoute: Route = {
+      type: 'transfer',
+      transferName: canonicalStationName('건대입구', line7),
+      fromLine: '2',
+      toLine: line7,
+      stopsToTransfer: 2,
+      stopsFromTransfer: 1,
+      secondsToTransfer: 120,
+      secondsFromTransfer: 60,
+    };
+    const destName = canonicalStationName('자양(뚝섬한강공원)', line7);
+    const transferLegLock: BoardingLock = {
+      destinationId: 'd',
+      trainCode: 'T-LOCK',
+      boardingStationId: transferOrigin.id,
+      boardingLine: line7,
+      boardedAt: 1_000_000,
+      expectedDurationMs: 1_800_000,
+    };
+
+    it('환승 후 leg 정방향(자양 쪽)에서 관측 → present', () => {
+      const result = detectMisBoarding(
+        transferLegLock,
+        {
+          line: line7,
+          trains: [train({ trainNo: 'T-LOCK', statnNm: canonicalStationName('청담', line7) })],
+        },
+        transferRoute,
+        destName,
+      );
+      expect(result).toBe('present');
+    });
+
+    it('환승 후 leg 반대 방향(어린이대공원 쪽)에서 관측 → wrong-direction', () => {
+      const result = detectMisBoarding(
+        transferLegLock,
+        {
+          line: line7,
+          trains: [
+            train({ trainNo: 'T-LOCK', statnNm: canonicalStationName('어린이대공원', line7) }),
+          ],
+        },
+        transferRoute,
+        destName,
+      );
+      expect(result).toBe('wrong-direction');
+    });
+  });
+
+  // 2호선 순환선 seam(시청↔충정로) — resolveTripDirection의 wraparound 판정이 반대편
+  // 알고리즘(inferLoopDirection)과 어긋나는 경계 지점(#2455 설계 노트). 기대/실제 방향 모두
+  // resolveTripDirection 자신으로 계산해 self-consistent하게 만들었으므로, 이 seam 근방에서는
+  // 최악의 경우 미탐(false negative)만 발생하고 오탐(false positive)은 절대 나지 않아야 한다 —
+  // 이 안전 속성을 회귀 테스트로 고정한다.
+  describe('2호선 순환선 seam(시청↔충정로) — 오탐 금지 회귀 고정', () => {
+    const chungjeongno = findStationByNameAndLine(canonicalStationName('충정로', '2'), '2')!;
+    const seamRoute: Route = { type: 'direct', stops: 1, line: '2', travelSeconds: 60 };
+    const seamLock: BoardingLock = {
+      destinationId: 'd',
+      trainCode: 'T-LOCK',
+      boardingStationId: chungjeongno.id,
+      boardingLine: '2',
+      boardedAt: 1_000_000,
+      expectedDurationMs: 1_800_000,
+    };
+    const sicheongName = canonicalStationName('시청', '2');
+
+    it('시청 방향으로 wrap-forward(을지로입구까지 진행) 관측 → 오탐 없음(present)', () => {
+      const result = detectMisBoarding(
+        seamLock,
+        positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '을지로입구' })] }),
+        seamRoute,
+        sicheongName,
+      );
+      expect(result).not.toBe('wrong-direction');
+    });
+
+    it('시청 반대편(아현 방향, wrap 없는 backward) 관측 → 오탐 없음(present)', () => {
+      const result = detectMisBoarding(
+        seamLock,
+        positions({ trains: [train({ trainNo: 'T-LOCK', statnNm: '아현' })] }),
+        seamRoute,
+        sicheongName,
+      );
+      expect(result).not.toBe('wrong-direction');
+    });
   });
 });

--- a/src/features/route/utils/__tests__/directionOnLine.test.ts
+++ b/src/features/route/utils/__tests__/directionOnLine.test.ts
@@ -1,0 +1,53 @@
+import { directionOnLine } from '../directionOnLine';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
+
+describe('directionOnLine (#2455)', () => {
+  it('단조 노선(3호선) 정방향 — id 증가 → down', () => {
+    const daehwa = findStationByNameAndLine(canonicalStationName('대화', '3'), '3')!;
+    const madu = findStationByNameAndLine(canonicalStationName('마두', '3'), '3')!;
+    expect(directionOnLine('3', daehwa.id, madu.id)).toBe('down');
+  });
+
+  it('단조 노선(3호선) 역방향 — id 감소 → up', () => {
+    const daehwa = findStationByNameAndLine(canonicalStationName('대화', '3'), '3')!;
+    const madu = findStationByNameAndLine(canonicalStationName('마두', '3'), '3')!;
+    expect(directionOnLine('3', madu.id, daehwa.id)).toBe('up');
+  });
+
+  it('2호선 순환선 비-seam 구간 — 뚝섬→성수(짧은 forward) → down', () => {
+    const ddukseom = findStationByNameAndLine(canonicalStationName('뚝섬', '2'), '2')!;
+    const seongsu = findStationByNameAndLine(canonicalStationName('성수', '2'), '2')!;
+    expect(directionOnLine('2', ddukseom.id, seongsu.id)).toBe('down');
+  });
+
+  it('2호선 순환선 비-seam 구간 — 성수→뚝섬(짧은 backward) → up', () => {
+    const ddukseom = findStationByNameAndLine(canonicalStationName('뚝섬', '2'), '2')!;
+    const seongsu = findStationByNameAndLine(canonicalStationName('성수', '2'), '2')!;
+    expect(directionOnLine('2', seongsu.id, ddukseom.id)).toBe('up');
+  });
+
+  it('같은 station이면 null', () => {
+    const ddukseom = findStationByNameAndLine(canonicalStationName('뚝섬', '2'), '2')!;
+    expect(directionOnLine('2', ddukseom.id, ddukseom.id)).toBeNull();
+  });
+
+  it('fromStationId가 해당 노선에 없으면 null', () => {
+    const seongsu = findStationByNameAndLine(canonicalStationName('성수', '2'), '2')!;
+    expect(directionOnLine('2', 'unknown-id', seongsu.id)).toBeNull();
+  });
+
+  it('toStationId가 해당 노선에 없으면 null', () => {
+    const ddukseom = findStationByNameAndLine(canonicalStationName('뚝섬', '2'), '2')!;
+    expect(directionOnLine('2', ddukseom.id, 'unknown-id')).toBeNull();
+  });
+
+  // 2호선 순환선 seam(시청↔충정로) — resolveTripDirection이 내부적으로 쓰는 것과 동일한
+  // shortestLinePathIndices 알고리즘이므로, resolveTripDirection(route, '시청', 충정로.id)와
+  // 정확히 같은 값을 내야 한다(#2455 설계 노트에서 검증한 값 그대로 고정).
+  it('2호선 seam(충정로→시청, wrap) — resolveTripDirection과 동일한 값으로 고정', () => {
+    const chungjeongno = findStationByNameAndLine(canonicalStationName('충정로', '2'), '2')!;
+    const sicheong = findStationByNameAndLine(canonicalStationName('시청', '2'), '2')!;
+    expect(directionOnLine('2', chungjeongno.id, sicheong.id)).toBe('up');
+  });
+});

--- a/src/features/route/utils/detectMisBoarding.ts
+++ b/src/features/route/utils/detectMisBoarding.ts
@@ -1,6 +1,10 @@
 import type { BoardingLock } from '../../../shared/types/boardingLock';
-import type { LinePositions } from '../../../shared/types/position';
+import type { LinePositions, TrainPosition } from '../../../shared/types/position';
+import type { Route } from '../../../shared/utils/stationRoute';
+import { getStationById, findStationByNameAndLine } from '../../../shared/utils/stationRoute';
 import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
+import { resolveTripDirection } from './tripDirection';
+import { directionOnLine } from './directionOnLine';
 
 /**
  * BoardingLock의 trainCode가 lock.boardingLine의 위치 데이터에서 관측되는지 검사 (#584 PR D3).
@@ -9,21 +13,76 @@ import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
  * - positions.line이 lock.boardingLine과 다름 → 'no-signal' (관측 불가)
  * - lock.trainCode가 #2407 pending sentinel(train 미확정) → 'no-signal' (오탐 금지 — pending을
  *   실 trainCode처럼 매칭에 넣으면 항상 'absent'로 잘못 확정된다)
- * - positions에 trainNo == lock.trainCode 존재 → 'present'
+ * - positions에 trainNo == lock.trainCode 존재 → 'present' (단, 아래 방향 검사에서 반대방향이면 'wrong-direction')
  * - positions는 있고 trainNo 부재 → 'absent'
  *
  * mock 데이터(isMock=true)는 'no-signal' — 실측이 아니므로 잘못 탑승 판단 근거가 될 수 없다.
+ *
+ * 잘못된 방향 tapping 감지 (Phase B, foreground). #584 mis-boarding subsystem 확장:
+ * lock.trainCode가 present여도 그 열차가 route와 반대 방향으로 진행 중이면(=반대편 승강장에서
+ * 잘못 탄 경우) trainCode 매칭만으로는 놓친다. route(현재 leg)와 destinationName이 주어지면
+ * 아래 로직으로 방향까지 확인한다:
+ *   - route/destinationName 미전달 → 방향 검사 skip (기존 동작, 항상 'present')
+ *   - 관측된 열차의 statnNm이 lock.boardingStationId(=현재 leg 시작역)와 같음 → 아직 출발 전,
+ *     이동 방향을 알 수 없어 'present' (indeterminate를 wrong으로 오판하지 않는다)
+ *   - resolveTripDirection(현재 leg의 기대 방향)과 실제 이동 방향 중 하나라도 null이면
+ *     'present' (판정 불가)
+ *   - 두 방향이 서로 다르면 'wrong-direction', 같으면 'present'
+ *
+ * 실제 이동 방향은 공유 primitive `directionOnLine`(station-id 두 개 → 방향, #2455)으로
+ * 계산한다. `resolveTravelDirection`/`inferLoopDirection`을 별도로 조합하지 않는 이유:
+ * 2호선 순환선 seam(시청↔충정로)에서 그 두 유틸의 wraparound 판정 알고리즘이 어긋나(#1922 step
+ * 비교 vs #1063 forward/backward 호 길이 비교) 정반대 라벨을 낼 수 있음을 직접 확인했다
+ * (리버스 엔지니어링, 두 유틸 자체는 미수정). `directionOnLine`은 `resolveTripDirection`이
+ * leg 선택 뒤 내부적으로 쓰는 것과 동일한 `shortestLinePathIndices` 알고리즘이라 기대/실제
+ * 양쪽이 이 알고리즘 하나로 self-consistent하다 — seam 부근에서는 최악의 경우 미탐
+ * (false negative)만 발생하고 오탐은 나지 않는다.
  */
-export type MisBoardingObservation = 'present' | 'absent' | 'no-signal';
+export type MisBoardingObservation = 'present' | 'absent' | 'no-signal' | 'wrong-direction';
+
+/**
+ * lock의 현재 leg 시작역 대비 관측된 열차의 실제 진행 방향이 route가 기대하는 방향과
+ * 반대인지 판정한다. 판정 불가(데이터 부족, 아직 출발 전 등)한 모든 경우는 false — 'present'로
+ * 남겨 오탐(false positive)을 차단한다.
+ */
+function isWrongDirection(
+  lock: BoardingLock,
+  observedTrain: TrainPosition,
+  route: Route,
+  destinationName: string | null,
+): boolean {
+  if (!route || !destinationName) return false;
+  const originStation = getStationById(lock.boardingStationId);
+  if (!originStation) return false;
+  // 아직 탑승역에 머물러 있으면(=1역도 이동 전) 방향 판정 불가 — 오탐 금지.
+  if (observedTrain.statnNm === originStation.name) return false;
+
+  const expectedDirection = resolveTripDirection(route, destinationName, lock.boardingStationId);
+  if (!expectedDirection) return false;
+
+  // positions는 statnNm(역명)만 준다 — Seoul API statnId는 stations.json id와 포맷이 달라
+  // 직접 비교 불가(useFusedNearestStation.ts의 동일 제약과 같은 이유). 역명으로 id를 역조회한다.
+  const observedStation = findStationByNameAndLine(observedTrain.statnNm, lock.boardingLine);
+  if (!observedStation) return false;
+
+  const actualDirection = directionOnLine(lock.boardingLine, lock.boardingStationId, observedStation.id);
+  if (!actualDirection) return false;
+
+  return actualDirection !== expectedDirection;
+}
 
 export function detectMisBoarding(
   lock: BoardingLock | null,
   positions: LinePositions | null,
+  route: Route = null,
+  destinationName: string | null = null,
 ): MisBoardingObservation {
   if (!lock || !positions) return 'no-signal';
   if (positions.isMock) return 'no-signal';
   if (positions.line !== lock.boardingLine) return 'no-signal';
   if (isPendingTrainCode(lock.trainCode)) return 'no-signal';
-  const found = positions.trains.some((t) => t.trainNo === lock.trainCode);
-  return found ? 'present' : 'absent';
+  const found = positions.trains.find((t) => t.trainNo === lock.trainCode);
+  if (!found) return 'absent';
+  if (isWrongDirection(lock, found, route, destinationName)) return 'wrong-direction';
+  return 'present';
 }

--- a/src/features/route/utils/directionOnLine.ts
+++ b/src/features/route/utils/directionOnLine.ts
@@ -1,0 +1,41 @@
+import type { LineNumber } from '../../../shared/types/station';
+import { getStationsOnLine } from '../../../shared/utils/stationRoute';
+import { shortestLinePathIndices } from '../../../shared/utils/lineLoopPath';
+
+/**
+ * 노선 위 진행 방향. 'up' = 내선/id 감소 방향, 'down' = 외선/id 증가 방향 —
+ * `resolveTripDirection`(tripDirection.ts)/`alarmDirection.ts`가 이미 쓰는 관례와 동일.
+ */
+export type LineDirection = 'up' | 'down';
+
+/**
+ * 같은 노선 위 두 station id 사이의 진행 방향을 산출하는 공유 primitive (#2455).
+ *
+ * `shortestLinePathIndices`(2호선 closed loop wraparound-aware 짧은 경로 산출, `lineLoopPath.ts`)
+ * 위에서 첫 step의 idx 증감으로 방향을 결정한다 — `resolveTripDirection`이 Route/leg 선택 뒤에
+ * 내부적으로 쓰는 것과 **동일한 알고리즘**을 Route 의존 없이 station id 두 개만으로 재사용할 수
+ * 있게 뽑아낸 것. `resolveTravelDirection`(단조 노선)/`inferLoopDirection`(forward-backward 호
+ * 길이 비교)을 조합하지 않는 이유: 2호선 순환선 seam(시청↔충정로)에서 그 두 유틸의 wraparound
+ * 판정이 서로 어긋나는 사례를 발견했다(#2455 설계 노트) — `shortestLinePathIndices` 기반 하나의
+ * 알고리즘만 쓰면 이 불일치가 원천적으로 없다.
+ *
+ * Route가 없는 호출자(예: R1c의 `arcStations: Station[]` 기반 estimator)도 station id만으로
+ * 쓸 수 있도록 의도적으로 Route-level이 아닌 station-id-level API로 설계했다.
+ *
+ * - 같은 station이거나(fromId === toId) 두 id 중 하나라도 해당 노선에 없으면 null (판정 불가).
+ */
+export function directionOnLine(
+  line: LineNumber,
+  fromStationId: string,
+  toStationId: string,
+): LineDirection | null {
+  const stations = getStationsOnLine(line);
+  const fromIdx = stations.findIndex((s) => s.id === fromStationId);
+  const toIdx = stations.findIndex((s) => s.id === toStationId);
+  if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return null;
+
+  const path = shortestLinePathIndices(stations, fromIdx, toIdx, line);
+  // shortestLinePathIndices invariant: fromIdx !== toIdx → path.length >= 2
+  const firstStepIdx = path[1];
+  return firstStepIdx > fromIdx ? 'down' : 'up';
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -84,7 +84,10 @@ import { CurrentStationConfirmModal } from '../features/nearest-station/componen
 import { ColdStartCandidatePicker } from '../features/nearest-station/components/ColdStartCandidatePicker';
 import { useColdStartCandidates } from '../features/nearest-station/hooks/useColdStartCandidates';
 import type { ColdStartCandidate } from '../features/nearest-station/hooks/useColdStartCandidates';
-import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
+import {
+  MisBoardingBanner,
+  type MisBoardingBannerReason,
+} from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
 import { ShareTripButton } from '../features/route/components/ShareTripButton';
 import { isDegenerateDestination } from '../features/route/utils/isDegenerateDestination';
@@ -897,22 +900,39 @@ export default function HomeScreen() {
   // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.
   // lock 없으면 line=null로 호출되어 polling이 자동 정지된다.
   const { positions: lockLinePositions } = useTrainPositions(boardingLock?.boardingLine ?? null);
-  const { detected: misBoardingDetected } = useMisBoardingDetector({
+  // #2455 (Phase B, foreground) — 반대 방향 탑승 감지. route/destination이 있어야 방향 검사가
+  // 활성화된다(둘 다 없으면 detectMisBoarding이 기존 absent 판정만 수행 — 하위호환).
+  const { detected: misBoardingDetected, wrongDirectionDetected } = useMisBoardingDetector({
     lock: boardingLock,
     positions: lockLinePositions,
+    route,
+    destinationName: destination?.name ?? null,
   });
   // #603: detected false→true 전환 시점에 토스트 + 모달 1회 발사. true가 유지되어도 중복 발사 X.
   // banner는 그대로 노출되어 사용자가 닫은 뒤에도 잘못 탑승 상태를 알 수 있다.
+  // #2455 — reason으로 absent/wrong-direction copy를 분기. 두 감지는 훅 내부에서 서로 배타적으로
+  // reset되므로 rising edge 시점의 reason이 현재 노출 상태와 항상 일치한다.
+  const [misBoardingReason, setMisBoardingReason] = useState<MisBoardingBannerReason>('absent');
   const [misBoardingToastVisible, setMisBoardingToastVisible] = useState(false);
   const [misBoardingModalVisible, setMisBoardingModalVisible] = useState(false);
   const prevMisBoardingRef = useRef(false);
   useEffect(() => {
     if (misBoardingDetected && !prevMisBoardingRef.current) {
+      setMisBoardingReason('absent');
       setMisBoardingToastVisible(true);
       setMisBoardingModalVisible(true);
     }
     prevMisBoardingRef.current = misBoardingDetected;
   }, [misBoardingDetected]);
+  const prevWrongDirectionRef = useRef(false);
+  useEffect(() => {
+    if (wrongDirectionDetected && !prevWrongDirectionRef.current) {
+      setMisBoardingReason('wrong-direction');
+      setMisBoardingToastVisible(true);
+      setMisBoardingModalVisible(true);
+    }
+    prevWrongDirectionRef.current = wrongDirectionDetected;
+  }, [wrongDirectionDetected]);
   const handleMisBoardingReselect = useCallback(
     (train: ArrivalInfo) => {
       createLockFromTrain(train);
@@ -1291,7 +1311,11 @@ export default function HomeScreen() {
       )}
       <Toast
         visible={misBoardingToastVisible}
-        message={t('home.misBoardingToast')}
+        message={t(
+          misBoardingReason === 'wrong-direction'
+            ? 'home.misBoardingWrongDirectionToast'
+            : 'home.misBoardingToast',
+        )}
         onDismiss={handleMisBoardingToastDismiss}
         accent={colors.warn}
         testID="mis-boarding-toast"
@@ -1313,6 +1337,7 @@ export default function HomeScreen() {
         onSelect={handleMisBoardingReselect}
         onClose={handleMisBoardingModalClose}
         nextStationLabel={nextStationName}
+        reason={misBoardingReason}
       />
       {/* #924 D1 — 환승 자동 detect 다중 후보 모달. F4 1탭 모달 인프라(#914) 재사용. */}
       <CurrentStationConfirmModal
@@ -1768,8 +1793,11 @@ export default function HomeScreen() {
                   {/* #625 — MisBoarding 배너는 route 컨텍스트 안에서 노출.
                        외곽 {destination && ...} 가드 안쪽이라 destination 재가드 불필요.
                        #758: BoardingLockBanner는 hop slot 안 BoardingLockHopCard로 통합 이전 — 별도 노출 제거. */}
-                  {boardingLock && misBoardingDetected && (
-                    <MisBoardingBanner onReselect={releaseBoardingLock} />
+                  {/* #2455 — wrongDirectionDetected 추가. 훅 내부에서 두 감지가 서로 배타적으로
+                       reset되므로 동시에 true가 될 수 없다 — misBoardingReason이 현재 노출 상태와
+                       항상 일치. */}
+                  {boardingLock && (misBoardingDetected || wrongDirectionDetected) && (
+                    <MisBoardingBanner onReselect={releaseBoardingLock} reason={misBoardingReason} />
                   )}
                   {/* #649 — BoardingTrainList 두 인스턴스(현재역/환승)는 EditorialTimeline의
                        renderHopSlot으로 이동: timeline hop 사이에 inline compact 표기.

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -69,6 +69,7 @@
     "consensusEstimatedBadge": "Estimated",
     "consensusManualSelectHint": "Select manually",
     "misBoardingToast": "Can't find your train. Please reselect.",
+    "misBoardingWrongDirectionToast": "Looks like you're heading the wrong way. Get off at the next station and switch to the other platform.",
     "autoDisembarkToast": {
       "message": "Arrived at {{name}} — destination cleared",
       "undo": "Undo"
@@ -369,6 +370,7 @@
       "assignSlotHint": "Saves the next selected station to this slot",
       "favoriteChipHint": "Tap to set this station as destination",
       "misBoardingBannerLabel": "Cannot identify your train. Please reselect.",
+      "misBoardingWrongDirectionBannerLabel": "You seem to be heading the wrong way. Please reselect.",
       "misBoardingReselectLabel": "Reselect boarding train",
       "misBoardingReselectHint": "Reopens the boarding train picker"
     }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -69,6 +69,7 @@
     "consensusEstimatedBadge": "推定",
     "consensusManualSelectHint": "直接選択",
     "misBoardingToast": "乗車中の列車が見つかりません。もう一度選択してください。",
+    "misBoardingWrongDirectionToast": "反対方向へ進んでいるようです。次の駅で降りて反対側のホームに乗り換えてください。",
     "autoDisembarkToast": {
       "message": "{{name}}に到着し、目的地を解除しました",
       "undo": "元に戻す"
@@ -369,6 +370,7 @@
       "assignSlotHint": "次に選択する駅をこのスロットに保存します",
       "favoriteChipHint": "タップしてこの駅を目的地に設定",
       "misBoardingBannerLabel": "乗車中の列車を特定できません。再選択してください。",
+      "misBoardingWrongDirectionBannerLabel": "反対方向へ進んでいるようです。再選択してください。",
       "misBoardingReselectLabel": "乗車列車を再選択",
       "misBoardingReselectHint": "乗車列車選択画面を再度開きます"
     }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -69,6 +69,7 @@
     "consensusEstimatedBadge": "추정",
     "consensusManualSelectHint": "직접 선택",
     "misBoardingToast": "탑승 열차를 찾을 수 없어요. 다시 선택해주세요.",
+    "misBoardingWrongDirectionToast": "반대 방향으로 가고 계신 것 같아요. 다음 역에서 내려 반대편에서 타세요.",
     "autoDisembarkToast": {
       "message": "{{name}}에 도착해 목적지를 해제했어요",
       "undo": "되돌리기"
@@ -369,6 +370,7 @@
       "assignSlotHint": "다음에 선택할 역을 이 슬롯에 저장합니다",
       "favoriteChipHint": "탭하여 이 역을 목적지로 선택",
       "misBoardingBannerLabel": "탑승 열차를 확인할 수 없습니다. 다시 선택하세요.",
+      "misBoardingWrongDirectionBannerLabel": "반대 방향으로 가고 계신 것 같아요. 다시 선택하세요.",
       "misBoardingReselectLabel": "탑승 열차 재선택",
       "misBoardingReselectHint": "탑승 열차 선택 화면을 다시 엽니다"
     }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -69,6 +69,7 @@
     "consensusEstimatedBadge": "推测",
     "consensusManualSelectHint": "直接选择",
     "misBoardingToast": "找不到乘坐的列车,请重新选择。",
+    "misBoardingWrongDirectionToast": "您好像坐反方向了。请在下一站下车，到对面站台换乘。",
     "autoDisembarkToast": {
       "message": "已到达{{name}},已清除目的地",
       "undo": "撤销"
@@ -369,6 +370,7 @@
       "assignSlotHint": "将下次选择的车站保存到此槽位",
       "favoriteChipHint": "点击将此站设为目的地",
       "misBoardingBannerLabel": "无法识别乘坐的列车，请重新选择。",
+      "misBoardingWrongDirectionBannerLabel": "您好像坐反方向了，请重新选择。",
       "misBoardingReselectLabel": "重新选择乘坐列车",
       "misBoardingReselectHint": "重新打开乘坐列车选择界面"
     }


### PR DESCRIPTION
## Summary
- `detectMisBoarding`에 `'wrong-direction'` observation을 추가한다. 기존에는 `lock.trainCode`가 `positions.trains`에 관측되기만 하면(`trainNo` 매칭) `'present'`로 판정했다 — 사용자가 반대 방향 승강장에서 탑승해도 관측은 되므로 놓쳤다(예: 뚝섬→신당 경로인데 성수 방면(외선) 열차 탑승).
- 새 공유 primitive **`directionOnLine(line, fromStationId, toStationId): 'up' | 'down' | null`** (`src/features/route/utils/directionOnLine.ts`)을 신설했다. `shortestLinePathIndices`(`lineLoopPath.ts`, 2호선 closed loop wraparound-aware 최단경로) 위에서 첫 step의 idx 증감으로 방향을 낸다 — `resolveTripDirection`(`tripDirection.ts`)이 leg 선택 뒤 내부적으로 쓰는 것과 **동일한 알고리즘**이며, **Route 의존 없는 station-id-level API**로 의도적으로 설계했다(Route가 없는 R1c의 `arcStations: Station[]` 기반 estimator, R2, U1-fix도 그대로 소비 가능).
- `detectMisBoarding.isWrongDirection()`은 기대 방향(`resolveTripDirection`, route 필요)과 실제 이동 방향(`directionOnLine`, route 불필요)을 비교해 반대면 `'wrong-direction'`을 반환한다.
- `useMisBoardingDetector`에 wrong-direction 전용 grace/threshold 카운터 추가(기존 absent 카운터와 동일 상수 재사용, 서로 배타적으로 reset — 동시에 true가 될 수 없다).
- `MisBoardingBanner`/`MisBoardingReselectModal`에 `reason?: 'absent' | 'wrong-direction'` prop 추가(기본값 `'absent'`로 완전 하위호환) + copy 분기. i18n 키(`home.misBoardingWrongDirectionToast`, `a11y.route.misBoardingWrongDirectionBannerLabel`)를 ko/en/ja/zh 4개 로케일에 추가.
- `HomeScreen`에 `route`/`destination?.name`을 훅에 배선하고, 어느 감지가 발화했는지 추적하는 `misBoardingReason` state로 Toast/Banner/Modal copy를 분기.
- Phase A(backend silent-push, 백그라운드/주머니 상황 대응)는 **본 PR 범위 아님** — 별도 후속 이슈로 분리, 코드에도 주석으로 명시.

## Discovered but out of scope
`resolveTripDirection`(#1922, step 비교)와 `inferLoopDirection`(#1063, forward/backward 호 길이 비교)이 **2호선 순환선 seam(시청↔충정로)에서 서로 다른 방향 라벨을 낸다**(같은 station pair 충정로→시청에 대해 하나는 'up', 하나는 'down'을 반환하는 것을 직접 재현·확인). 두 유틸 자체는 이번 PR에서 수정하지 않았다(각각 다른 다수 호출자의 기존 동작을 건드릴 위험). 대신 `directionOnLine` 하나의 알고리즘으로 기대/실제 방향을 통일해 이 불일치를 피했다 — seam 근방에서는 최악의 경우 미탐(false negative)만 발생하고 오탐(false positive)은 나지 않는다는 것을 회귀 테스트로 고정했다(`directionOnLine.test.ts`, `detectMisBoarding.test.ts`의 "2호선 순환선 seam" describe 블록).

`directionOnLine`은 이번 PR의 keystone 공유 primitive다 — R1c/R2/U1-fix 등 다른 병렬 작업이 이를 소비할 예정.

## False-positive guard 목록 (must-not-false-positive, 전부 테스트로 고정)
- 아직 탑승역에 머무는 중(1역도 이동 전) → indeterminate, `'present'`
- 정방향으로 정상 진행 중 → `'present'`
- route/destinationName 미전달(하위호환) → 방향 검사 skip, `'present'`
- lock.boardingStationId가 stations.json에 없음 → `'present'`
- destinationName이 boardingLine 위에 없음(resolveTripDirection null) → `'present'`
- 관측된 열차 statnNm이 boardingLine 위에 없음(observedStation lookup 실패) → `'present'`
- expectedDirection은 resolve되지만 directionOnLine fromId 조회 실패(데이터 불일치 방어) → `'present'`
- 환승 leg 경계 — `lock.boardingStationId`는 PR E 정책상 leg마다 새 lock으로 교체되어 이미 "현재 leg" 시작역이므로 whole-trip origin이 아닌 현재 leg 기준으로 판정됨을 테스트로 확인
- 2호선 순환선 seam(시청↔충정로) 근방 — wrap-forward/backward 둘 다 오탐 없음(`.not.toBe('wrong-direction')`)
- no-signal(positions/line/trainCode 없음, mock 데이터) → 기존 동작 그대로, wrong-direction 판정 자체가 실행되지 않음

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass 확인(0 orphan). `directionOnLine`은 `detectMisBoarding.ts`에서 소비.
2. **V/X dashboard** — `MisBoardingBanner`/`MisBoardingReselectModal`이 시각 노출 지점. `detected`/`wrongDirectionDetected`는 `useMisBoardingDetector`의 return 값으로 관측 가능(향후 DebugModal 노출은 후속 과제, 기존 absent 경로도 동일하게 미노출).
3. **의존 PR** — N/A. backend 변경 없음, device-only.
4. **측정 plan** — 실기기 반대 방향 탑승 재현(예: 2호선 역에서 의도적으로 반대편 승강장 탑승) 후 배너/모달 노출 확인. N-consecutive(3회, ~90s) + grace(60s) 임계값이 기존 absent 경로와 동일하므로 오탐/지연 특성도 동일하게 관찰 가능.
5. **Device verify** — **필요**. 코드-only 검증(type-check + unit 100%)은 완료했으나, 실기기 반대 방향 탑승 시나리오는 검증되지 않음. 사용자 실기기 검증 후 머지 권장.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 466 suites / 9874 tests pass, 전역 커버리지 100%
- [x] `npm run lint:orphan` — 0 orphan
- [x] `directionOnLine.test.ts` 8 tests, 100% coverage (단조 노선, 순환선 비-seam, 순환선 seam, null 가드 3종)
- [x] `detectMisBoarding.test.ts` wrong-direction describe 블록 22 tests, 100% coverage
- [x] `useMisBoardingDetector.test.tsx` wrongDirectionDetected describe 블록 17 tests(기존 11 + 신규 6), 100% coverage
- [x] `MisBoardingBanner.test.tsx` / `MisBoardingReselectModal.test.tsx` reason variant 테스트 추가, 100% coverage
- [ ] 실기기 반대 방향 탑승 재현 검증 (사용자 책임, 위 Device verify 참고)

Closes #2455

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9