### PR TITLE
feat(#2478): BG hopWindowGate에 active-lock 배선 — 지하 다역 전진 오차단 차단

### DIFF
--- a/src/features/alarm/utils/__tests__/stationPipeline.hopWindowLockBypass.dumpReplay.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.hopWindowLockBypass.dumpReplay.test.ts
@@ -1,0 +1,185 @@
+/**
+ * #2478 — hopWindowGate(#2373)에 active lock을 배선해 지하 다역 전진 오차단을 막는 red→green
+ * fixture. 덤프 근거(~/Downloads/텍스트-B9182EBB56F8-1.txt, 2026-09-02 저녁, 7호선 건대입구→용마산):
+ *
+ *   - lock 17:14:14 autolock-success, origin=건대입구, destination=용마산, trainCode=실코드.
+ *   - firedAlarms(이 trip)=비어있음 — 17:14~22 중간역(어린이대공원/군자/중곡) station-passed가
+ *     전부 억제돼 BG hop 추적 기준점(`BG_HOP_WINDOW_STATION_KEY`)이 origin(건대입구)에 stuck.
+ *   - GPS: 지하 garbage 후 17:22:27 용마산서 20m로 지상 복귀 → gap=4 hop > windowSize(1) →
+ *     `evaluateBgHopWindowGate`가 `blocked` 반환 → destination 발사 억제(#2478 발견 근본).
+ *
+ * 하네스: `bgPositionTrainFire.dumpReplay.e2eFire.test.ts`(#2400) 패턴 — `processLocationUpdate`는
+ * mock 없이 실체인 구동. leaf만 mock(getBoardingLock, AsyncStorage in-memory, expo-notifications,
+ * logger). storedRoute는 실제 findRoute(건대입구→용마산, 7호선)로 명시 배선해 결정성 확보
+ * (spike는 route 미전달로 내부 findRoute 유도에 의존 — 이 fixture는 명시 배선으로 대체).
+ *
+ * 게이트 통과 ≠ 발사(#2400 교훈) — 이 fixture는 게이트 판정이 아니라 fireLocalAlarmNotification
+ * 도달까지 assert한다.
+ */
+process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+
+const storage = new Map<string, string>();
+
+const mockGetItem = jest.fn((key: string) =>
+  Promise.resolve(storage.has(key) ? storage.get(key)! : null),
+);
+const mockSetItem = jest.fn((key: string, value: string) => {
+  storage.set(key, value);
+  return Promise.resolve();
+});
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: [string]) => mockGetItem(...args),
+  setItem: (...args: [string, string]) => mockSetItem(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+}));
+
+const mockFireLocalAlarmNotification = jest.fn().mockResolvedValue(undefined);
+jest.mock('../stationNotification', () => {
+  const actual = jest.requireActual('../stationNotification');
+  return {
+    ...actual,
+    fireLocalAlarmNotification: (...args: unknown[]) => mockFireLocalAlarmNotification(...args),
+  };
+});
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('id'),
+  dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  getAllScheduledNotificationsAsync: jest.fn().mockResolvedValue([]),
+  cancelScheduledNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  getPresentedNotificationsAsync: jest.fn().mockResolvedValue([]),
+  setNotificationHandler: jest.fn(),
+  AndroidNotificationPriority: { MAX: 5 },
+  AndroidImportance: { HIGH: 4, MAX: 5, DEFAULT: 3 },
+  AndroidNotificationVisibility: { PUBLIC: 1 },
+  SchedulableTriggerInputTypes: { DATE: 'date' },
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { processLocationUpdate } from '../stationPipeline';
+import { findRoute, findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { _resetCrossCategoryDedupForTests } from '../crossCategoryStationDedup';
+import { BG_HOP_WINDOW_STATION_KEY } from '../../../../shared/constants/storageKeys';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
+
+const BOARDING_LINE = '7';
+const ORIGIN = findStationByNameAndLine('건대입구', BOARDING_LINE)!;
+const DESTINATION = findStationByNameAndLine('용마산', BOARDING_LINE)!;
+const STORED_ROUTE = findRoute(ORIGIN.id, DESTINATION.id);
+const LOCK_TRAIN_CODE = '2026090201';
+const REAL_LOCK = {
+  destinationId: DESTINATION.id,
+  trainCode: LOCK_TRAIN_CODE,
+  boardingStationId: ORIGIN.id,
+  boardingLine: BOARDING_LINE,
+  boardedAt: 0,
+  expectedDurationMs: 600_000,
+};
+
+async function runFinalTick() {
+  return processLocationUpdate({
+    lat: DESTINATION.lat,
+    lng: DESTINATION.lng,
+    destination: DESTINATION,
+    firedAlarms: new Set<string>(),
+    sleepMode: false,
+    storedRoute: STORED_ROUTE,
+    source: 'bg',
+    fusionSource: 'gps',
+  });
+}
+
+describe('processLocationUpdate 실체인 — #2478 hopWindowGate active-lock bypass (9/2 저녁 용마산 재현)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage.clear();
+    _resetCrossCategoryDedupForTests();
+    mockFireLocalAlarmNotification.mockResolvedValue(undefined);
+    // 덤프 재현: 중간역 station-passed가 전부 억제돼 BG hop 추적 기준점이 origin(건대입구)에 stuck.
+    storage.set(
+      BG_HOP_WINDOW_STATION_KEY,
+      JSON.stringify({ destinationId: DESTINATION.id, station: ORIGIN }),
+    );
+  });
+
+  it('lock 활성 + 실 trainCode + forward 전진 → hop window gap(4) 우회, destination 발사', async () => {
+    mockGetBoardingLock.mockResolvedValue(REAL_LOCK);
+
+    const result = await runFinalTick();
+
+    expect(mockFireLocalAlarmNotification).toHaveBeenCalled();
+    expect(result.alarmEvent?.type).toBe('destination');
+  });
+
+  it('#2373 방어 negative — lock 없음이면 gap(4)은 여전히 차단(오발사 0)', async () => {
+    mockGetBoardingLock.mockResolvedValue(null);
+
+    // hopWindowGate 차단은 fireLocalAlarmNotification 미호출로만 관측된다 — alarmEvent 자체는
+    // evaluateAlarmPhase가 게이트와 무관하게 항상 계산하므로(#2400 교훈: 게이트 통과≠발사),
+    // suppress 여부의 유일한 관측 지점은 발사 호출이다.
+    await runFinalTick();
+
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('#2373 방어 negative — lock.trainCode가 PENDING(미확정)이면 gap(4)은 여전히 차단', async () => {
+    mockGetBoardingLock.mockResolvedValue({ ...REAL_LOCK, trainCode: PENDING_TRAIN_CODE });
+
+    await runFinalTick();
+
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('#2373 방어 negative — lock은 있으나 candidate가 locked route arc 밖(같은 노선, 목적지 너머 이탈)이면 여전히 차단', async () => {
+    mockGetBoardingLock.mockResolvedValue(REAL_LOCK);
+    // 기준점을 목적지 바로 앞(중곡, forward 정상 진행 중)으로 두고, 최종 tick을 같은 노선(7호선)
+    // 이지만 origin→destination arc 밖(용마산 너머 상봉 방향)으로 대체 — line은 같아 조기
+    // early-return(#2373 "방금 환승" 경로)을 우회하지 않으면서 arc forward-only 판정 자체가
+    // candidateArcIndex=-1(off-route)로 차단하는지 검증한다.
+    const NEAR_DEST = findStationByNameAndLine('중곡', BOARDING_LINE)!;
+    storage.set(
+      BG_HOP_WINDOW_STATION_KEY,
+      JSON.stringify({ destinationId: DESTINATION.id, station: NEAR_DEST }),
+    );
+    const OFF_ROUTE = findStationByNameAndLine('상봉', BOARDING_LINE)!;
+
+    await processLocationUpdate({
+      lat: OFF_ROUTE.lat,
+      lng: OFF_ROUTE.lng,
+      destination: DESTINATION,
+      firedAlarms: new Set<string>(),
+      sleepMode: false,
+      storedRoute: STORED_ROUTE,
+      source: 'bg',
+      fusionSource: 'gps',
+    });
+
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('회귀 — 정상 근거리 hop(gap=1)은 기존대로 통과(우회 로직과 무관하게 불변)', async () => {
+    mockGetBoardingLock.mockResolvedValue(REAL_LOCK);
+    const NEAR_DEST = findStationByNameAndLine('중곡', BOARDING_LINE)!; // 용마산 직전역, gap=1
+    storage.set(
+      BG_HOP_WINDOW_STATION_KEY,
+      JSON.stringify({ destinationId: DESTINATION.id, station: NEAR_DEST }),
+    );
+
+    const result = await runFinalTick();
+
+    expect(mockFireLocalAlarmNotification).toHaveBeenCalled();
+    expect(result.alarmEvent?.type).toBe('destination');
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -20,6 +20,7 @@ const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
 const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
 const mockGetRouteRemainingSeconds = jest.fn((..._args: unknown[]) => 360);
 const mockGetStationsOnLine = jest.fn((..._args: unknown[]) => [] as Station[]);
+const mockGetStationById = jest.fn((..._args: unknown[]) => undefined as Station | undefined);
 jest.mock('../../../../shared/utils/stationRoute', () => {
   // #2373 — computeHopWindowSize/isStationWithinHopWindow/arcIndexOf/LOCKLESS_HOP_WINDOW_DEFAULT는
   // FG(useStationAlarm) 검증 로직을 그대로 재사용하는 게이트라 실제 구현을 requireActual로 통과시킨다.
@@ -35,12 +36,22 @@ jest.mock('../../../../shared/utils/stationRoute', () => {
     // #2279 — processLocationUpdate가 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
     getRouteRemainingSeconds: (...args: unknown[]) => mockGetRouteRemainingSeconds(...args),
     getStationsOnLine: (...args: unknown[]) => mockGetStationsOnLine(...args),
+    // #2478 — evaluateBgHopWindowGate의 lock-확증 forward 우회가 lock.boardingStationId로 origin을
+    // 조회할 때 사용. mock으로 undefined/유효 station 양쪽 분기를 제어한다.
+    getStationById: (...args: unknown[]) => mockGetStationById(...args),
     arcIndexOf: actual.arcIndexOf,
     computeHopWindowSize: actual.computeHopWindowSize,
     isStationWithinHopWindow: actual.isStationWithinHopWindow,
     LOCKLESS_HOP_WINDOW_DEFAULT: actual.LOCKLESS_HOP_WINDOW_DEFAULT,
   };
 });
+
+// #2478 — isLockConfirmedForwardHop이 route 방향대로 정렬된 arc를 얻기 위해 재사용하는 함수.
+// bgPositionTrainFire.test.ts와 동일하게 mock으로 arc 반환값을 직접 제어(null/빈 배열/정상 등).
+const mockComputeRouteArc = jest.fn();
+jest.mock('../../../route/utils/routeProgress', () => ({
+  computeRouteArc: (...args: unknown[]) => mockComputeRouteArc(...args),
+}));
 
 const mockGetBgHopWindowStation = jest.fn();
 const mockSetBgHopWindowStation = jest.fn();
@@ -205,6 +216,10 @@ describe('processLocationUpdate', () => {
     mockGetBgHopWindowStation.mockResolvedValue(null);
     mockSetBgHopWindowStation.mockResolvedValue(undefined);
     mockGetStationsOnLine.mockReturnValue([]);
+    // #2478 — 기본은 lock-확증 우회 대상 자체가 없는 상태(getStationById undefined / arc 없음).
+    // 각 lock-bypass 테스트가 필요한 값으로 override한다.
+    mockGetStationById.mockReturnValue(undefined);
+    mockComputeRouteArc.mockReturnValue(null);
   });
 
   it('returns null nearest and null alarm when findNearestStation returns null', async () => {
@@ -1488,6 +1503,128 @@ describe('processLocationUpdate', () => {
       await call();
 
       expect(mockGetBgHopWindowStation).not.toHaveBeenCalled();
+    });
+  });
+
+  // #2478 (ADR-036 Phase 0 G0-3c) — active lock이 forward 전진을 확증하면 #2373 hop-window
+  // 차단을 우회한다. 지하 구간에서 중간역 tick이 gate-accuracy로 evaluateBgHopWindowGate 자체에
+  // 도달하지 못해 기준(prevStation)이 origin에 stuck된 채 GPS가 지상 복귀하면(큰 gap), lock이
+  // 실 trainCode로 확증한 forward 전진만 신뢰해 발사를 되살린다. lock 부재/PENDING/
+  // destinationId mismatch/역행/off-route는 기존 #2373 차단 그대로 유지(오발사 방어).
+  describe('#2478 hop-window 게이트 lock-확증 forward 우회', () => {
+    const lineStationA: Station = { id: 'l7-a', name: 'A역', line: '7', lineColor: '#747F00', lat: 37.50, lng: 127.02 };
+    const lineStationB: Station = { id: 'l7-b', name: 'B역', line: '7', lineColor: '#747F00', lat: 37.51, lng: 127.03 };
+    const lineStationC: Station = { id: 'l7-c', name: 'C역', line: '7', lineColor: '#747F00', lat: 37.52, lng: 127.04 };
+    const lineStationD: Station = { id: 'l7-d', name: 'D역', line: '7', lineColor: '#747F00', lat: 37.53, lng: 127.05 };
+    const lineStations = [lineStationA, lineStationB, lineStationC, lineStationD];
+    const activeLock = {
+      destinationId: mockDestination.id,
+      trainCode: 'REAL-TRAIN-CODE',
+      boardingStationId: lineStationA.id,
+      boardingLine: '7' as const,
+      boardedAt: 0,
+      expectedDurationMs: 600_000,
+    };
+
+    beforeEach(() => {
+      // 기준(index 1) 대비 2 hop 이상 앞선 candidate(index 3) — hop-window 자체는 항상 blocked.
+      mockGetStationsOnLine.mockReturnValue(lineStations);
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: '시청',
+      });
+      mockGetBgHopWindowStation.mockResolvedValue(lineStationB); // 기준 = index 1
+      mockFindNearestStation.mockReturnValue({ station: lineStationD, distanceKm: 0.1 }); // candidate = index 3
+      // lock이 forward 확증하는 정상 경로: origin(lineStationA)부터 candidate까지 순서대로 정렬된 arc.
+      mockGetStationById.mockReturnValue(lineStationA);
+      mockComputeRouteArc.mockReturnValue({
+        stations: [lineStationA, lineStationB, lineStationC, lineStationD],
+      });
+    });
+
+    it('lock 활성 + 실 trainCode + forward 전진 → 우회해 발사하고 candidate를 새 기준으로 저장한다', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
+      expect(mockSetBgHopWindowStation).toHaveBeenCalledWith(mockDestination.id, lineStationD);
+    });
+
+    it('lock.trainCode가 PENDING(미확정)이면 우회하지 않고 기존대로 차단한다', async () => {
+      mockGetBoardingLock.mockResolvedValue({ ...activeLock, trainCode: 'PENDING-TRAIN-CODE' });
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+      expect(mockSetBgHopWindowStation).not.toHaveBeenCalled();
+    });
+
+    it('lock.destinationId가 이번 trip destination과 다르면(stale lock) 우회하지 않는다', async () => {
+      mockGetBoardingLock.mockResolvedValue({ ...activeLock, destinationId: 'other-destination' });
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('lock.boardingStationId로 origin을 찾지 못하면(getStationById undefined) 우회하지 않는다', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetStationById.mockReturnValue(undefined);
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('computeRouteArc가 null이면(arc 계산 불가) 우회하지 않는다', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockComputeRouteArc.mockReturnValue(null);
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('arc가 빈 배열이면 우회하지 않는다', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockComputeRouteArc.mockReturnValue({ stations: [] });
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('arc에 기준/candidate station이 없으면(off-route) 우회하지 않는다', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      const offRouteArcStation: Station = { id: 'l2-x', name: 'X역', line: '2', lineColor: '#009246', lat: 37.55, lng: 127.06 };
+      mockComputeRouteArc.mockReturnValue({ stations: [offRouteArcStation] });
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('candidate가 arc상 기준보다 역행(역방향)이면 우회하지 않는다', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      // arc 순서를 뒤집어(candidate가 기준보다 앞선 index) 역행으로 재현.
+      mockComputeRouteArc.mockReturnValue({
+        stations: [lineStationD, lineStationC, lineStationB, lineStationA],
+      });
+
+      await call();
+
+      expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -7,7 +7,9 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
-import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition, getStationsOnLine, arcIndexOf, computeHopWindowSize, isStationWithinHopWindow } from '../../../shared/utils/stationRoute';
+import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition, getStationsOnLine, arcIndexOf, computeHopWindowSize, isStationWithinHopWindow, getStationById } from '../../../shared/utils/stationRoute';
+import { computeRouteArc } from '../../route/utils/routeProgress';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 import { isInTripByEvidence } from '../../../shared/utils/boardingWait';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { updateStationNotification, fireLocalAlarmNotification, fireFgAuxStationPassedNotification } from './stationNotification';
@@ -47,6 +49,7 @@ import { clearDismissSilence, getDismissSilence } from './dismissSilenceStorage'
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { AlarmEvent } from './stationAlarm';
 import type { FusionSource } from '../../../shared/types/fusion';
 import { resolveNotificationSource } from './notificationSource';
@@ -237,17 +240,47 @@ export interface ProcessLocationInputs {
  * windowSize 동적 확장도 동일하게 적용된다.
  *
  * 반환:
- *   - null: 게이트 미적용(기준 없음 / 방금 환승 / arc 인덱스 미발견) — candidate를 새 기준으로 채택.
+ *   - null: 게이트 미적용(기준 없음 / 방금 환승 / arc 인덱스 미발견 / lock 확증 우회) — candidate를
+ *     새 기준으로 채택.
  *   - { blocked: true, ... }: hop window 밖 — 기준 station 유지(overwrite 안 함), caller가 이번
  *     tick의 phase 알람 발사만 suppress한다. candidate 자체(route/notification)는 계속 갱신된다
  *     (FG와 동일 — hop window는 "발사"만 가드, "현재 위치 추정"은 가드하지 않음).
+ *
+ * #2478 (ADR-036 Phase 0 G0-3c) — lock 확증 forward 전진 우회.
+ *
+ * 배경: 지하 구간에서 GPS accuracy 게이트(gate-accuracy)로 중간역 tick 자체가 이 함수 호출까지
+ * 못 미쳐(evaluateBgHopWindowGate가 아예 호출 안 됨) prevStation(기준점)이 origin(탑승역)에
+ * stuck된 채 GPS가 지상 복귀하면, 정당한 다역 전진(예: gap=4)도 GPS drift와 구분 못 하고 그대로
+ * 차단된다(2026-09-02 저녁 건대입구→용마산 evidence, `fireLocalAlarmNotification` 미호출).
+ *
+ * 이 함수는 lock/trainCode/arvlCd 신호를 원래 입력받지 않아(#2373 최초 설계, destinationId/
+ * candidateStation/route뿐) drift와 정당 전진을 구분할 수 없었다 — active lock이 이미 확증한
+ * trainCode(실코드, PENDING sentinel 아님)가 있으면 그 신뢰를 이 게이트에도 배선한다.
+ *
+ * 우회 조건 (#2373 방어 유지 — 아래 중 하나라도 미충족이면 기존 차단 그대로):
+ *   1. lock 활성 (`lockForLineGuard`는 `processLocationUpdate`가 이미 fetch — 재조회 안 함)
+ *   2. lock.trainCode가 실코드(`!isPendingTrainCode`) — fallback lock(미확정)은 신뢰 못 함(#2407과
+ *      동일 취지, `evaluatePositionTrainFire`가 pending을 skip하는 것과 동일 가드)
+ *   3. lock.destinationId === destinationId — 다른 trip의 stale lock 오매칭 방지
+ *   4. candidate가 locked 경로 forward 전진 — `computeRouteArc(route, origin, destination)`로
+ *      route 방향대로 정렬된 arc(bgPositionTrainFire.ts와 동일 패턴, `getStationsOnLine`의
+ *      raw 노선 전체 순서와 달리 환승 포함 실제 trip 진행 방향)에서 prevStation → candidateStation
+ *      인덱스가 감소하지 않아야 한다. off-route(arc 밖, 노선 이탈) 또는 역행(인덱스 감소)이면
+ *      우회하지 않는다 — 이게 #2373 원취지(GPS drift 조기 발사) 방어의 핵심.
+ *
+ * `passesLockedStationGate`(#2383)를 그대로 재사용하지 않는 이유: 그 함수의
+ * `LOCK_NEXT_HOP_WINDOW`(±3 hop)는 position-train candidate 선별용 좁은 창으로, 이 evidence
+ * 케이스(탑승역 기준 4 hop 밖 목적지)조차 차단해 이 fix의 목적과 충돌한다. 이 게이트는 이미
+ * hop-window 자체가 정상 진행을 별도로 bound하므로, lock 확증 우회는 "방향"만 검증하면 된다.
  */
 async function evaluateBgHopWindowGate(params: {
   destinationId: string;
+  destination: Station;
   candidateStation: Station;
   route: Route;
+  lock: BoardingLock | null;
 }): Promise<{ blocked: true; currentHopIndex: number; candidateIndex: number } | null> {
-  const { destinationId, candidateStation, route } = params;
+  const { destinationId, destination, candidateStation, route, lock } = params;
   const prevStation = await getBgHopWindowStation(destinationId);
   if (!prevStation || prevStation.line !== candidateStation.line) {
     // 기준 없음(첫 tick) 또는 방금 환승선 전환 — 게이트 미적용, candidate를 새 기준으로 채택.
@@ -269,7 +302,46 @@ async function evaluateBgHopWindowGate(params: {
     return null;
   }
 
+  if (
+    lock &&
+    lock.destinationId === destinationId &&
+    !isPendingTrainCode(lock.trainCode) &&
+    isLockConfirmedForwardHop(prevStation, candidateStation, lock, route, destination)
+  ) {
+    await setBgHopWindowStation(destinationId, candidateStation);
+    return null;
+  }
+
   return { blocked: true, currentHopIndex, candidateIndex };
+}
+
+/**
+ * #2478 — prevStation → candidateStation이 lock 경로 방향으로 forward 전진인지(off-route/역행
+ * 아닌지) 판정. `computeRouteArc`가 route 방향대로 정렬한 arc를 재사용해 방향을 확정한다
+ * (`getStationsOnLine`의 raw 노선 순서는 진행 방향과 무관해 직접 비교 불가).
+ */
+function isLockConfirmedForwardHop(
+  prevStation: Station,
+  candidateStation: Station,
+  lock: BoardingLock,
+  route: Route,
+  destination: Station,
+): boolean {
+  // 방어적 가드 — lock.boardingStationId는 계약상 항상 실존 Station.id지만(BoardingLock 계약),
+  // station 데이터 drift/malformed route 대비로 명시 처리한다(#2478, bgPositionTrainFire.ts와
+  // 동일 취지의 graceful degrade — 우회 실패 시 기존 #2373 차단 유지).
+  const origin = getStationById(lock.boardingStationId);
+  if (!origin) return false;
+
+  const arc = computeRouteArc(route, origin, destination);
+  const arcStations = arc?.stations ?? [];
+  if (arcStations.length === 0) return false;
+
+  const prevIndex = arcStations.findIndex((s) => s.id === prevStation.id);
+  const candidateArcIndex = arcStations.findIndex((s) => s.id === candidateStation.id);
+  if (prevIndex === -1 || candidateArcIndex === -1) return false;
+
+  return candidateArcIndex >= prevIndex;
 }
 
 export async function processLocationUpdate(inputs: ProcessLocationInputs): Promise<PipelineResult> {
@@ -321,8 +393,10 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   const hopWindowGate = route
     ? await evaluateBgHopWindowGate({
         destinationId: destination.id,
+        destination,
         candidateStation: nearest.station,
         route,
+        lock: lockForLineGuard,
       })
     : null;
 


### PR DESCRIPTION
## 요약

Closes #2478

`evaluateBgHopWindowGate`(#2373 게이트, `stationPipeline.ts`)는 지하 구간에서 GPS accuracy 게이트로 중간역 tick 자체가 이 함수에 도달하지 못해 기준점(prevStation)이 탑승역(origin)에 stuck된 채로, GPS가 지상 복귀 시점에 큰 hop gap을 GPS drift와 구분 못 하고 그대로 차단해 정당한 도착 알림까지 억제했다(2026-09-02 저녁 건대입구→용마산 evidence, `fireLocalAlarmNotification` 미호출).

이 PR은 `evaluateBgHopWindowGate`에 active lock(`processLocationUpdate`가 이미 fetch한 `lockForLineGuard` 재사용, 재조회 없음)을 배선해, lock이 **forward 전진을 확증**한 경우에만 차단을 우회한다.

## 변경

- `evaluateBgHopWindowGate`에 `destination`/`lock` 파라미터 추가.
- 신규 `isLockConfirmedForwardHop` — `computeRouteArc(route, origin, destination)`(bgPositionTrainFire.ts와 동일 패턴)로 route 방향대로 정렬된 arc에서 prevStation→candidateStation 인덱스가 감소하지 않는지(forward, off-route 아님) 판정.
- 우회 조건(전부 충족 시에만): lock 활성 + `lock.destinationId` 일치 + `!isPendingTrainCode(lock.trainCode)`(실코드) + `isLockConfirmedForwardHop`.
- `passesLockedStationGate`(#2383)를 직접 재사용하지 않음 — 그 함수의 `LOCK_NEXT_HOP_WINDOW`(±3 hop)는 이 evidence 케이스(탑승역 기준 4 hop 밖 목적지)조차 차단해 목적과 충돌.

## #2373 방어 (오발사 0 유지)

lock 부재 / `trainCode` PENDING(미확정) / `destinationId` mismatch / 역행(backward) / off-route(arc 밖)는 **기존 차단 그대로** — negative fixture 4종 + mocked 단위 테스트 6종으로 검증.

## Red→Green 증거

`stationPipeline.hopWindowLockBypass.dumpReplay.test.ts` — `bgPositionTrainFire.dumpReplay.e2eFire.test.ts` 패턴(mock 없이 `processLocationUpdate` 실체인 구동, leaf만 mock). storedRoute는 실제 `findRoute(건대입구, 용마산, 7호선)`로 명시 배선.

- **수정 전 실행 결과(RED, 확인됨)**: 주 시나리오 1개 FAIL — `fireLocalAlarmNotification` 0회 호출(`Expected number of calls: >= 1, Received number of calls: 0`), negative/회귀 4개는 이미 PASS(수정 전에도 차단 유지가 맞는 동작이므로).
- **수정 후(GREEN)**: 5개 전부 PASS — 주 시나리오는 `fireLocalAlarmNotification` 호출 + `alarmEvent.type === 'destination'` 확인.

추가로 `stationPipeline.test.ts`에 mocked 단위 테스트 8종(우회 성공 1 + negative 7: PENDING trainCode/destinationId mismatch/origin 미발견/arc null/arc 빈 배열/off-route/역행)을 더해 `isLockConfirmedForwardHop`의 방어적 분기까지 100% 커버리지로 검증(코드 리뷰 피드백 반영 — 처음엔 `istanbul ignore`로 우회했다가 실제 도달 가능한 경로임을 확인해 정식 테스트로 교체).

## 알려진 리스크 (device verify에서 확인 필요)

우회 판정은 **방향(forward)만** 검증하고 이동 거리(magnitude)는 bound하지 않는다 — lock이 활성이고 실 trainCode가 있는 상태에서 GPS가 목적지 방향으로 크게 drift하면(원 #2373이 막던 조기 오발사 모드) 우회될 수 있다. 이슈 스펙(lock 확증 forward 전진 시 우회)대로 구현했으며, 실기기 1주 검증으로 이 리스크가 실현되는지 확인 필요.

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass. `evaluateBgHopWindowGate`/`isLockConfirmedForwardHop`은 파일 내부 전용(export 없음), 신규 export 없음.
2. **V/X dashboard**: DebugModal alarmLog — `gate-hop-window` suppressed 이벤트가 사라지고 `destination` fired 이벤트로 전환되는지 다음 지하 탑승 dump로 확인.
3. **의존 PR**: 없음(N/A) — #2477(G0-3a) 독립, 병행 가능. ADR-036 #2473(문서)은 컨텍스트 참조용.
4. **측정 plan**: 다음 지하 탑승(건대입구→용마산류 다역 지하 구간)에서 destination 알림 발사 여부 확인. 이 PR의 red fixture가 CI에서 상시 회귀 가드로 남는다.
5. **Device verify**: 🔴 실기기 지하 필수 — 게이트 우회는 오발사 리스크가 있는 변경(위 "알려진 리스크" 참조). red fixture로 로직은 확정했으나, 실기기 1주 동안 (a) 용마산류 지하 다역 전진 시나리오에서 정상 발사, (b) 오발사(#2373 재발) 0건 둘 다 확인 필요.

## 테스트

- `npm test` — 469 suites / 9952 tests pass, coverage 100%(statements/branches/functions/lines).
- `npm run type-check` — pass.
- `npm run lint:orphan` — pass.
- code-review 에이전트 리뷰 반영(istanbul ignore → 실제 테스트로 교체, 잔여 리스크는 PR 본문에 명시).