### PR TITLE
fix(#2468): 지하 GPS garbage 하에서 barometer subsurface=false 단독 surface 오분류 차단

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsQualityGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsQualityGate.test.ts
@@ -106,8 +106,46 @@ describe('#2070 useFusedNearestStation — gpsQualityDegraded → inferEnvironme
     expect(hook.result.current.environmentHintReason).toBeUndefined();
   });
 
-  it('barometer.subsurface=false 명시 시 gpsQualityDegraded=true여도 surface 우선 (기존 판정 대체 아님)', async () => {
+  it('#2468 회귀 fix — barometer.subsurface=false + gpsQualityDegraded=true(garbage GPS) + lock 없음 → unknown (surface 단정 X)', async () => {
+    // 변경 전(#1932 당시): 'surface' 반환 — barometer subsurface=false를 GPS 품질과 무관하게
+    // 지상으로 단정하던 것이 바로 확인된 회귀(#2468). accuracyMeters=200(setupNearest)은 garbage
+    // GPS이므로 raw subsurface=false 단독으로 surface를 신뢰하지 않는다. lock 미활성이라 근거
+    // 부족 → unknown(underground 단정도 하지 않음).
     setupNearest(true);
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+
+    await waitFor(() => {
+      expect(hook.result.current.environment).toBe('unknown');
+    });
+    expect(hook.result.current.environmentHintReason).toBeUndefined();
+  });
+
+  it('barometer.subsurface=false + GPS 양호(accuracy≤50m) → surface 유지 (gpsDerivedFastPath 보존, blanket revert 아님)', async () => {
+    setupNearest(false);
+    mockNearest.mockReturnValue({
+      result: { station: hanyangdae, distanceKm: 0.05 },
+      liveResult: { station: hanyangdae, distanceKm: 0.05 },
+      stickyDisplayOnly: null,
+      variants: [hanyangdae],
+      userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+      ...GPS_BASE_DEFAULTS,
+      accuracyMeters: 20, // GPS 양호
+      lastFixAtMs: T0,
+      gpsQualityDegraded: false,
+      refresh: jest.fn(),
+    });
 
     const hook = renderHook(() =>
       useFusedNearestStation(

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1347,6 +1347,10 @@ export function useFusedNearestStation(
   // #2076 — gpsQualityDegraded는 absence(게이트 통과 fix 30s+ 부재, 독립 타이머 구동) 단독으로만
   // true가 된다. 급락(accuracy 1회성 급증) 단독으로는 true가 되지 않아(#2076 결함2) 지상 urban
   // canyon 오탐이 이 hint를 발동시키지 않는다.
+  // #2468 (#1932 회귀 fix) — GPS accuracy(gpsAccuracyMeters) + lock 활성(lockActive) 추가 입력.
+  // GPS garbage(accuracy>50m 또는 qualityDegraded) 하에서 raw `subsurface===false`가
+  // 'surface'로 단정되지 않도록 — lock 활성 trip이면 'underground'로 되돌려
+  // positionTrainBoardingLockMatch(아래) 재활성 경로를 복구한다.
   const cascadeEnvironmentResult: InferEnvironmentResult = inferEnvironment({
     subsurface: barometerSubsurface,
     surfaceSSOT: cascadeSurfaceSSOT !== null,
@@ -1354,6 +1358,8 @@ export function useFusedNearestStation(
     tripActive,
     barometerStop: barometerSignal?.stop,
     qualityDegraded: gps.gpsQualityDegraded,
+    gpsAccuracyMeters: gps.accuracyMeters,
+    lockActive: boardingLock != null,
   });
   // #1932 — cascade tier 1/2가 직접 read하는 environment 변수.
   // 후속 cascade-wide post-section(L1378~)에서도 동일 값 재사용 (분산 산출 0건 SSOT).

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
@@ -442,4 +442,69 @@ describe('#1932 inferEnvironment 호출자 통합 (SSOT 단일화 + cascade 직�
       // 1주 environment 분포 측정 인프라 prereq — Sentry breadcrumb는 useEffect에서 emit (deps environment).
     });
   });
+
+  describe('#2468 (#1932 회귀 fix) garbage GPS 하에서 subsurface=false 단독 surface 단정 차단', () => {
+    /**
+     * D1 dump 실측: 지하 구간 subsurface=false ×140/true ×19, GPS accuracy 1,395~3,703m.
+     * SSOT 둘 다 미합의(gps garbage로 surfaceSSOT 불성립, undergroundSSOT 신호 없음).
+     */
+    function setupGarbageGpsNoSsot(): void {
+      const live = { station: hanyangdae, distanceKm: 0.05 };
+      mockNearest.mockReturnValue({
+        result: live,
+        liveResult: live,
+        stickyDisplayOnly: null,
+        variants: [hanyangdae],
+        userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+        ...GPS_BASE_DEFAULTS,
+        accuracyMeters: 1395, // 실 dump garbage GPS accuracy — GPS_DERIVED_ACCURACY_MAX_M(50m) 훨씬 초과
+        lastFixAtMs: T0,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+      mockArrival.mockReturnValue(arrivalRet(null)); // SSOT 미합의
+      mockPos.mockReturnValue(positionRet(null));
+    }
+
+    it('subsurface=false + garbage GPS(1395m) + lock 활성 → underground (positionTrainBoardingLockMatch 재활성 경로 복구, RED before #2468 fix)', async () => {
+      setupGarbageGpsNoSsot();
+
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          lockOn2,
+          undefined,
+          { subsurface: false },
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('underground');
+      });
+      expect(hook.result.current.environmentHintReason).toBe('gps-garbage-underground');
+    });
+
+    it('subsurface=false + garbage GPS(1395m) + lock 없음 → unknown (lock 근거 없어 underground 단정 X)', async () => {
+      setupGarbageGpsNoSsot();
+
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: false },
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('unknown');
+      });
+    });
+  });
 });

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -25,12 +25,118 @@ describe('inferEnvironment', () => {
     ).toBe('underground');
   });
 
-  it('#1932 — subsurface=false + 두 SSOT 모두 null + hint 미발동 → surface (raw barometer 신뢰)', () => {
+  it('#1932 — subsurface=false + 두 SSOT 모두 null + hint 미발동 → surface (raw barometer 신뢰, GPS accuracy 미전달)', () => {
     // cascade tier 2(gpsDerivedFastPath)와의 semantic equivalence 보존.
     // 기존: 'unknown' (DebugModal 표시 전용 시기). 변경: barometer 명시 지상 신뢰 → 'surface'.
+    // gpsAccuracyMeters 미전달(fix 없음)은 #2468 garbage 판정 미적용 — 기존 동작 그대로.
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }).label,
     ).toBe('surface');
+  });
+
+  describe('#2468 — garbage GPS 하에서 subsurface=false 단독 surface 단정 차단', () => {
+    it('GPS 양호(accuracy=20m) + 두 SSOT null → surface 유지 (gpsDerivedFastPath 보존, blanket revert 아님)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: 20,
+      });
+      expect(result.label).toBe('surface');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('gpsAccuracyMeters=null(fix 없음) + 두 SSOT null → surface (기존 동작 보존, garbage 판정 미적용)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: null,
+      });
+      expect(result.label).toBe('surface');
+    });
+
+    it('GPS garbage(accuracy=1395m, 실 dump값) + lockActive=true + 두 SSOT null → underground (RED before fix, #2468)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: 1395,
+        lockActive: true,
+      });
+      expect(result.label).toBe('underground');
+      expect(result.hintReason).toBe('gps-garbage-underground');
+    });
+
+    it('GPS garbage(accuracy=3703m) + lockActive=false → unknown (lock 근거 없어 underground 단정 안 함)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: 3703,
+        lockActive: false,
+      });
+      expect(result.label).toBe('unknown');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('GPS garbage + lockActive 미전달 → unknown (기본값 false 취급)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: 5000,
+      });
+      expect(result.label).toBe('unknown');
+    });
+
+    it('qualityDegraded=true(accuracy 미전달) + lockActive=true → underground (accuracy 없어도 qualityDegraded 단독으로 garbage 판정)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        qualityDegraded: true,
+        lockActive: true,
+      });
+      expect(result.label).toBe('underground');
+      expect(result.hintReason).toBe('gps-garbage-underground');
+    });
+
+    it('accuracy=50m 경계값(초과 아님) → garbage 아님, surface 유지', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: 50,
+        lockActive: true,
+      });
+      expect(result.label).toBe('surface');
+    });
+
+    it('surfaceSSOT 활성이면 GPS garbage여도 surface 우선 (priority-2가 4보다 앞섬, 회귀 아님)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: true,
+        undergroundSSOT: false,
+        gpsAccuracyMeters: 5000,
+        lockActive: false,
+      });
+      expect(result.label).toBe('surface');
+    });
+
+    it('barometer-stop hint가 GPS garbage 판정보다 우선 (priority 순서 보존)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+        gpsAccuracyMeters: 5000,
+        lockActive: true,
+      });
+      expect(result.label).toBe('unknown');
+      expect(result.hintReason).toBe('barometer-stop');
+    });
   });
 
   it('subsurface=undefined + surfaceSSOT만 활성 → surface (hybrid)', () => {
@@ -123,14 +229,17 @@ describe('inferEnvironment', () => {
       expect(result.hintReason).toBeUndefined();
     });
 
-    it('subsurface=false + SSOT 없음이면 qualityDegraded=true여도 surface 우선 (raw barometer 신뢰)', () => {
+    it('#2468 회귀 fix — subsurface=false + SSOT 없음 + qualityDegraded=true(lockActive 미전달) → unknown (surface 단정 X)', () => {
+      // 변경 전(#1932 당시): 'surface' 반환 — 이것이 바로 #2468 확인된 회귀(garbage GPS를
+      // barometer subsurface=false 단독으로 지상 단정). qualityDegraded는 GPS garbage 신호이므로
+      // lock 근거 없는 이 case는 'unknown'이 맞다(lockActive=true였다면 'underground').
       const result = inferEnvironment({
         subsurface: false,
         surfaceSSOT: false,
         undergroundSSOT: false,
         qualityDegraded: true,
       });
-      expect(result.label).toBe('surface');
+      expect(result.label).toBe('unknown');
       expect(result.hintReason).toBeUndefined();
     });
   });

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -9,9 +9,19 @@
  *   1. `subsurface === true` 명시 → 'underground' (barometer 확정).
  *   2. `subsurface === false` 명시 + surfaceSSOT 활성 → 'surface'.
  *   3. `subsurface === false` + undergroundSSOT 활성 → 'underground' (지하상가/매핑 SSID).
- *   4. `subsurface === false` + 두 SSOT 모두 null + barometer-stop hint 미발동 → 'surface'
- *      (#1932 — barometer 명시 지상 신뢰. raw `subsurface === false` 동작 보존).
- *      hint 발동(tripActive + barometerStop=true) 시는 우선 5번으로 흘러 unknown 유지.
+ *   4. `subsurface === false` + 두 SSOT 모두 null + barometer-stop hint 미발동:
+ *      4a. GPS 양호(accuracyMeters ≤ 50m, qualityDegraded 아님) → 'surface'
+ *          (#1932 — barometer 명시 지상 신뢰. raw `subsurface === false` 동작 보존.
+ *          gpsDerivedFastPath와의 semantic equivalence 유지).
+ *      4b. GPS garbage(accuracyMeters > 50m 또는 qualityDegraded=true) + lockActive=true →
+ *          'underground' (#2468/#1932 회귀 fix — barometer subsurface는 EDGE 감지기라 steady
+ *          지하 주행에서 dP≈0 → false. GPS 3km급 오차는 지상일 수 없다 — garbage GPS 하에서
+ *          raw subsurface=false 단독으로 'surface' 단정 금지. lock 활성 시 underground로
+ *          되돌려 `positionTrainBoardingLockMatch` 재활성 → 지하 device 자율 advance 복구).
+ *      4c. GPS garbage + lockActive=false(또는 미전달) → 'unknown' (보수적 — lock 근거 없이
+ *          underground 단정하지 않는다. 지상 urban canyon/non-trip 오탐 방지).
+ *      hint 발동(tripActive + barometerStop=true) 시는 4보다 먼저 처리 — 우선 5번으로 흘러
+ *      unknown 유지.
  *   5. `subsurface === false` + 두 SSOT 모두 null + tripActive + barometerStop=true →
  *      'unknown' (with hint 'barometer-stop'). 지하상가 hint paradigm.
  *   6. `subsurface === undefined` + surfaceSSOT만 활성 → 'surface' (hybrid).
@@ -34,7 +44,16 @@
  * #2076 — GPS 품질 저하 입력(qualityDegraded)은 게이트 통과 fix가 30s 이상 부재(absence)할
  * 때만 true다. accuracy 1회성 급락 단독으로는 true가 되지 않는다 — 지상 urban canyon(고층빌딩
  * multipath)에서의 급락 1회가 지하로 오분류되던 결함(#2076 결함2) 차단.
+ *
+ * #2468 — 우선순위 4가 4a/4b/4c로 세분화됨(#1932 회귀 fix). GPS accuracy(gpsAccuracyMeters)와
+ * lock 활성 여부(lockActive)가 새 입력으로 추가. `GPS_DERIVED_ACCURACY_MAX_M`(50m, 기존
+ * gpsDerivedFastPath와 동일 threshold)를 초과하거나 qualityDegraded=true면 GPS를 garbage로
+ * 간주 — 이 상태에서는 raw `subsurface === false`가 지상을 증명하지 않는다(barometer는 하강
+ * edge만 감지, steady 지하 주행 dP≈0). lock 활성 trip에서만 'underground'로 판정을 뒤집는다
+ * (lock 없는 case는 근거 부족 → 'unknown').
  */
+
+import { GPS_DERIVED_ACCURACY_MAX_M } from '../../../shared/constants/realtime';
 
 export type Environment = 'surface' | 'underground' | 'unknown';
 
@@ -47,8 +66,11 @@ export interface InferEnvironmentResult {
    *
    * #2070 — 'gps-quality-drop': subsurface===undefined + 두 SSOT 무판정 + GPS 품질 저하
    * (#2076 — absence 30s+ 단독. 급락 단독으로는 발동하지 않는다) 관측 시 발동.
+   *
+   * #2468 — 'gps-garbage-underground': subsurface===false + 두 SSOT null + GPS garbage
+   * (accuracy > 50m 또는 qualityDegraded) + lockActive=true 관측 시 발동.
    */
-  hintReason?: 'barometer-stop' | 'gps-quality-drop';
+  hintReason?: 'barometer-stop' | 'gps-quality-drop' | 'gps-garbage-underground';
 }
 
 export interface InferEnvironmentInput {
@@ -68,11 +90,29 @@ export interface InferEnvironmentInput {
    * 판정에 관여한다(우선순위 8). 미전달이면 false로 간주(기존 동작 보존).
    */
   qualityDegraded?: boolean;
+  /**
+   * #2468 — barometer garbage-GPS 판정 입력. GPS fix accuracy(m). null/undefined = fix 없음
+   * (garbage 판정 미적용, 기존 동작 보존). `GPS_DERIVED_ACCURACY_MAX_M`(50m) 초과 시 garbage.
+   */
+  gpsAccuracyMeters?: number | null;
+  /**
+   * #2468 — 사용자 명시 의향 trip(boardingLock 활성) 여부. GPS garbage 판정 시 'underground'
+   * 대 'unknown' 분기 조건 — lock 근거 없이는 underground를 단정하지 않는다.
+   */
+  lockActive?: boolean;
 }
 
 export function inferEnvironment(input: InferEnvironmentInput): InferEnvironmentResult {
-  const { subsurface, surfaceSSOT, undergroundSSOT, tripActive, barometerStop, qualityDegraded } =
-    input;
+  const {
+    subsurface,
+    surfaceSSOT,
+    undergroundSSOT,
+    tripActive,
+    barometerStop,
+    qualityDegraded,
+    gpsAccuracyMeters,
+    lockActive,
+  } = input;
   if (subsurface === true) return { label: 'underground' };
   if (subsurface === false) {
     if (surfaceSSOT) return { label: 'surface' };
@@ -82,8 +122,23 @@ export function inferEnvironment(input: InferEnvironmentInput): InferEnvironment
     if (tripActive && barometerStop === true) {
       return { label: 'unknown', hintReason: 'barometer-stop' };
     }
-    // #1932 — barometer 명시 지상 신뢰. cascade tier 2(gpsDerivedFastPath)와의 semantic
-    // equivalence 보존: 두 SSOT 비활성이라도 `subsurface === false` raw signal을 surface로 인정.
+    // #2468 — GPS garbage 하에서는 raw `subsurface === false` 단독으로 'surface' 단정 금지.
+    // barometer는 하강 edge만 감지(steady 지하 주행 dP≈0 → false) — GPS accuracy 3km급 오차는
+    // 지상 증거가 될 수 없다.
+    const gpsGarbage =
+      (gpsAccuracyMeters != null && gpsAccuracyMeters > GPS_DERIVED_ACCURACY_MAX_M) ||
+      qualityDegraded === true;
+    if (gpsGarbage) {
+      if (lockActive === true) {
+        // lock 활성 trip → underground로 되돌려 positionTrainBoardingLockMatch 재활성.
+        return { label: 'underground', hintReason: 'gps-garbage-underground' };
+      }
+      // lock 없음 → underground 단정 근거 부족, 보수적으로 unknown.
+      return { label: 'unknown' };
+    }
+    // #1932 — barometer 명시 지상 신뢰(GPS 양호 한정). cascade tier 2(gpsDerivedFastPath)와의
+    // semantic equivalence 보존: 두 SSOT 비활성이라도 `subsurface === false` raw signal을
+    // surface로 인정.
     return { label: 'surface' };
   }
   // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.


### PR DESCRIPTION
## 배경 (CONFIRMED regression #1932)

`inferEnvironment.ts` 우선순위-4(#1932, commit 8572264a)가 `subsurface===false` + 두 SSOT null → 무조건 `'surface'` 반환. barometer `subsurface`는 하강 EDGE 감지기(압력 상승 구간만 true) — steady 지하 주행은 dP≈0 → false. 즉 `subsurface===false`가 지상을 증명하지 않는다.

**D1 dump 확인**: 지하 구간 `subsurface false ×140 / true ×19`, GPS accuracy 1,395–3,703m(garbage). 'surface' 오분류 → `positionTrainBoardingLockMatch`(`useFusedNearestStation.ts`)가 `cascadeEnvironment==='underground'` 요구 → 지하에서 disabled → device 자율 advance 불가 → backend consensus 의존 → ~5분 첫 알림 지연(boarding 19:29:52 → backend fire 19:34:51).

#1932가 이 리스크를 self-flag했음: "지하 lock + spurious subsurface=false → mismatch false positive, G3/G4에서 가드 보강 필요" — 후속 가드 불충분했던 것이 확인된 회귀.

## Fix (surgical, blanket revert 아님)

`inferEnvironment.ts` 우선순위-4를 4a/4b/4c로 세분화. 새 입력 `gpsAccuracyMeters`, `lockActive` 추가.

- **4a. GPS 양호**(accuracy ≤ `GPS_DERIVED_ACCURACY_MAX_M`(50m), qualityDegraded 아님) → 기존대로 `'surface'`. `gpsDerivedFastPath`(#1932가 이 목적으로 우선순위-4를 도입)를 그대로 보존.
- **4b. GPS garbage**(accuracy > 50m 또는 `qualityDegraded===true`) + **lock 활성** → `'underground'` (hint `gps-garbage-underground`). `positionTrainBoardingLockMatch` 재활성 → 지하 device 자율 advance 복구.
- **4c. GPS garbage + lock 비활성** → `'unknown'` (보수적 — lock 근거 없이 underground 단정 안 함, urban canyon/non-trip 오탐 방지).

threshold는 기존 `GPS_DERIVED_ACCURACY_MAX_M`(50m) 재사용 — `gpsDerivedFastPath`와 동일 기준.

`positionTrainBoardingLockMatch`는 이미 `trainProgress.trainNo === lockedTrainCode`(lockMatch) 3-of-3 합의를 요구하므로, 새 'underground' 경로는 그 trainCode-match 게이트를 우회하지 않는다 — `useTrainCodeMismatchDetector`의 false-positive 가드는 그대로 유효.

## 변경 파일
- `src/features/nearest-station/utils/inferEnvironment.ts` — 우선순위-4 세분화 + doc 갱신
- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — `gpsAccuracyMeters`/`lockActive` 배선
- `src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts` — RED→GREEN + 회귀 lock-in 테스트 갱신
- `src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts` — caller-level RED→GREEN (dump 실측 accuracy=1395m)
- `src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsQualityGate.test.ts` — 회귀 lock-in 테스트 갱신 + 신규 케이스

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — DebugModal environment 라인 + 신규 hintReason `gps-garbage-underground` 노출.
3. **의존 PR** — 없음 (N/A, 프론트엔드/device 전용 로직).
4. **측정 plan** — 다음 지하 실탑승 dump에서 garbage GPS 구간의 environment 라벨이 `'underground'`로 찍히는지, 첫 알림 latency가 단축되는지 확인.
5. **Device verify** — 필요. 다음 지하 실탑승에서 검증 (사용자 책임, 본 PR은 type-check + unit(100%)만 검증됨).

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` — 468 suites / 9935 tests, 100% coverage pass
- [x] `npm run lint:orphan` — 0 orphan
- [x] `npx eslint` (변경 파일) — clean
- [ ] 실기기 지하 탑승 재검증 (사용자)

Closes #2468