### PR TITLE
fix(#2464): 건대입구 실환승 시 환승 알람 스킵 방지

### DIFF
--- a/src/features/alarm/utils/__tests__/stationAlarm.test.ts
+++ b/src/features/alarm/utils/__tests__/stationAlarm.test.ts
@@ -447,6 +447,56 @@ describe('evaluateAlarmPhase', () => {
         ),
       ).toBeNull();
     });
+
+    // #2464 — 건대입구(7→2) 실환승 회귀: 환승 타겟에 아직 도달 전(stops>0)인데
+    // currentLine이 station complex GPS/fusion jitter로 toLine(2)으로 조기 flip되면,
+    // 기존 로직은 미도달 환승 타겟을 건너뛰고 도착 타겟(approachLine=toLine)으로
+    // 오매칭돼 "환승하세요" 안내가 통째로 스킵됐다. stops>0인 미도달 타겟은
+    // currentLine mismatch 시 다음 leg로 fall-through하지 않고 그 tick은 보류(null)해야 한다.
+    it('#2464 — 환승 타겟 미도달(stops>0)인데 currentLine이 toLine으로 조기 flip되면 도착 타겟으로 오매칭하지 않는다', () => {
+      // 건대입구 1정거장 전(stopsToTransfer=1, 아직 미도달) — currentLine은 이미 '2'로 flip.
+      const route = makeTransferRoute(1, 1, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '2' }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
+
+    it('#2464 — currentLine이 fromLine으로 복귀하면 보류됐던 환승 알람이 정상 발사된다', () => {
+      // 위 케이스와 동일 route/stops. currentLine만 올바른 값(fromLine='7')으로 복귀.
+      const route = makeTransferRoute(1, 1, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '7' }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'transfer', stationName: '건대입구' });
+    });
+
+    it('#2464 — 환승 타겟을 이미 통과(stops<=0)했다면 currentLine mismatch여도 다음 leg로 정상 진행한다', () => {
+      // 환승역 통과(stops=0), 도착역 1정거장 전. currentLine='2'(toLine)로 정상 매칭.
+      const route = makeTransferRoute(0, 1, '건대입구', '7', '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '성수', currentLine: '2' }),
+          new Set(),
+        ),
+      ).toEqual({ phaseId: 'early', type: 'destination', stationName: '성수' });
+    });
+
+    it('#2464 — 유일한 타겟이 이미 통과(stops<=0)했지만 currentLine이 어느 leg와도 안 맞으면 loop 끝까지 진행 후 null', () => {
+      // DirectRoute stops=0(이미 도달) + currentLine mismatch → stops<=0이라 continue하지만
+      // 더 이상 평가할 leg가 없어 loop 종료 후 최종 null로 떨어진다.
+      const route = makeDirectRoute(0, '2');
+      expect(
+        evaluateAlarmPhase(
+          source({ route, destinationName: '강남', currentLine: '5' }),
+          new Set(),
+        ),
+      ).toBeNull();
+    });
   });
 
   describe('suppressedOut out-param (#580)', () => {

--- a/src/features/alarm/utils/stationAlarm.ts
+++ b/src/features/alarm/utils/stationAlarm.ts
@@ -159,7 +159,16 @@ export function evaluateAlarmPhase(
 
   for (let i = 0; i < targets.length; i++) {
     const target = targets[i];
-    if (target.approachLine !== currentLine) continue;
+    if (target.approachLine !== currentLine) {
+      // #2464 — target.stops <= 0(이미 도달/통과)일 때만 다음 leg로 진행 허용한다.
+      // stops > 0(아직 도달 전)인데 currentLine이 mismatch면, station complex에서
+      // GPS/fusion이 currentLine을 다음 leg 노선으로 조기 flip했을 가능성이 있다 —
+      // 이 tick엔 아직 도달하지 않은 웨이포인트(예: 환승역)를 건너뛰고 뒤 leg(도착역 등)로
+      // 오매칭하지 않도록 보류(null)한다. currentLine이 올바르게 복귀하면 다음 tick에
+      // 이 웨이포인트가 정상 평가된다.
+      if (target.stops <= 0) continue;
+      return null;
+    }
 
     const isFinal = i === targets.length - 1;
     const context: AlarmContext = {


### PR DESCRIPTION
## Summary
- 실탑승 회귀: 건대입구(7→2) 환승 중 도착 알림은 왔으나 "환승하세요" 안내가 발사되지 않음
- Root cause: `evaluateAlarmPhase`(`src/features/alarm/utils/stationAlarm.ts`) per-target loop이
  `target.approachLine !== currentLine`이면 무조건 `continue`하며 다음 target으로 fall-through했음.
  건대입구는 7/2호선 플랫폼이 물리적으로 인접한 하나의 station complex라 GPS/fusion이 만드는
  `currentLine`이 아직 환승역에 도달하지 않았는데도(stopsToTransfer>0) toLine(2)으로 조기 flip될 수
  있음 — 이 경우 미도달 환승 타겟을 건너뛰고 도착 타겟(approachLine=toLine)으로 오매칭돼 환승
  안내가 통째로 스킵됨.
- Fix: mismatch 시 `target.stops <= 0`(이미 도달/통과)일 때만 다음 leg로 진행 허용. 미도달
  (`stops > 0`)인데 currentLine이 mismatch면 그 tick은 `null`(보류) — currentLine이 다음
  tick에 올바르게 복귀하면 그때 정상 평가된다.

## 선택한 옵션 (a vs b)
**옵션 (a)** — loop ordering만 수정 (stationAlarm.ts 단독). 옵션 (b: currentLine 소스 자체를
lock/route leg 경계로 게이팅)는 다른 in-flight 작업(`resolveCurrentLine.ts` 등, N8/#1204 계열)과
충돌 가능성이 있어 범위 밖으로 뒀다. (a)가 더 surgical하고, currentLine의 실제 발생 원인(GPS
jitter vs 진짜 flip)을 몰라도 안전하게 동작 — 즉 root cause가 device-side에서 나중에 (b)로
추가 수정되더라도 이 fix와 상충하지 않는다(오히려 (b)가 currentLine 자체를 더 정확하게 만들면
이 fix의 fallback 경로를 덜 타게 될 뿐).

## #579 / #152 보존
- 두 회귀 모두 "currentLine이 approachLine과 정확히 일치하는 leg만 평가한다"는 게이트가
  핵심이며, 이번 변경은 **일치하는 경우의 동작을 전혀 바꾸지 않았다** — mismatch일 때의
  fall-through 조건만 `stops<=0`으로 좁혔다.
- 기존 `currentLine gate (#579)` describe 블록의 5개 테스트 모두 무변경으로 그린
  (`does not fire destination/early on transfer route when user is on fromLine...`,
  `returns null when currentLine does not match any leg...` 등).
- MultiTransferRoute의 `does not fire at the start of multi-segment route (regression: #152)`
  테스트도 무변경 그린.

## Test plan
- [x] Red 재현: `#2464` 신규 테스트가 fix 전 `evaluateAlarmPhase`에서 기대와 다른
  `{ phaseId: 'early', type: 'destination', stationName: '성수' }`를 반환함을 확인
  (환승 안내 대신 도착 타겟으로 오매칭되는 실제 버그 재현)
- [x] Green: fix 적용 후 신규 테스트 4건 + 기존 61개 테스트 전부 통과
  (`npx jest src/features/alarm/utils/__tests__/stationAlarm.test.ts`)
- [x] `npm test` — 468 suites / 9923 tests 전부 통과, coverage 100% (lines/branches/functions/statements)
- [x] `npm run type-check` clean
- [x] `npm run lint:orphan` — 0 orphan
- [x] `npx eslint` (변경 파일) clean

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 없음(기존 함수 내부 로직만 수정).
2. **V/X dashboard** — 변경 신호는 `evaluateAlarmPhase`의 순수 함수 반환값. 기존과 동일하게
   `useStationAlarm.ts` → alarm banner / OS 알림으로 이어지는 기존 경로를 그대로 통과한다
   (신규 관측 채널 불필요). unit test(`stationAlarm.test.ts`)가 회귀 게이트 역할.
3. **의존 PR** — N/A. 이 fix는 device-local 순수 함수 하나만 수정, backend/infra 의존 없음.
4. **측정 plan** — 다음 실탑승 환승 시나리오(7↔2 등 platform-adjacent station complex)에서
   "환승하세요" 안내가 정상 발사되는지 확인. 실패 시 `evaluateAlarmPhase` 진입 시점의
   `currentLine`/`target.stops` 로그(DebugModal alarmLog)로 진단.
5. **Device verify** — **필요**. 실기기 실환승(건대입구 7→2 또는 유사 platform-adjacent
   환승역) 1회 이상 재탑승해 "환승하세요" 안내가 정상 발사되는지 확인 필요. 이 PR은
   type-check + unit만 검증됨 — device-only 회귀(실제 GPS jitter 재현 여부)는 에이전트가
   검증 불가.

Closes #2464