### PR TITLE
feat(#2476): FG arvlCd fast-path 게이트를 arvlCd 확증으로 대체 (G0-3a)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3647,7 +3647,12 @@ describe('useStationAlarm', () => {
       expect(mockGetBoardingLock).not.toHaveBeenCalled();
     });
 
-    it('movement gate 차단(speed=0) → fast path 발사 X + logSuppressedMovement(fg-arvlcd)', async () => {
+    // #2476 (G0-3a) 이전엔 movement gate(speed=0)가 fg-arvlcd 경로를 'movement-static-speed'로
+    // 억제했다. arvlCd 확증(signal) 자체가 이미 강한 ground-truth이므로 이제 movement gate는
+    // fg-arvlcd 경로에서 항상 우회된다 — 이 케이스는 station-level dedup(lastNotifiedStationId
+    // 기존값과 동일)이 대신 fast path를 차단한다. GPS station-passed effect('fg' source)는
+    // 본 이슈 스코프 밖이라 speed=0 movement 억제가 여전히 별도로 발생한다.
+    it('#2476 movement gate 우회(arvlCd 확증) 이후 speed=0 → fast path는 dedup으로 차단(발사 X)', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock);
       mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
@@ -3655,14 +3660,7 @@ describe('useStationAlarm', () => {
       renderHook(() => useStationAlarm(fastPathInputs({ speedMps: 0 })));
 
       await waitFor(() =>
-        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
-          expect.objectContaining({
-            source: 'fg-arvlcd',
-            stationName: onRouteStation.name,
-            kind: 'station-passed',
-            reason: 'movement-static-speed',
-          }),
-        ),
+        expect(mockLogSuppressedDedupStation).toHaveBeenCalledWith('fg-arvlcd', onRouteStation),
       );
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
@@ -3693,30 +3691,59 @@ describe('useStationAlarm', () => {
       );
     });
 
-    // 회귀 가드: subsurfaceStationDetected=false(합의 없음, 진짜 정적 사용자)면 기존처럼
-    // 정적 misfire 가드가 그대로 억제한다 — 통과 열차 momentary adopt 등 false positive 방어 유지.
-    it('#2364 회귀 가드 — subsurfaceStationDetected=false(합의 없음) + speed=0 → 여전히 억제', async () => {
+    // #2476 (G0-3a, ADR-036 Phase 0 축2) — 9/2 저녁 덤프 replay(건대→용마산 leg).
+    // 지하 garbage GPS(acc~2500m, speed=0 정적)에서 barometer flip으로 subsurfaceStationDetected가
+    // false로 떨어져도, findFgArvlCdFireSignal 확증(lock.trainCode 일치 + arvlCd∈{0,1})이 이미
+    // 강한 ground-truth이므로 movement gate를 우회해 발사해야 한다. #2364 시점엔
+    // subsurfaceStationDetected만이 우회 조건이라 이 케이스가 오억제됐다(RED) — 우회 조건을
+    // "subsurfaceStationDetected || arvlCd 확증(signal)"으로 확장해 발사(GREEN)한다.
+    it('#2476 G0-3a — subsurfaceStationDetected=false(barometer flip) + speed=0(garbage GPS) + arvlCd 확증 → movement gate 우회 발사', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock);
-      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
 
       renderHook(() =>
         useStationAlarm(
-          fastPathInputs({ speedMps: 0, subsurfaceStationDetected: false }),
+          fastPathInputs({
+            speedMps: 0,
+            accuracyMeters: 2500,
+            subsurfaceStationDetected: false,
+          }),
         ),
       );
 
       await waitFor(() =>
-        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
-          expect.objectContaining({
-            source: 'fg-arvlcd',
-            stationName: onRouteStation.name,
-            kind: 'station-passed',
-            reason: 'movement-static-speed',
-          }),
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id),
+      );
+      expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'fg-arvlcd' }),
+      );
+    });
+
+    // G0-4 오발사 방어 (지상 정상 정지 회귀 겸용) — arvlCd 확증(signal) 자체가 없으면(lock
+    // 부재/trainCode 불일치)위 우회는 적용되지 않고 억제가 그대로 유지된다.
+    // findFgArvlCdFireSignal이 null이면 `if (!signal) return`으로 movement 게이트 이전에 이미
+    // 차단되므로(#640), accuracyMeters(지상 정상치 10 vs 지하 garbage 2500)와 무관하게 항상
+    // 같은 경로로 억제된다 — "지상 정상 정지" 회귀 케이스는 이 경로의 subset이라 별도 분기 없이
+    // 여기서 함께 검증한다(리뷰 지적: 두 케이스가 accuracyMeters만 다르고 동일 코드 경로를
+    // 실행해 중복이었음).
+    it('#2476 G0-4 — arvlCd 확증 없음(signal null) → subsurfaceStationDetected/accuracy 무관 항상 억제(지상 정상 정지 포함)', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue(null);
+
+      renderHook(() =>
+        useStationAlarm(
+          fastPathInputs({ speedMps: 0, accuracyMeters: 10, subsurfaceStationDetected: false }),
         ),
       );
+
+      await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
+      await Promise.resolve();
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+      expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'fg-arvlcd' }),
+      );
     });
 
     it('dismiss silence 활성 시 fast path 발사 X + logSuppressedDismissSilence(fg-arvlcd)', async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -1525,7 +1525,8 @@ export function useStationAlarm({
   //   4. nearestStation이 route 상에 있음 (off-route 신호 무시)
   //   5. lock 존재 + lock.trainCode == row.trainCode + arvlCd∈{0,1} (findFgArvlCdFireSignal — #640 회귀 가드)
   //   6. dismiss silence 미적용
-  //   7. movement gate(speed/accuracy/static) 통과
+  //   7. movement gate(speed/accuracy/static) — #2476 (G0-3a) 이후 이 fast-path는 5번 가드
+  //      (signal 확증) 자체가 movement gate보다 강한 ground-truth이므로 항상 우회한다.
   //   8. lastNotifiedStationId 미일치 (GPS station-passed와 dedup 공유 — 한 station에 한 알람)
   //
   // dedup 정책: lastNotifiedStationId 단일 출처. 기존 station-passed effect와 같은 키를 사용해
@@ -1559,22 +1560,18 @@ export function useStationAlarm({
       // #727/#728/#733 — 정적 misfire 가드. arvlCd 신호가 강해도 정적 사용자(speed=0) 발사는
       // 잘못된 trainCode lock 케이스 (fusion이 통과 열차를 momentary adopt)에서 위험.
       // movement gate는 silence gate보다 먼저 평가 — 정적 사용자면 silence 만료 부수효과도 불필요.
-      // #2364 (ADR-033 A5) — subsurfaceStationDetected=true는 useFusedNearestStation이 이미
-      // subsurface(지하 진입 확정) + ≥2 신호 합의(barometer-stop/motion-stationary/arvlcd-arrived) +
-      // 역 근접 게이트를 통과시킨 상태. 지하 GPS 사멸로 speed/positionStability가 불명(motion-warmup/
-      // static-position 등)일 뿐인데 정적 misfire 가드가 이미 간접 확인된 이동을 오억제하는 회귀
-      // 차단 — trainProgressing(#1401)과 동일한 취지의 우회. false positive 방어(통과 열차
-      // momentary adopt)는 lock.trainCode 일치(findFgArvlCdFireSignal)가 1차로 이미 담당하고,
-      // subsurfaceStationDetected 자체도 근접 게이트를 포함해 GPS 좌표 기반 지하 추정과는 무관하다.
-      if (movementSuppressionReason && !subsurfaceStationDetected) {
-        logSuppressedMovement({
-          source: 'fg-arvlcd',
-          stationName: candidateStation.name,
-          kind: 'station-passed',
-          reason: movementSuppressionReason,
-        });
-        return;
-      }
+      // #2364 (ADR-033 A5) — subsurfaceStationDetected=true(지하 진입 확정 + ≥2 신호 합의 +
+      // 근접 게이트 통과)면 movement gate를 우회했다. 지하 GPS 사멸로 speed/positionStability가
+      // 불명(motion-warmup/static-position 등)일 뿐인데 정적 misfire 가드가 이미 간접 확인된
+      // 이동을 오억제하는 회귀 차단 — trainProgressing(#1401)과 동일한 취지.
+      // #2476 (G0-3a, ADR-036 Phase 0 축2) — 9/2 저녁 덤프: 지하 garbage GPS(정지 좌표)에서
+      // barometer flip으로 subsurfaceStationDetected가 false로 떨어지면 위 우회가 적용되지 않아
+      // 오억제됐다(용마산/군자/중곡). 그러나 이 시점에 도달했다는 것 자체가 이미 `signal`
+      // non-null(lock 존재 + lock.trainCode 일치 + arvlCd∈{0,1} 확증, #640 회귀 가드, :1556-1557)을
+      // 의미하는 강한 ground-truth이므로, movement gate는 subsurfaceStationDetected 여부와
+      // 무관하게 항상 우회한다 — "게이트 제거"가 아니라 "arvlCd 확증으로 대체". G0-4 오발사
+      // 방어: 확증(signal) 자체가 없으면 :1557에서 이미 return되어 이 지점에 도달하지 않으므로
+      // lock 부재/trainCode 불일치/arvlCd 무효 시 기존 억제는 그대로 보존된다.
 
       // #1266 (Epic #1204 D2 follow-up) — fast-path에도 hop window 게이트 적용.
       // 2026-06-12 22:31 회귀: GPS station-passed effect는 D2(#1208) 게이트로 차단됐으나
@@ -1660,9 +1657,8 @@ export function useStationAlarm({
     nearestStation?.name,
     nearestStation?.line,
     currentStationArrival,
-    movementSuppressionReason,
-    // #2364 — subsurfaceStationDetected 변화 시 movement gate 우회 여부 재평가.
-    subsurfaceStationDetected,
+    // #2476 (G0-3a) — movement gate가 arvlCd 확증 시 항상 우회되어 movementSuppressionReason/
+    // subsurfaceStationDetected를 더 이상 이 effect 본문에서 읽지 않는다 (재평가 불필요, dep 제거).
     dismissSilence,
     clearDismissSilenceAction,
     userLocation?.lat,


### PR DESCRIPTION
Closes #2476

## 요약

FG arvlCd fast-path의 movement-static/speed 억제 게이트를 arvlCd 확증으로 대체 (ADR-036 Phase 0 축2 / G0-3a).

9/2 저녁 지하 leg(건대→용마산) 덤프 확정: `movement-static-position` 억제가 최대 17회 발생해 용마산/군자/중곡 도착 발사가 0건이었다. 지하 garbage GPS(acc 2500m급, speed 0 정적)에서 barometer flip으로 `subsurfaceStationDetected`가 false로 떨어지면 기존 우회 조건(`subsurfaceStationDetected`만)이 적용되지 않아 오억제됐다. 그러나 이 지점(FG arvlcd fast-path의 movement 체크)에 도달했다는 것 자체가 이미 `findFgArvlCdFireSignal` non-null(lock 존재 + `lock.trainCode` 일치 + `arvlCd∈{0,1}` 확증, #640 회귀 가드)을 의미하는 강한 ground-truth이므로, movement gate를 `subsurfaceStationDetected` 여부와 무관하게 우회하도록 변경했다.

**"게이트 제거"가 아니라 "arvlCd 확증으로 대체"** — signal이 null(lock 부재/trainCode 불일치/arvlCd 무효)이면 상단 `if (!signal) return`에서 이미 함수가 종료되어 이 우회는 절대 적용되지 않는다. 즉 확증 없는 케이스의 기존 억제는 완전히 보존된다(G0-4).

## 변경

- `src/features/alarm/hooks/useStationAlarm.ts`
  - FG arvlCd fast-path(~:1556-1574)의 `if (movementSuppressionReason && !subsurfaceStationDetected)` 억제 블록 제거. `signal`이 이 시점에 항상 non-null임이 구조적으로 보장되므로(상단 early-return), 조건을 남겨두면 항상-false인 dead branch가 되어 100% branch coverage를 깰 수 있어 블록 자체를 제거하고 주석으로 이유를 명시.
  - 해당 effect의 deps 배열에서 `movementSuppressionReason`/`subsurfaceStationDetected` 제거 (더 이상 effect 본문에서 읽지 않음 — 다른 effect들은 각자 독립 deps 배열로 영향 없음).
  - JSDoc 가드 목록 주석 갱신.
- `src/features/alarm/hooks/__tests__/useStationAlarm.test.ts`
  - RED→GREEN: 9/2 재현 fixture (garbage GPS acc=2500m, speed=0, `subsurfaceStationDetected=false`, arvlCd 확증) — 수정 전 억제(RED) 확인 후 수정, 발사(GREEN) 확인.
  - G0-4 negative: `findFgArvlCdFireSignal` null(확증 없음) → subsurfaceStationDetected/accuracy와 무관하게 항상 억제 (지상 정상 정지 회귀 케이스 겸용).
  - 기존 `movement gate 차단(speed=0)` 테스트를 새 동작(움직임 게이트 우회 후 dedup으로 차단)에 맞게 재정합.

## 스코프 아웃 (이슈에 코멘트로 별도 기록: https://github.com/handokei/subway-now/issues/2476#issuecomment-5509469630)

- **G0-3b (hop-window-no-source)**: 코드 확인 결과 FG/FG-arvlcd 경로의 `effectiveHopIndex < 0`(no-source) 케이스는 기존에도 로그만 남기고 return하지 않는 pass-through(#1266 graceful fallback, 기존 테스트로 이미 검증됨). 우회할 억제가 실재하지 않아 구현하지 않음(구현 시 순수 no-op / dead code가 됨).
- **BG destination gate-hop-window**: `backgroundLocationTask.ts`에 이슈가 가정한 동일 게이트 코드 자체가 존재하지 않음(grep 확인).

## Wire-completion 5단

1. **Orphan**: `useStationAlarm.ts` 내부 로직 수정만, 신규 export 없음. `npm run lint:orphan` pass.
2. **V/X dashboard**: DebugModal alarmLog — 지하 leg에서 `movement-static-position` 억제 카운트가 감소하고 해당 station-passed가 `fired`(또는 dedup)로 전환되는지 다음 지하 탑승 dump에서 확인.
3. **의존 PR**: ADR-036 PR #2473(문서). 코드 의존 N/A.
4. **측정 plan**: 다음 지하 탑승 dump에서 (a) `movement-static-position` source=`fg-arvlcd` 억제가 더 이상 발생하지 않는지, (b) 용마산류 도착이 정상 발사(`setLastNotifiedStationId` 호출)되는지 확인. 동시에 오발사(확증 없는 케이스의 fire) 0건인지 dedup/SSoT 로그로 교차 검증.
5. **Device verify**: 🔴 **실기기 지하 필수** — 억제게이트 우회는 오발사 리스크가 있는 high-risk 변경. CI(RED→GREEN fixture + negative)로 로직은 확정했으나, 실기기 지하 1주 재탑승에서 (a) 9/2류 미발사 재발 0건, (b) 오발사(확증 없는데 발사) 0건 둘 다 확인 필요.

## 검증

- `npm test`: 468 suites / 9940 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check`: pass (no errors)
- `npm run lint:orphan`: no orphan exports
- 커밋 전 code-review 에이전트 실행 — no blockers. should-fix(코멘트 프레이밍 명확화)/nit(중복 테스트 통합) 반영 완료.
