### PR TITLE
chore(#2466): EAS production Sentry 소스맵 업로드 실패 차단 (SENTRY_DISABLE_AUTO_UPLOAD=true)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -21,7 +21,8 @@
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APNS_ENV": "production",
-        "EXPO_PUBLIC_ALARM_BACKEND_URL": "https://subway-now-alarm-worker.handokei.workers.dev"
+        "EXPO_PUBLIC_ALARM_BACKEND_URL": "https://subway-now-alarm-worker.handokei.workers.dev",
+        "SENTRY_DISABLE_AUTO_UPLOAD": "true"
       }
     }
   },


### PR DESCRIPTION
Closes #2466

## 문제
EAS production 빌드가 `Bundle React Native code and images` 단계에서 실패:
```
sentry-cli - An organization ID or slug is required (provide with --org)
▸ ** ARCHIVE FAILED ** (exit 65)
```
`ios/sentry.properties`가 org/project를 `SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_AUTH_TOKEN` 환경변수로 fallback하는데, EAS production env엔 `EXPO_PUBLIC_SENTRY_DSN`만 있고 그 3개가 없어 소스맵 자동 업로드가 실패.

## 수정
`eas.json` production env에 `SENTRY_DISABLE_AUTO_UPLOAD=true` 추가 → 소스맵 업로드 skip → 빌드 통과. (로컬 Release 빌드 리추얼과 동일 패턴.)

## Wire-completion 5단
1. Orphan: N/A — config only.
2. V/X: EAS build 성공 여부 (다음 production 빌드).
3. 의존 PR: N/A.
4. 측정: 다음 `eas build --profile production --platform ios`가 Sentry 단계 통과.
5. Device verify: N/A — 빌드 설정. (소스맵 심볼화 필요 시 후속으로 SENTRY_ORG/PROJECT/AUTH_TOKEN 등록.)