### PR TITLE
feat(#2470): LA 인터랙티브 프롬프트 미탑승/아직이요 버튼 + intent 발사 진단 로그

### DIFF
--- a/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts
@@ -65,7 +65,9 @@ import {
 } from '../useLiveActivityIntentBridge';
 import {
   BOARDING_PROMPT_ACTION_BOARDED,
+  BOARDING_PROMPT_ACTION_NOT_BOARDED,
   DISEMBARK_ACTION_DISEMBARKED,
+  DISEMBARK_ACTION_NOT_YET,
 } from '../../utils/notificationCategory';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -100,6 +102,24 @@ const validDisembarkRaw = JSON.stringify({
   atMs: 200,
 });
 
+const validNotBoardedRaw = JSON.stringify({
+  id: 'trip-1-300',
+  tripToken: 'trip-1',
+  action: 'BOARDING_NOT_BOARDED',
+  originStation: '군자',
+  line: '5',
+  atMs: 300,
+});
+
+const validDisembarkNotYetRaw = JSON.stringify({
+  id: 'trip-1-400',
+  tripToken: 'trip-1',
+  action: 'DISEMBARK_NOT_YET',
+  originStation: '군자',
+  line: '5',
+  atMs: 400,
+});
+
 describe('parsePendingBoardingIntent', () => {
   it('유효한 JSON을 파싱한다', () => {
     expect(parsePendingBoardingIntent(validBoardedRaw)).toEqual({
@@ -114,6 +134,28 @@ describe('parsePendingBoardingIntent', () => {
 
   it('malformed JSON → null', () => {
     expect(parsePendingBoardingIntent('not-json{')).toBeNull();
+  });
+
+  it('BOARDING_NOT_BOARDED action을 파싱한다', () => {
+    expect(parsePendingBoardingIntent(validNotBoardedRaw)).toEqual({
+      id: 'trip-1-300',
+      tripToken: 'trip-1',
+      action: 'BOARDING_NOT_BOARDED',
+      originStation: '군자',
+      line: '5',
+      atMs: 300,
+    });
+  });
+
+  it('DISEMBARK_NOT_YET action을 파싱한다', () => {
+    expect(parsePendingBoardingIntent(validDisembarkNotYetRaw)).toEqual({
+      id: 'trip-1-400',
+      tripToken: 'trip-1',
+      action: 'DISEMBARK_NOT_YET',
+      originStation: '군자',
+      line: '5',
+      atMs: 400,
+    });
   });
 
   it('object가 아님 → null', () => {
@@ -210,6 +252,40 @@ describe('useLiveActivityIntentBridge', () => {
       expect.anything(),
     );
     expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-200');
+  });
+
+  it('BOARDING_NOT_BOARDED → handleResponse(NOT_BOARDED, hopEndKind=undefined) 호출 후 clear', async () => {
+    mockReadPendingBoardingIntent.mockReturnValue(validNotBoardedRaw);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledWith(
+      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      expect.objectContaining({
+        kind: 'boarding-prompt',
+        originStation: '군자',
+        line: '5',
+        tripToken: 'trip-1',
+        hopEndKind: undefined,
+      }),
+      expect.objectContaining({ ...baseDeps, createLock: mockCreateLock }),
+    );
+    expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-300');
+  });
+
+  it('DISEMBARK_NOT_YET → handleResponse(NOT_YET, hopEndKind=disembark) 호출 후 clear', async () => {
+    mockReadPendingBoardingIntent.mockReturnValue(validDisembarkNotYetRaw);
+    renderHook(() => useLiveActivityIntentBridge(baseDeps));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHandleResponse).toHaveBeenCalledWith(
+      DISEMBARK_ACTION_NOT_YET,
+      expect.objectContaining({ hopEndKind: 'disembark' }),
+      expect.anything(),
+    );
+    expect(mockClearPendingBoardingIntent).toHaveBeenCalledWith('trip-1-400');
   });
 
   it('clearPendingBoardingIntent 실패 → throw 없이 흡수', async () => {

--- a/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
+++ b/src/features/alarm/hooks/useLiveActivityIntentBridge.ts
@@ -42,7 +42,9 @@ import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import {
   BOARDING_PROMPT_ACTION_BOARDED,
+  BOARDING_PROMPT_ACTION_NOT_BOARDED,
   DISEMBARK_ACTION_DISEMBARKED,
+  DISEMBARK_ACTION_NOT_YET,
 } from '../utils/notificationCategory';
 import {
   handleResponse,
@@ -57,7 +59,7 @@ const log = createLogger('liveActivityIntentBridge');
 export interface PendingBoardingIntent {
   id: string;
   tripToken: string;
-  action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED';
+  action: 'BOARDING_BOARDED' | 'DISEMBARK_DISEMBARKED' | 'BOARDING_NOT_BOARDED' | 'DISEMBARK_NOT_YET';
   originStation: string;
   line: string;
   atMs: number;
@@ -66,7 +68,20 @@ export interface PendingBoardingIntent {
 const VALID_ACTIONS: readonly PendingBoardingIntent['action'][] = [
   'BOARDING_BOARDED',
   'DISEMBARK_DISEMBARKED',
+  'BOARDING_NOT_BOARDED',
+  'DISEMBARK_NOT_YET',
 ];
+
+/**
+ * #2470 — 알림 대칭 액션(미탑승/아직이요) 포함 4종 action → handleResponse 호출 파라미터
+ * data-driven 매핑(글로벌 규칙 3, 하드코딩 삼항 금지).
+ */
+const ACTION_MAP: Record<PendingBoardingIntent['action'], { actionIdentifier: string; hopEnd: boolean }> = {
+  BOARDING_BOARDED: { actionIdentifier: BOARDING_PROMPT_ACTION_BOARDED, hopEnd: false },
+  BOARDING_NOT_BOARDED: { actionIdentifier: BOARDING_PROMPT_ACTION_NOT_BOARDED, hopEnd: false },
+  DISEMBARK_DISEMBARKED: { actionIdentifier: DISEMBARK_ACTION_DISEMBARKED, hopEnd: true },
+  DISEMBARK_NOT_YET: { actionIdentifier: DISEMBARK_ACTION_NOT_YET, hopEnd: true },
+};
 
 /**
  * `readPendingBoardingIntent()`가 반환한 raw JSON 문자열을 파싱 + 검증한다.
@@ -134,18 +149,15 @@ async function processPendingBoardingIntent(deps: BridgeDeps): Promise<void> {
   if (intent.action === 'BOARDING_BOARDED' && isDuplicateBoardingIntent(intent)) {
     log.info('duplicate boarding intent — active lock already exists, no-op');
   } else {
+    const mapped = ACTION_MAP[intent.action];
     const payload: BoardingPromptPayload = {
       kind: 'boarding-prompt',
       originStation: intent.originStation,
       line: intent.line,
       tripToken: intent.tripToken,
-      hopEndKind: intent.action === 'DISEMBARK_DISEMBARKED' ? 'disembark' : undefined,
+      hopEndKind: mapped.hopEnd ? 'disembark' : undefined,
     };
-    const actionIdentifier =
-      intent.action === 'DISEMBARK_DISEMBARKED'
-        ? DISEMBARK_ACTION_DISEMBARKED
-        : BOARDING_PROMPT_ACTION_BOARDED;
-    await handleResponse(actionIdentifier, payload, deps);
+    await handleResponse(mapped.actionIdentifier, payload, deps);
   }
 
   try {

--- a/targets/subway-widget/Localizable.xcstrings
+++ b/targets/subway-widget/Localizable.xcstrings
@@ -262,6 +262,35 @@
         }
       }
     },
+    "widget.boardingPrompt.boarded.notBoarded.button" : {
+      "comment" : "Not boarded button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Didn't board"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗車していない"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미탑승"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未上车"
+          }
+        }
+      }
+    },
     "widget.boardingPrompt.disembark.question" : {
       "comment" : "Live Activity boarding/disembark confirmation prompt",
       "localizations" : {
@@ -316,6 +345,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已下车"
+          }
+        }
+      }
+    },
+    "widget.boardingPrompt.disembark.notYet.button" : {
+      "comment" : "Not yet disembark button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not yet"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まだ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직이요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还没"
           }
         }
       }

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -265,27 +265,51 @@ private struct BoardingPromptButton: View {
 
     var body: some View {
         if phase == "pre-boarding" {
-            Button(intent: BoardingConfirmIntent(
-                tripToken: state.boardingPromptTripToken ?? "",
-                originStation: state.boardingPromptOriginStation ?? "",
-                line: state.boardingPromptLine ?? ""
-            )) {
-                Text(NSLocalizedString("widget.boardingPrompt.boarded.button", comment: "Confirm boarding button label"))
-                    .font(.subheadline)
-                    .fontWeight(.bold)
+            VStack(spacing: 6) {
+                Button(intent: BoardingConfirmIntent(
+                    tripToken: state.boardingPromptTripToken ?? "",
+                    originStation: state.boardingPromptOriginStation ?? "",
+                    line: state.boardingPromptLine ?? ""
+                )) {
+                    Text(NSLocalizedString("widget.boardingPrompt.boarded.button", comment: "Confirm boarding button label"))
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                }
+                .tint(.white)
+
+                Button(intent: NotBoardedIntent(
+                    tripToken: state.boardingPromptTripToken ?? "",
+                    originStation: state.boardingPromptOriginStation ?? "",
+                    line: state.boardingPromptLine ?? ""
+                )) {
+                    Text(NSLocalizedString("widget.boardingPrompt.boarded.notBoarded.button", comment: "Not boarded button label"))
+                        .font(.subheadline)
+                }
+                .tint(.secondary)
             }
-            .tint(.white)
         } else {
-            Button(intent: DisembarkConfirmIntent(
-                tripToken: state.boardingPromptTripToken ?? "",
-                originStation: state.boardingPromptOriginStation ?? "",
-                line: state.boardingPromptLine ?? ""
-            )) {
-                Text(NSLocalizedString("widget.boardingPrompt.disembark.button", comment: "Confirm disembark button label"))
-                    .font(.subheadline)
-                    .fontWeight(.bold)
+            VStack(spacing: 6) {
+                Button(intent: DisembarkConfirmIntent(
+                    tripToken: state.boardingPromptTripToken ?? "",
+                    originStation: state.boardingPromptOriginStation ?? "",
+                    line: state.boardingPromptLine ?? ""
+                )) {
+                    Text(NSLocalizedString("widget.boardingPrompt.disembark.button", comment: "Confirm disembark button label"))
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                }
+                .tint(.white)
+
+                Button(intent: DisembarkNotYetIntent(
+                    tripToken: state.boardingPromptTripToken ?? "",
+                    originStation: state.boardingPromptOriginStation ?? "",
+                    line: state.boardingPromptLine ?? ""
+                )) {
+                    Text(NSLocalizedString("widget.boardingPrompt.disembark.notYet.button", comment: "Not yet disembark button label"))
+                        .font(.subheadline)
+                }
+                .tint(.secondary)
             }
-            .tint(.white)
         }
     }
 }

--- a/targets/subway-widget/_shared/BoardingIntents.swift
+++ b/targets/subway-widget/_shared/BoardingIntents.swift
@@ -28,6 +28,8 @@ private let PENDING_BOARDING_INTENT_KEY = "pendingBoardingIntent"
 private let intentLog = Logger(subsystem: "com.subwaynow.app.widget", category: "BoardingIntent")
 private let ACTION_BOARDING_BOARDED = "BOARDING_BOARDED"
 private let ACTION_DISEMBARK_DISEMBARKED = "DISEMBARK_DISEMBARKED"
+private let ACTION_BOARDING_NOT_BOARDED = "BOARDING_NOT_BOARDED"
+private let ACTION_DISEMBARK_NOT_YET = "DISEMBARK_NOT_YET"
 
 /// boardingPhase enum 값(모듈 index.ts LiveActivityData.boardingPhase 타입과 동일 어휘 사용).
 /// 'pre-boarding' → 탑승 확인 버튼 탭 → 'boarded'. 'hop-end' → 하차 확인 버튼 탭 → 'arrival'.
@@ -60,9 +62,10 @@ private func writePendingBoardingIntent(
 
 /// (a) 현재 추적 중인 Activity(들)의 boardingPhase를 즉시 전환 — 버튼 탭 즉시 시각 피드백.
 /// 아키텍처상 활성 Activity는 최대 1개(LiveActivityManager.endAllActivities)이므로 전수 update해도
-/// 안전하다.
+/// 안전하다. `nil`이면 프롬프트 배너를 즉시 숨긴다(미탑승/아직이요 — 아직 판단 유보라 boarded/arrival
+/// 어느 쪽으로도 전환하지 않고 LockScreenView.isBoardingPrompt를 false로 되돌린다).
 @available(iOS 17.0, *)
-private func markCurrentActivity(boardingPhase: String) async {
+private func markCurrentActivity(boardingPhase: String?) async {
     for activity in Activity<SubwayActivityAttributes>.activities {
         var state = activity.content.state
         state.boardingPhase = boardingPhase
@@ -145,6 +148,89 @@ struct DisembarkConfirmIntent: LiveActivityIntent {
         await markCurrentActivity(boardingPhase: PHASE_ARRIVAL)
         writePendingBoardingIntent(
             action: ACTION_DISEMBARK_DISEMBARKED,
+            tripToken: tripToken,
+            originStation: originStation,
+            line: line
+        )
+        return .result()
+    }
+}
+
+/// pre-boarding 단계 "미탑승" 버튼의 AppIntent — 알림 `BOARDING_PROMPT_ACTION_NOT_BOARDED`와 대칭
+/// (#2470). 프롬프트 배너만 즉시 닫고(boardingPhase=nil) 도메인 처리는 JS `handleResponse`에 위임.
+@available(iOS 17.0, *)
+struct NotBoardedIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "미탑승 확인"
+    static var isDiscoverable: Bool = false
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "tripToken")
+    var tripToken: String
+
+    @Parameter(title: "originStation")
+    var originStation: String
+
+    @Parameter(title: "line")
+    var line: String
+
+    init() {
+        self.tripToken = ""
+        self.originStation = ""
+        self.line = ""
+    }
+
+    init(tripToken: String, originStation: String, line: String) {
+        self.tripToken = tripToken
+        self.originStation = originStation
+        self.line = line
+    }
+
+    func perform() async throws -> some IntentResult {
+        intentLog.info("perform NOT_BOARDED tapped tripToken=\(tripToken, privacy: .public)")
+        await markCurrentActivity(boardingPhase: nil)
+        writePendingBoardingIntent(
+            action: ACTION_BOARDING_NOT_BOARDED,
+            tripToken: tripToken,
+            originStation: originStation,
+            line: line
+        )
+        return .result()
+    }
+}
+
+/// hop-end 단계 "아직이요" 버튼의 AppIntent — 알림 `DISEMBARK_ACTION_NOT_YET`와 대칭 (#2470).
+@available(iOS 17.0, *)
+struct DisembarkNotYetIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "아직 하차 안 함"
+    static var isDiscoverable: Bool = false
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "tripToken")
+    var tripToken: String
+
+    @Parameter(title: "originStation")
+    var originStation: String
+
+    @Parameter(title: "line")
+    var line: String
+
+    init() {
+        self.tripToken = ""
+        self.originStation = ""
+        self.line = ""
+    }
+
+    init(tripToken: String, originStation: String, line: String) {
+        self.tripToken = tripToken
+        self.originStation = originStation
+        self.line = line
+    }
+
+    func perform() async throws -> some IntentResult {
+        intentLog.info("perform DISEMBARK_NOT_YET tapped tripToken=\(tripToken, privacy: .public)")
+        await markCurrentActivity(boardingPhase: nil)
+        writePendingBoardingIntent(
+            action: ACTION_DISEMBARK_NOT_YET,
             tripToken: tripToken,
             originStation: originStation,
             line: line


### PR DESCRIPTION
Closes #2470

## 요약
8/31 실탑승 피드백: LA 탑승 프롬프트가 "탑승했어요"만 있고 미탑승 선택지가 없어 유령 알림 같음 + intent 발사 여부를 확인할 device 로그 부재. 알림(notification) 쪽은 이미 `BOARDING_PROMPT_ACTION_NOT_BOARDED`/`DISEMBARK_ACTION_NOT_YET` 대칭 액션이 존재 — LA에 native intent 2종 + 위젯 버튼 2개 + 브릿지 action 매핑만 추가해 대칭을 맞춘다. 새 도메인 로직 없이 기존 `handleResponse`(useBoardingPromptResponder.ts)의 미탑승/아직이요 경로에 위임만 한다.

## 변경 사항
- `targets/subway-widget/_shared/BoardingIntents.swift`: `NotBoardedIntent`/`DisembarkNotYetIntent` 신규(기존 intent 패턴 그대로 복제), `markCurrentActivity(boardingPhase:)` 파라미터를 `String?`로 옵셔널화(nil이면 프롬프트 배너 즉시 숨김). 기존 `intentLog`(os.Logger) 진단 로그는 이미 `BoardingConfirmIntent`/`DisembarkConfirmIntent` perform()에 존재해 재사용, 신규 intent에도 동일 패턴 적용.
- `targets/subway-widget/SubwayLiveActivityWidget.swift`: `BoardingPromptButton.body`를 VStack 2버튼(확인 버튼 + 미탑승/아직이요 버튼)으로 확장.
- `targets/subway-widget/Localizable.xcstrings`: `widget.boardingPrompt.boarded.notBoarded.button` / `widget.boardingPrompt.disembark.notYet.button` 키를 기존 `.boarded.button` 블록 포맷 그대로 미러링해 4개 언어(en/ja/ko/zh-Hans) 추가.
- `src/features/alarm/hooks/useLiveActivityIntentBridge.ts`: `PendingBoardingIntent['action']` 유니온에 `BOARDING_NOT_BOARDED`/`DISEMBARK_NOT_YET` 추가, data-driven `ACTION_MAP`으로 하드코딩 삼항 분기 제거(글로벌 규칙 3), 기존 `handleResponse` 재사용만(신규 lock/dismiss 로직 없음).
- `src/features/alarm/hooks/__tests__/useLiveActivityIntentBridge.test.ts`: 신규 액션 2종 파싱 + handleResponse 위임 테스트 추가, 커버리지 100% 유지.

## 스펙 대비 이탈
- 이슈 스펙은 `import os` 추가 + `logger` 신규 상수 생성을 요구했으나, 파일에 이미 `import os.log` + `intentLog`(subsystem/category 동일)가 존재하고 기존 두 intent의 perform() 맨 앞에 진단 로그도 이미 있었음(#2439/#2441에서 선행 구현됨). 중복 생성 대신 기존 `intentLog`를 그대로 재사용해 신규 intent 2종에도 동일 로그 패턴을 적용함 — 진단 로그라는 목적은 100% 충족.

## Wire-completion 5단
1. **Orphan 없음**: 신규 intent 2종은 `BoardingPromptButton`이 caller. JS `ACTION_MAP`은 `processPendingBoardingIntent`가 사용. `npm run lint:orphan` → 0 orphan 확인.
2. **V/X dashboard**: 버튼 발사 = `BoardingIntents.swift`의 `intentLog`(os.Logger, subsystem `com.subwaynow.app.widget` / category `BoardingIntent`) → device Console.app. JS 처리 = `liveActivityIntentBridge` logger + `handleResponse`의 `boarding_prompt_interactive_tap` breadcrumb(DebugModal).
3. **의존 PR**: N/A (backend는 이미 미탑승/아직이요 dismiss 처리 중).
4. **측정 plan**: 다음 실탑승 시 (a) LA에 미탑승/아직이요 버튼 노출 확인 (b) 미탑승 탭 → Console 로그 발사 확인 + 프롬프트 사라짐 확인 (c) breadcrumb `boarding_prompt_interactive_tap` action=`BOARDING_PROMPT_NOT_BOARDED` 확인.
5. **Device verify**: 필요 — iOS 17+ 실기기, LA 프롬프트에서 미탑승/아직이요 탭. 본 PR은 type+unit만 검증(코드-only 아님, native 변경 포함이라 device 검증 필수).

## 검증
- [x] `npm run type-check` pass
- [x] `npm test` 커버리지 100% pass (468 suites / 9939 tests)
- [x] `npm run lint` — 신규/수정 파일 0 error (pre-existing 12 errors는 본 PR과 무관한 기존 파일, before/after 동일 확인)
- [x] `npm run lint:orphan` 0 orphan