### PR TITLE
fix(#2460): 활성 trip 중 off-route position 시 phantom route 재계산 차단

### DIFF
--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -491,6 +491,56 @@ describe('processLocationUpdate', () => {
     expect(mockCalculateStaticETA).toHaveBeenCalledWith(updatedRoute, expect.any(Object));
   });
 
+  // #U1 (2026-08-31) — 실탑승 evidence: 뚝섬→신당 활성 trip 도중 단일 off-route GPS 좌표
+  // (성수 방면 잘못 탑승 라벨 버그로 인한 잠실 방향 스냅)가 들어오면 updateRouteFromPosition이
+  // null을 반환하고, 기존 코드는 그 off-route 위치로 findRoute를 재호출해 완전히 다른(잠실 경유)
+  // 경로를 만들어 그 route의 alarmEvent(예: "잠실 환승하세요")를 phantom 발사했다.
+  // 활성 boardingLock이 있으면(=사용자가 명시 탑승 확정한 trip 진행 중) 단일 glitch position으로
+  // 경로를 갈아엎지 않고 storedRoute를 그대로 유지(hold)한다 — Option (a).
+  it('활성 boardingLock 중 updateRouteFromPosition이 null이면 findRoute로 재계산하지 않고 storedRoute를 유지한다 (#U1 off-route hold)', async () => {
+    const storedRoute = makeDirectRoute(5, '2');
+    const activeLock = {
+      destinationId: 'station-2',
+      trainCode: 'T-2',
+      boardingStationId: 'station-0',
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    // off-route 후보역 — 실제로는 storedRoute 상에 없는 역(예: 잠실)이라고 가정.
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockUpdateRouteFromPosition.mockReturnValue(null);
+    mockGetBoardingLock.mockResolvedValue(activeLock);
+    mockIsStationOnRoute.mockReturnValue(false);
+
+    await call({ storedRoute });
+
+    expect(mockUpdateRouteFromPosition).toHaveBeenCalledWith(storedRoute, mockStation, 'station-2');
+    // 핵심 assertion — off-route 위치로 새 경로를 재탐색하지 않는다.
+    expect(mockFindRoute).not.toHaveBeenCalled();
+    expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+      expect.objectContaining({ route: storedRoute }),
+      expect.any(Set),
+      undefined,
+      expect.any(Array),
+    );
+  });
+
+  // MUST-NOT-REGRESS — lock 없는 자유 탐색(genuine reroute)은 기존대로 findRoute 재계산을 허용한다.
+  // (이는 기존 회귀 테스트 '#468 falls back to findRoute...'가 이미 lockless 기본값으로 커버하지만,
+  // #U1 hold 분기 추가 후에도 명시적으로 재확인.)
+  it('lock 없으면(#U1 hold 미적용) updateRouteFromPosition null 시 기존대로 findRoute로 재계산한다 (MUST-NOT-REGRESS)', async () => {
+    const storedRoute = makeDirectRoute(5, '2');
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockUpdateRouteFromPosition.mockReturnValue(null);
+    mockGetBoardingLock.mockResolvedValue(null);
+    mockFindRoute.mockReturnValue(mockRoute);
+
+    await call({ storedRoute });
+
+    expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
+  });
+
   it('calls findRoute when no storedRoute is provided', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -295,12 +295,25 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   const nearest = findNearestStation(lat, lng, MAX_STATION_DISTANCE_KM);
   if (!nearest) return { alarmEvent: null, nearest: null };
 
+  // #707용 lock을 여기서 미리 조회 — 아래 U1 off-route hold 가드가 currentLine 강등 로직보다
+  // 먼저 lock 존재 여부를 알아야 한다. 중복 조회 방지를 위해 이 결과를 아래에서 재사용한다.
+  const lockForLineGuard = await getBoardingLock();
+
   let route: Route = null;
   if (storedRoute) {
     route = updateRouteFromPosition(storedRoute, nearest.station, destination.id);
   }
   if (!route) {
-    route = findRoute(nearest.station.id, destination.id);
+    // #U1 (2026-08-31 실탑승 evidence) — 활성 boardingLock이 있는 trip 도중 단일 off-route
+    // position(GPS drift/오분류 등)이 들어와 updateRouteFromPosition이 null을 반환하면, 그
+    // off-route position으로 findRoute를 재탐색하지 않는다. 재탐색은 완전히 다른(엉뚱한 노선/
+    // 방향) 경로를 만들어 그 route의 alarmEvent(phantom transfer/destination 안내)를 발사시킨다
+    // — 뚝섬→신당 trip 중 잠실 방향 오탐 스냅으로 "잠실 환승하세요"가 잘못 발사된 사례.
+    // 대신 storedRoute를 그대로 유지(hold)한다 — 다음 tick에 position이 route로 복귀하면
+    // updateRouteFromPosition이 정상 성공해 자연 복구된다. lock 없는 자유 탐색(genuine reroute,
+    // 예: 목적지 변경 직후 최초 route 탐색)은 기존대로 findRoute 재계산을 허용해야 하므로
+    // storedRoute 존재 + lock 활성 조합일 때만 hold한다.
+    route = storedRoute && lockForLineGuard ? storedRoute : findRoute(nearest.station.id, destination.id);
   }
 
   // #2373 (RCA #2180) — FG의 검증된 station-passed hop-window 게이트를 BG 채널에 이식.
@@ -335,8 +348,8 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // BG path는 fusion이 없어 nearest.station.line(raw GPS 최근접)이 환승역에서 옆 노선으로
   // 잘못 잡힐 수 있다. 사용자가 명시 탭한 lock.boardingLine을 source of truth로 신뢰 —
   // evaluateAlarmPhase의 approachLine 게이트(#579)와 맞물려 잘못된 leg 알람 발사를 차단.
-  // lock 없으면 기존 동작(GPS line) 유지.
-  const lockForLineGuard = await getBoardingLock();
+  // lock 없으면 기존 동작(GPS line) 유지. lockForLineGuard는 위 U1 hold 가드에서 이미 조회했다
+  // (중복 AsyncStorage read 방지 — 재사용).
   const currentLine = lockForLineGuard?.boardingLine ?? nearest.station.line;
 
   const suppressed: AlarmEvent[] = [];


### PR DESCRIPTION
## Summary
- U1 fix: `src/features/alarm/utils/stationPipeline.ts`의 `processLocationUpdate`에서 활성 boardingLock + storedRoute 조합일 때, `updateRouteFromPosition`이 null(off-route)을 반환해도 `findRoute`로 재계산하지 않고 `storedRoute`를 그대로 유지(hold)한다.
- 실탑승 evidence: 뚝섬→신당 trip 중 단일 off-route GPS 스냅(잠실 방향)이 완전히 다른 route를 findRoute로 재탐색시켜, 그 route의 alarmEvent("잠실 환승하세요")가 phantom 발사됐고 boarding lock/재프롬프트도 스푸리어스하게 트리거됐다.
- lock 없는 자유 탐색(genuine reroute)은 기존대로 findRoute 재계산 허용 — 회귀 없음.

## Option 선택 — (a) off-route hold
`getBoardingLock()` 조회를 route 결정 로직보다 앞으로 이동해 재사용(중복 AsyncStorage read 방지). 활성 trip(=사용자 명시 탑승 확정, boardingLock 존재) 중에는 단일 glitch position으로 route를 갈아엎지 않고 hold — 다음 tick에 position이 route로 복귀하면 `updateRouteFromPosition`이 정상 성공해 자연 복구된다.

Option (b)(alarmEvent grace)나 (c)(directionOnLine util 의존)는 채택하지 않음 — (a)만으로 repro가 완전히 해소되고, workstream `impl-misdirection-B`의 `directionOnLine` util과 cross-PR 결합을 피하기 위해 util-independent guard를 우선했다.

Closes #2460

## Test plan
- [x] Red 테스트 작성 (활성 lock 중 off-route hold) → 수정 전 FAIL 확인
- [x] Green 확인 (수정 후 PASS, 103/103 in file)
- [x] MUST-NOT-REGRESS 테스트 추가 (lock 없는 자유 탐색은 기존대로 findRoute 재계산)
- [x] `npm test` 전체 스위트 그린 (465 suites / 9845 tests, 커버리지 100%)
- [x] `npm run type-check` 통과
- [x] `npm run lint:orphan` — orphan 0
- [x] `npx eslint` 대상 파일 clean

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass, 신규 export 없음(기존 함수 내부 로직 변경만)
2. **V/X dashboard** — DebugModal 알람 로그(`logSuppressedDedupAlarm` 등 기존 alarmLog 인프라)로 route hold 시 alarmEvent 미발사가 그대로 관측됨. off-route 시 `isStationOnRoute`가 false가 되어 station-passed 분기도 자연 skip. 신규 로그 채널 추가 없음.
3. **의존 PR** — N/A
4. **측정 plan** — 다음 지하/환승 실탑승에서 off-route 단일 glitch position 발생 시 phantom transfer alarmEvent 미발사 + 스푸리어스 재프롬프트 미발생을 dump/DebugModal로 확인.
5. **Device verify** — 실기기 검증 권장 (지하/환승 실탑승 trip). 본 PR 자체는 type+unit only로 완결 — device-only 회귀(런타임 lock 상태 전이 등)는 에이전트가 검증 불가.

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9