### PR TITLE
feat(#2474): position-train 발사 경로 false-사유 자가진단 로그

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -88,6 +88,7 @@ import {
   logCategoryRegistrationFailed,
   logBoardingPromptCategoryReceived,
   logBgTaskHeartbeat,
+  logPositionTrainFireDiagnostic,
   logBoardingPromptResponded,
   logCompanionAlarmFired,
   logLastTrainAlarmFired,
@@ -1597,6 +1598,108 @@ describe('alarmLog', () => {
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
       const matching = saved.filter((e) => e.source === 'bg-task-heartbeat');
       expect(matching).toHaveLength(3);
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: context 생략 시 기본값({})으로 적재한다', async () => {
+      logPositionTrainFireDiagnostic('skip-no-destination');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'skip-no-destination',
+      });
+      expect(saved[0].stationName).toBeUndefined();
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: skip-* reason은 source=bg, outcome=suppressed로 컨텍스트와 함께 적재한다', async () => {
+      logPositionTrainFireDiagnostic('skip-no-lock', { hasTrainCode: false });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'skip-no-lock',
+        hasTrainCode: false,
+      });
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: skip-poll-null은 anchorStationName을 stationName으로 적재한다', async () => {
+      logPositionTrainFireDiagnostic('skip-poll-null', { anchorStationName: '군자' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'skip-poll-null',
+        stationName: '군자',
+      });
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: skip-no-train-progress/skip-locked-gate는 candidatesCount를 적재한다', async () => {
+      logPositionTrainFireDiagnostic('skip-no-train-progress', {
+        anchorStationName: '군자',
+        candidatesCount: 2,
+      });
+      logPositionTrainFireDiagnostic('skip-locked-gate', {
+        anchorStationName: '군자',
+        candidatesCount: 1,
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved.filter((e) => e.reason === 'skip-no-train-progress')[0]).toMatchObject({
+        candidatesCount: 2,
+      });
+      expect(saved.filter((e) => e.reason === 'skip-locked-gate')[0]).toMatchObject({
+        candidatesCount: 1,
+      });
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: engaged(성공)는 outcome=received로 적재해 fired 분모를 오염하지 않는다', async () => {
+      logPositionTrainFireDiagnostic('engaged', { anchorStationName: '군자', candidatesCount: 1 });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'received',
+        reason: 'engaged',
+        stationName: '군자',
+        candidatesCount: 1,
+      });
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: 연속 동일 reason+station은 #1024 burst inline counter로 count++된다', async () => {
+      _resetBurstSuppressWindowForTests();
+      logPositionTrainFireDiagnostic('skip-poll-null', { anchorStationName: '군자' });
+      logPositionTrainFireDiagnostic('skip-poll-null', { anchorStationName: '군자' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'skip-poll-null');
+      expect(matching).toHaveLength(1);
+      expect(matching[0].count).toBe(2);
+    });
+
+    it('#2474 logPositionTrainFireDiagnostic: 다른 stationName의 연속 호출은 별개 entry로 적재한다', async () => {
+      _resetBurstSuppressWindowForTests();
+      logPositionTrainFireDiagnostic('skip-poll-null', { anchorStationName: '군자' });
+      logPositionTrainFireDiagnostic('skip-poll-null', { anchorStationName: '어린이대공원' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved.filter((e) => e.reason === 'skip-poll-null')).toHaveLength(2);
     });
 
     it('#2339 logSuppressedGate: different reasons are NOT deduped against each other', async () => {

--- a/src/features/alarm/utils/__tests__/bgPositionTrainFire.test.ts
+++ b/src/features/alarm/utils/__tests__/bgPositionTrainFire.test.ts
@@ -27,6 +27,11 @@ jest.mock('../notificationState', () => ({
   setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
 }));
 
+const mockLogPositionTrainFireDiagnostic = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logPositionTrainFireDiagnostic: (...args: unknown[]) => mockLogPositionTrainFireDiagnostic(...args),
+}));
+
 const mockIsMinimalAlarmEnabled = jest.fn();
 jest.mock('../../../../shared/constants/debugFlags', () => ({
   isMinimalAlarmEnabled: () => mockIsMinimalAlarmEnabled(),
@@ -154,6 +159,8 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    // #2474 — MINIMAL_ALARM flag-off는 비활성 사용자 전원 스팸 방지를 위해 진단 로그 미적재.
+    expect(mockLogPositionTrainFireDiagnostic).not.toHaveBeenCalled();
   });
 
   it('lock이 없으면 false를 반환한다', async () => {
@@ -163,6 +170,10 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockPollTrainPositionsIfDue).not.toHaveBeenCalled();
+    // #2474 — 진단 로그: lock 자체가 없는 케이스는 skip-no-lock.
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-no-lock', {
+      hasTrainCode: false,
+    });
   });
 
   it('lock.trainCode가 없으면 false를 반환한다', async () => {
@@ -172,6 +183,10 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockPollTrainPositionsIfDue).not.toHaveBeenCalled();
+    // #2474 — lock은 있으나 trainCode가 falsy(빈 문자열)면 skip-no-lock으로 분류.
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-no-lock', {
+      hasTrainCode: false,
+    });
   });
 
   // #2407 — pending lock(fallback lock, trainCode 미확정)은 이 정밀추적 경로를 skip해야
@@ -183,6 +198,10 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockPollTrainPositionsIfDue).not.toHaveBeenCalled();
+    // #2474 — trainCode는 존재하지만 pending sentinel인 케이스는 skip-pending-traincode로 분류.
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-pending-traincode', {
+      hasTrainCode: true,
+    });
   });
 
   it('isUndergroundProfile/wifiStation 게이트를 걸지 않는다 — profile 무관하게 진행', async () => {
@@ -200,6 +219,7 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockGetStationById).not.toHaveBeenCalled();
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-no-destination');
   });
 
   it('destination JSON 파싱 실패면 false를 반환한다', async () => {
@@ -208,6 +228,7 @@ describe('evaluatePositionTrainFire', () => {
     const result = await evaluatePositionTrainFire();
 
     expect(result).toBe(false);
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-bad-destination');
   });
 
   it('destination에 id가 없으면 false를 반환한다', async () => {
@@ -216,6 +237,7 @@ describe('evaluatePositionTrainFire', () => {
     const result = await evaluatePositionTrainFire();
 
     expect(result).toBe(false);
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-bad-destination');
   });
 
   it('route가 없으면 false를 반환한다(arc 계산 불가)', async () => {
@@ -230,6 +252,7 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockGetStationById).not.toHaveBeenCalled();
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-no-route');
   });
 
   it('탑승역 station lookup 실패 시 false를 반환한다', async () => {
@@ -239,6 +262,7 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockComputeRouteArc).not.toHaveBeenCalled();
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-no-origin');
   });
 
   it('arc가 비어있으면 false를 반환한다', async () => {
@@ -248,6 +272,9 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockPollTrainPositionsIfDue).not.toHaveBeenCalled();
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-empty-arc', {
+      anchorStationName: ORIGIN.name,
+    });
   });
 
   it('sleepJson이 저장되지 않았으면 sleepMode=false로 기본 처리한다', async () => {
@@ -317,6 +344,10 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockPickCandidateTrains).not.toHaveBeenCalled();
+    // #2474 — 지하 회귀 핵심 후보: 폴링 null(쿨다운 미경과/fetch 실패/빈 응답)을 skip-poll-null로 적재.
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-poll-null', {
+      anchorStationName: ORIGIN.name,
+    });
   });
 
   it('trackTrainProgress가 null이면(후보 없음) false를 반환한다', async () => {
@@ -326,6 +357,10 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-no-train-progress', {
+      anchorStationName: ORIGIN.name,
+      candidatesCount: 1,
+    });
   });
 
   it('lock 게이트를 통과 못 하면 false를 반환한다', async () => {
@@ -335,6 +370,10 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(false);
     expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('skip-locked-gate', {
+      anchorStationName: ORIGIN.name,
+      candidatesCount: 1,
+    });
   });
 
   it('userLocation 없이(GPS-free) lock.boardingLine으로 폴링하고 pickCandidateTrains/trackTrainProgress/lock 게이트를 순서대로 호출해 station 채택 시 true를 반환한다', async () => {
@@ -342,6 +381,11 @@ describe('evaluatePositionTrainFire', () => {
 
     expect(result).toBe(true);
     expect(mockPollTrainPositionsIfDue).toHaveBeenCalledWith(LOCK.boardingLine);
+    // #2474 — 성공(engaged) 대비군 stamp.
+    expect(mockLogPositionTrainFireDiagnostic).toHaveBeenCalledWith('engaged', {
+      anchorStationName: ORIGIN.name,
+      candidatesCount: 1,
+    });
     expect(mockPickCandidateTrains).toHaveBeenCalledWith(
       expect.objectContaining({
         positions: [LINE_POSITIONS],

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -414,7 +414,38 @@ export type AlarmLogReason =
   // 상태가 PAUSE_AUTO_END_MS(15분) 경과해 자동 종료된 1건. FG useCountdown 만료 /
   // cold-start rehydration backstop 두 진입점 공통 reason — source='lifecycle-backstop'로
   // 적재해 기존 backstop 계열과 같은 분포로 관측(fire 분모 제외 유지).
-  | 'trip-paused-auto-ended';
+  | 'trip-paused-auto-ended'
+  // #2474 (ADR-036 Phase 0 G0-1) — `evaluatePositionTrainFire`(#2383)의 각 false-return 지점 +
+  // 성공(true) 지점 진단 stamp. 순수 관측 — 반환값/게이트 로직/발사 판정 순서는 절대 변경하지
+  // 않는다. 2026-09-02 저녁 지하 return leg에서 이 경로가 계속 false를 반환한 원인(poll empty /
+  // realtimePosition 피드 드롭 / BG cadence skip / trainCode 매칭 실패 중 무엇인지)이 poll-레벨
+  // 로그 부재로 미확정이었다 — 다음 실탑승 dump가 이 reason 분포로 원인을 스스로 확정한다.
+  //   'skip-no-lock'           : lock 자체가 없음 (line 60).
+  //   'skip-pending-traincode' : lock은 있으나 trainCode가 fallback pending sentinel (line 60).
+  //   'skip-no-destination'    : DESTINATION_KEY 미존재 (line 63).
+  //   'skip-bad-destination'   : 목적지 JSON 파싱 실패 또는 id 없음 (line 70/78).
+  //   'skip-no-route'          : ROUTE_KEY 미존재 (line 89).
+  //   'skip-no-origin'         : lock.boardingStationId station lookup 실패 (line 92).
+  //   'skip-empty-arc'         : computeRouteArc 결과 arc.stations 0건 (line 96).
+  //   'skip-poll-null'         : realtimePosition 폴링 결과 null — 쿨다운 미경과(cadence) 또는
+  //                              fetch 실패/빈 응답(empty) 두 원인이 섞여 있음(line 112, 지하
+  //                              핵심 후보).
+  //   'skip-no-train-progress' : trackTrainProgress 매칭 실패 — candidate 없음/backward 등
+  //                              (line 125, 피드 드롭/매칭 실패 후보).
+  //   'skip-locked-gate'       : passesLockedStationGate 거부 — lock 노선/arc-window/forward-only
+  //                              (line 128).
+  //   'engaged'                : processLocationUpdate까지 완료한 성공 tick (line 146) — 대비군.
+  | 'skip-no-lock'
+  | 'skip-pending-traincode'
+  | 'skip-no-destination'
+  | 'skip-bad-destination'
+  | 'skip-no-route'
+  | 'skip-no-origin'
+  | 'skip-empty-arc'
+  | 'skip-poll-null'
+  | 'skip-no-train-progress'
+  | 'skip-locked-gate'
+  | 'engaged';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -496,6 +527,12 @@ export interface AlarmLogEntry {
   // currentHopIndex = D1 estimator/fallback이 결정한 SSOT hop, candidateIndex = arc 위 candidate 위치.
   currentHopIndex?: number;
   candidateIndex?: number;
+  // #2474 — position-train-fire 진단 stamp 컨텍스트.
+  // hasTrainCode: lock.trainCode 필드 자체의 존재 여부(falsy 문자열 포함 판정). pending
+  // sentinel인지 여부는 별도로 reason('skip-pending-traincode')이 구분한다.
+  // candidatesCount: pickCandidateTrains가 반환한 후보 열차 수 (매칭 실패 원인 분석용).
+  hasTrainCode?: boolean;
+  candidatesCount?: number;
 }
 
 /**
@@ -1667,6 +1704,53 @@ export function logBgTaskHeartbeat(location: AlarmLogLocation): void {
     source: 'bg-task-heartbeat',
     outcome: 'received',
     location,
+  });
+}
+
+/**
+ * #2474 (ADR-036 Phase 0 G0-1) — `evaluatePositionTrainFire`(#2383) false-return/성공 지점
+ * 진단 stamp. 순수 관측 — 호출자는 이 함수 호출로 반환값/게이트 로직을 바꾸지 않는다.
+ *
+ * `'engaged'`(성공)는 outcome='received'로 적재한다 — 실제 알람 발사 카운트(`FIRED_ALARM_SOURCES`
+ * 기준 outcome='fired')는 `processLocationUpdate` 내부 경로가 별도로 남기므로, 여기서 'fired'를
+ * 쓰면 같은 tick이 이중 집계된다. 나머지 `'skip-*'`는 outcome='suppressed'.
+ *
+ * `reason`을 채우므로 `appendAlarmLog`의 #1024 burst inline counter(연속 동일
+ * (source, reason, kind, phaseId, stationName)이면 새 entry 대신 count++)가 그대로 적용된다 —
+ * 같은 지점이 연속 tick 동안 막혀도 ring buffer를 점령하지 않으면서 count로 반복 빈도는 보존한다.
+ * 별도의 시간-윈도우 `isBurstDuplicate` 호출은 하지 않는다 — reason이 바뀌거나 anchorStationName이
+ * 달라지면(예: 열차가 실제로 이동) 곧바로 새 entry로 분리돼야 poll empty vs cadence skip vs
+ * 매칭 실패 지점 전환을 놓치지 않는다.
+ */
+export function logPositionTrainFireDiagnostic(
+  reason: Extract<
+    AlarmLogReason,
+    | 'skip-no-lock'
+    | 'skip-pending-traincode'
+    | 'skip-no-destination'
+    | 'skip-bad-destination'
+    | 'skip-no-route'
+    | 'skip-no-origin'
+    | 'skip-empty-arc'
+    | 'skip-poll-null'
+    | 'skip-no-train-progress'
+    | 'skip-locked-gate'
+    | 'engaged'
+  >,
+  context: {
+    anchorStationName?: string | null;
+    hasTrainCode?: boolean;
+    candidatesCount?: number;
+  } = {},
+): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg',
+    outcome: reason === 'engaged' ? 'received' : 'suppressed',
+    reason,
+    stationName: context.anchorStationName ?? undefined,
+    hasTrainCode: context.hasTrainCode,
+    candidatesCount: context.candidatesCount,
   });
 }
 

--- a/src/features/alarm/utils/bgPositionTrainFire.ts
+++ b/src/features/alarm/utils/bgPositionTrainFire.ts
@@ -11,6 +11,7 @@ import { getBoardingLock } from './boardingLockStorage';
 import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 import { getFiredAlarms } from './notificationState';
 import { persistBgFireResult } from './bgFirePersist';
+import { logPositionTrainFireDiagnostic } from './alarmLog';
 import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 import { passesLockedStationGate } from '../../nearest-station/utils/lockedStationGate';
 import { pollTrainPositionsIfDue } from '../../nearest-station/tasks/bgPositionTrainPoll';
@@ -57,16 +58,25 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
   // #2407 — trainCode pending(fallback lock, 미확정) 상태에서는 이 경로(realtimePosition 정밀추적)를
   // skip한다. pending sentinel을 실 trainCode처럼 매칭에 넣으면 항상 미매칭이라 false negative만
   // 쌓인다 — 호출자(backgroundLocationTask)가 기존 GPS/route 파이프라인으로 graceful degrade.
-  if (!lock?.trainCode || isPendingTrainCode(lock.trainCode)) return false;
+  if (!lock?.trainCode || isPendingTrainCode(lock.trainCode)) {
+    void logPositionTrainFireDiagnostic(!lock?.trainCode ? 'skip-no-lock' : 'skip-pending-traincode', {
+      hasTrainCode: !!lock?.trainCode,
+    });
+    return false;
+  }
 
   const destJson = await AsyncStorage.getItem(DESTINATION_KEY);
-  if (!destJson) return false;
+  if (!destJson) {
+    void logPositionTrainFireDiagnostic('skip-no-destination');
+    return false;
+  }
 
   let destinationRaw: unknown;
   try {
     destinationRaw = JSON.parse(destJson);
   } catch {
     logger.error('목적지 JSON 파싱 실패');
+    void logPositionTrainFireDiagnostic('skip-bad-destination');
     return false;
   }
   if (
@@ -75,6 +85,7 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
     typeof (destinationRaw as { id?: unknown }).id !== 'string'
   ) {
     logger.error('목적지에 id가 없음');
+    void logPositionTrainFireDiagnostic('skip-bad-destination');
     return false;
   }
   const destination = destinationRaw as Station;
@@ -86,14 +97,23 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
   ]);
   const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
   const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
-  if (!storedRoute) return false;
+  if (!storedRoute) {
+    void logPositionTrainFireDiagnostic('skip-no-route');
+    return false;
+  }
 
   const origin = getStationById(lock.boardingStationId);
-  if (!origin) return false;
+  if (!origin) {
+    void logPositionTrainFireDiagnostic('skip-no-origin');
+    return false;
+  }
 
   const arc = computeRouteArc(storedRoute, origin, destination);
   const arcStations = arc?.stations ?? [];
-  if (arcStations.length === 0) return false;
+  if (arcStations.length === 0) {
+    void logPositionTrainFireDiagnostic('skip-empty-arc', { anchorStationName: origin.name });
+    return false;
+  }
 
   // pickCandidateTrains anchor — BG_LAST_STATION(진행한 마지막 확인 역)이 있으면 그 역,
   // 없으면 탑승역. anchorStationName은 window(±3역, DEFAULT_WINDOW_STATIONS) 후보 필터링에만
@@ -109,7 +129,10 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
   }
 
   const positions = await pollTrainPositionsIfDue(lock.boardingLine);
-  if (!positions) return false;
+  if (!positions) {
+    void logPositionTrainFireDiagnostic('skip-poll-null', { anchorStationName });
+    return false;
+  }
 
   const candidates = pickCandidateTrains({
     positions: [positions],
@@ -122,10 +145,22 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
     segmentStations: arcStations,
     boardingStationId: lock.boardingStationId,
   });
-  if (!trainProgress) return false;
+  if (!trainProgress) {
+    void logPositionTrainFireDiagnostic('skip-no-train-progress', {
+      anchorStationName,
+      candidatesCount: candidates.length,
+    });
+    return false;
+  }
 
   const { currentStation } = trainProgress;
-  if (!passesLockedStationGate(currentStation, lock, arcStations)) return false;
+  if (!passesLockedStationGate(currentStation, lock, arcStations)) {
+    void logPositionTrainFireDiagnostic('skip-locked-gate', {
+      anchorStationName,
+      candidatesCount: candidates.length,
+    });
+    return false;
+  }
 
   const firedAlarms = await getFiredAlarms(destination.id);
   const { alarmEvent, nearest } = await processLocationUpdate({
@@ -142,6 +177,11 @@ export async function evaluatePositionTrainFire(): Promise<boolean> {
   });
 
   await persistBgFireResult({ alarmEvent, nearest, destination, firedAlarms, storedRoute });
+
+  void logPositionTrainFireDiagnostic('engaged', {
+    anchorStationName,
+    candidatesCount: candidates.length,
+  });
 
   return true;
 }


### PR DESCRIPTION
## Summary

Closes #2474

ADR-036 Phase 0 축1(G0-1) — `evaluatePositionTrainFire`(#2383, gate-free 발사 경로)의 각 false-return 지점 + 성공(true) 지점에 진단 로그를 순수 additive로 삽입한다. 2026-09-02 저녁 지하 return leg에서 이 경로가 계속 `false`를 반환해 engage하지 못하고 gate-accuracy 경로로 fall해 지하 도착 miss가 발생했다 — 원인 후보(poll empty / realtimePosition 피드 드롭 / BG cadence skip / trainCode 매칭 실패)가 poll-레벨 로그 부재로 미확정이었다. 이 PR은 관측 인프라만 추가한다.

- `src/features/alarm/utils/bgPositionTrainFire.ts`: `evaluatePositionTrainFire`의 모든 false-return 지점(`skip-no-lock` / `skip-pending-traincode` / `skip-no-destination` / `skip-bad-destination` / `skip-no-route` / `skip-no-origin` / `skip-empty-arc` / `skip-poll-null` / `skip-no-train-progress` / `skip-locked-gate`) + 성공 return(`engaged`) 직전에 `void logPositionTrainFireDiagnostic(...)` 호출을 삽입. **반환값/게이트 로직/발사 판정 순서는 완전히 동일** — return 문 자체는 무수정, 로그 호출만 추가.
- `src/features/alarm/utils/alarmLog.ts`: `logPositionTrainFireDiagnostic` 함수 + 11개 신규 `AlarmLogReason` + `AlarmLogEntry.hasTrainCode`/`candidatesCount` 컨텍스트 필드 추가. `engaged`는 `outcome='received'`로 적재해 실제 알람 발사 카운트(`FIRED_ALARM_SOURCES`)와 이중 집계되지 않게 한다. `reason`을 채우므로 기존 `#1024` burst inline counter가 그대로 적용돼 연속 동일 지점 반복은 ring buffer를 점령하지 않고 count로 흡수된다.
- `MINIMAL_ALARM` flag-off return(line 55)에는 로그 **미추가** — 이슈 명시 요구사항(비활성 사용자 전원 스팸 방지).
- poll null(line 112 상당)은 단일 `skip-poll-null` 사유로 유지 — `pollWithCooldown.ts`는 arrival API 폴러와 공유하는 범용 헬퍼라 cadence-skip/fetch-empty 세분화는 이 PR 범위 밖으로 두었다(이슈가 명시한 선택 사항).

## Test plan

- [x] `npm test` — 468 suites / 9946 tests pass, coverage 100%(lines/functions/branches/statements)
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — No orphan exports detected
- [x] code-review 에이전트 실행 — "Ready to commit" (반환값/제어흐름 보존 확인, MINIMAL_ALARM 미로깅 확인, 테스트가 mock 검증 + 실제 로거 동작 검증 이중 계층으로 견고함을 확인)

## Wire-completion 5단

1. **Orphan 없음**: 신규 export `logPositionTrainFireDiagnostic`는 `bgPositionTrainFire.ts`가 즉시 caller. `npm run lint:orphan` pass.
2. **V/X dashboard**: DebugModal Alarm Log Reasons 섹션(device 로컬 로그) — 다음 실탑승 dump에서 `skip-*`/`engaged` reason 분포를 관측한다.
3. **의존 PR**: N/A (ADR-036 PR #2473은 문서, 코드 의존 아님).
4. **측정 plan**: 다음 평범한 지하 탑승 dump에서 `evaluatePositionTrainFire` false 사유 분포를 확인해 poll empty / cadence skip / 매칭 실패 중 어느 것이 근본 원인인지 확정 → G0-2 hardening 타겟팅.
5. **Device verify**: N/A — type+unit only. 로그 삽입 자체는 동작 불변(코드 리뷰 + 테스트로 검증 완료), 로그 **내용**은 다음 실탑승에서 사용자가 확인(이 PR의 관측 목적 그 자체).
