### PR TITLE
feat(#2480): waypoint arvlCd 직폴 BG 발사 spine — 지하+취침 자동알림 척추

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -89,6 +89,7 @@ import {
   logBoardingPromptCategoryReceived,
   logBgTaskHeartbeat,
   logPositionTrainFireDiagnostic,
+  logWaypointArvlcdFireDiagnostic,
   logBoardingPromptResponded,
   logCompanionAlarmFired,
   logLastTrainAlarmFired,
@@ -1700,6 +1701,62 @@ describe('alarmLog', () => {
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
       expect(saved.filter((e) => e.reason === 'skip-poll-null')).toHaveLength(2);
+    });
+
+    it('#2480 logWaypointArvlcdFireDiagnostic: context 생략 시 기본값({})으로 적재한다', async () => {
+      logWaypointArvlcdFireDiagnostic('skip-no-destination');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'skip-no-destination',
+      });
+      expect(saved[0].stationName).toBeUndefined();
+    });
+
+    it('#2480 logWaypointArvlcdFireDiagnostic: skip-* reason은 source=bg, outcome=suppressed로 컨텍스트와 함께 적재한다', async () => {
+      logWaypointArvlcdFireDiagnostic('skip-no-lock', { hasTrainCode: false });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'skip-no-lock',
+        hasTrainCode: false,
+      });
+    });
+
+    it('#2480 logWaypointArvlcdFireDiagnostic: skip-not-imminent은 waypointName을 stationName으로 적재한다', async () => {
+      logWaypointArvlcdFireDiagnostic('skip-not-imminent', { waypointName: '용마산' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'suppressed',
+        reason: 'skip-not-imminent',
+        stationName: '용마산',
+      });
+    });
+
+    it('#2480 logWaypointArvlcdFireDiagnostic: engaged(성공)는 outcome=received로 적재해 fired 분모를 오염하지 않는다', async () => {
+      logWaypointArvlcdFireDiagnostic('engaged', { waypointName: '용마산' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'bg',
+        outcome: 'received',
+        reason: 'engaged',
+        stationName: '용마산',
+      });
     });
 
     it('#2339 logSuppressedGate: different reasons are NOT deduped against each other', async () => {

--- a/src/features/alarm/utils/__tests__/bgWaypointArvlcdFire.dumpReplay.e2eFire.test.ts
+++ b/src/features/alarm/utils/__tests__/bgWaypointArvlcdFire.dumpReplay.e2eFire.test.ts
@@ -1,0 +1,238 @@
+/**
+ * #2480 — 2026-09-02 저녁 직행(건대입구→용마산, 7호선) RED→GREEN 재현.
+ *
+ * 배경: 그날 저녁 garbage GPS(지하 drift, ~2500m 오차)로 `#2383`(evaluatePositionTrainFire,
+ * realtimePosition 열차 매칭)이 트랙 후보를 못 찾아 매 tick false를 반환했고, GPS accuracy
+ * 게이트도 실패해 gate-accuracy 강등 분기(#2381 consensus)로만 빠졌다 — 그 경로 역시 WiFi
+ * 매칭 실패로 발사하지 못해 용마산 도착 알림이 0건이었다.
+ *
+ * 이 spine(`evaluateWaypointArvlcdFire`)은 GPS/WiFi/열차위치매칭 전부 무관하게 "내 목적지(다음
+ * waypoint)에 내 열차가 도착하나"만 arvlCd로 직접 확인한다 — lock에 real trainCode가 있고
+ * 목적지 arvlCd가 ENTERING/ARRIVED로 응답하면 GPS 상태와 완전히 독립적으로 발사한다.
+ *
+ * REAL(mock 금지): `processLocationUpdate`(stationPipeline 전체, `bgPositionTrainFire.
+ * dumpReplay.e2eFire.test.ts`와 동일 취지 — 발사 함수 도달까지 실체인 검증), `resolveAllTargets`/
+ * `alarmKey`(stationAlarm), `isImminentByArrivalCode`(arrival), `pollWaypointArrivalIfDue`/
+ * `pollWithCooldown`(제네릭 쿨다운 skeleton), `findStationByNameAndLine`/`getStationById`
+ * (stationRoute, 실제 stations.json).
+ *
+ * mock 대상(leaf, `bgPositionTrainFire.dumpReplay.e2eFire.test.ts`와 동일 원칙 — 인프라 경계 +
+ * 발사 여부 assert 대상만):
+ *   - `getBoardingLock`(boardingLockStorage)
+ *   - AsyncStorage — in-memory Map
+ *   - `createArrivalProvider`(arrival provider factory) — 네트워크 fetch 경계
+ *   - `fireLocalAlarmNotification`(stationNotification) — 발사 여부 spy
+ *   - `saveStationToWidget`(widgetStorage)
+ *   - `expo-notifications` — 네이티브 SDK 경계
+ *   - logger
+ */
+process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+
+const storage = new Map<string, string>();
+
+const mockGetItem = jest.fn((key: string) =>
+  Promise.resolve(storage.has(key) ? storage.get(key)! : null),
+);
+const mockSetItem = jest.fn((key: string, value: string) => {
+  storage.set(key, value);
+  return Promise.resolve();
+});
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: [string]) => mockGetItem(...args),
+  setItem: (...args: [string, string]) => mockSetItem(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+}));
+
+const mockGetArrival = jest.fn();
+jest.mock('../../../arrival/providers/factory', () => ({
+  createArrivalProvider: () => ({ getArrival: (...args: unknown[]) => mockGetArrival(...args) }),
+}));
+
+const mockSaveStationToWidget = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../widget/api/widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
+  clearWidgetStation: jest.fn().mockResolvedValue(undefined),
+}));
+
+// leaf: 발사 여부를 spy로 assert. 같은 모듈의 다른 export는 real 유지.
+const mockFireLocalAlarmNotification = jest.fn().mockResolvedValue(undefined);
+jest.mock('../stationNotification', () => {
+  const actual = jest.requireActual('../stationNotification');
+  return {
+    ...actual,
+    fireLocalAlarmNotification: (...args: unknown[]) => mockFireLocalAlarmNotification(...args),
+  };
+});
+
+// 인프라 경계 — 네이티브 SDK.
+const mockScheduleNotificationAsync = jest.fn().mockResolvedValue('id');
+const mockDismissNotificationAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllScheduledNotificationsAsync = jest.fn().mockResolvedValue([]);
+const mockCancelScheduledNotificationAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetPresentedNotificationsAsync = jest.fn().mockResolvedValue([]);
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: (...args: unknown[]) => mockScheduleNotificationAsync(...args),
+  dismissNotificationAsync: (...args: unknown[]) => mockDismissNotificationAsync(...args),
+  getAllScheduledNotificationsAsync: (...args: unknown[]) =>
+    mockGetAllScheduledNotificationsAsync(...args),
+  cancelScheduledNotificationAsync: (...args: unknown[]) =>
+    mockCancelScheduledNotificationAsync(...args),
+  getPresentedNotificationsAsync: (...args: unknown[]) =>
+    mockGetPresentedNotificationsAsync(...args),
+  setNotificationHandler: jest.fn(),
+  AndroidNotificationPriority: { MAX: 5 },
+  AndroidImportance: { HIGH: 4, MAX: 5, DEFAULT: 3 },
+  AndroidNotificationVisibility: { PUBLIC: 1 },
+  SchedulableTriggerInputTypes: { DATE: 'date' },
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { evaluateWaypointArvlcdFire } from '../bgWaypointArvlcdFire';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
+import { _resetCrossCategoryDedupForTests } from '../crossCategoryStationDedup';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+import {
+  DESTINATION_KEY,
+  SLEEP_MODE_KEY,
+  ROUTE_KEY,
+  ALARM_EVENT_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+// 2026-09-02 저녁 직행 evidence — 건대입구(7-212) 탑승 → 용마산(7-211) 목적지, 단일 leg.
+const LINE = '7';
+const ORIGIN_NAME = '건대입구';
+const DESTINATION_NAME = '용마산';
+
+const DESTINATION = findStationByNameAndLine(DESTINATION_NAME, LINE)!;
+const ORIGIN = findStationByNameAndLine(ORIGIN_NAME, LINE)!;
+const ROUTE = { type: 'direct' as const, line: LINE, stops: 4 };
+const LOCK_TRAIN_CODE = '2026090201';
+const LOCK = {
+  destinationId: DESTINATION.id,
+  trainCode: LOCK_TRAIN_CODE,
+  boardingStationId: ORIGIN.id,
+  boardingLine: LINE,
+  boardedAt: 0,
+  expectedDurationMs: 600_000,
+};
+
+describe('evaluateWaypointArvlcdFire → processLocationUpdate 실체인 end-to-end (#2480, 9/2 저녁 용마산 재현)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage.clear();
+    _resetCrossCategoryDedupForTests();
+    storage.set(DESTINATION_KEY, JSON.stringify(DESTINATION));
+    storage.set(SLEEP_MODE_KEY, 'false');
+    storage.set(ROUTE_KEY, JSON.stringify(ROUTE));
+
+    mockGetBoardingLock.mockResolvedValue(LOCK);
+    mockSaveStationToWidget.mockResolvedValue(undefined);
+    mockFireLocalAlarmNotification.mockResolvedValue(undefined);
+    mockScheduleNotificationAsync.mockResolvedValue('id');
+    mockDismissNotificationAsync.mockResolvedValue(undefined);
+    mockGetAllScheduledNotificationsAsync.mockResolvedValue([]);
+    mockCancelScheduledNotificationAsync.mockResolvedValue(undefined);
+    mockGetPresentedNotificationsAsync.mockResolvedValue([]);
+  });
+
+  // 🔴 핵심(#2480 acceptance): garbage GPS(evaluatePositionTrainFire 실패 대상 시나리오)에서도
+  // GPS 좌표를 전혀 참조하지 않고 목적지 arvlCd만으로 발사한다 — 발사 함수 도달까지 assert
+  // (게이트 통과만으로는 불충분, #2400과 동일 원칙).
+  it('lock real trainCode + 목적지 arvlCd ENTERING → destination 발사(GREEN)', async () => {
+    mockGetArrival.mockResolvedValue({
+      up: [{ trainCode: LOCK_TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ENTERING }],
+      down: [],
+      isMock: false,
+    });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(true);
+    expect(mockGetArrival).toHaveBeenCalledWith(DESTINATION_NAME, { lineHint: LINE });
+
+    // 🔴 진짜 목적지 — fireLocalAlarmNotification이 실제로 호출됐는가.
+    expect(mockFireLocalAlarmNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'destination',
+        stationName: canonicalStationName(DESTINATION_NAME, LINE),
+      }),
+      'positionTrain',
+    );
+
+    expect(mockSetItem).toHaveBeenCalledWith(
+      ALARM_EVENT_KEY,
+      expect.stringContaining(canonicalStationName(DESTINATION_NAME, LINE)),
+    );
+  });
+
+  it('lock real trainCode + 목적지 arvlCd ARRIVED → destination 발사(GREEN)', async () => {
+    mockGetArrival.mockResolvedValue({
+      up: [{ trainCode: LOCK_TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ARRIVED }],
+      down: [],
+      isMock: false,
+    });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(true);
+    expect(mockFireLocalAlarmNotification).toHaveBeenCalled();
+  });
+
+  // negative 1 — PENDING trainCode(#2407 fallback lock, 미확정)로는 절대 발사하지 않는다.
+  it('lock.trainCode가 PENDING sentinel이면 arvlCd가 ENTERING이어도 발사하지 않는다 (오발사 0)', async () => {
+    const { PENDING_TRAIN_CODE } = jest.requireActual('../../../../shared/constants/boardingLock');
+    mockGetBoardingLock.mockResolvedValue({ ...LOCK, trainCode: PENDING_TRAIN_CODE });
+    mockGetArrival.mockResolvedValue({
+      up: [{ trainCode: LOCK_TRAIN_CODE, arrivalCode: ARRIVAL_CODE.ENTERING }],
+      down: [],
+      isMock: false,
+    });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockGetArrival).not.toHaveBeenCalled();
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  // negative 2 — 내 열차가 아직 도착 확증되지 않았으면(DEPARTED 등) 조용히 미발사.
+  it('목적지 arvlCd가 내 열차의 ENTERING/ARRIVED가 아니면 발사하지 않는다 (오발사 0)', async () => {
+    mockGetArrival.mockResolvedValue({
+      up: [{ trainCode: LOCK_TRAIN_CODE, arrivalCode: ARRIVAL_CODE.DEPARTED }],
+      down: [],
+      isMock: false,
+    });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  // negative 3 — arvlCd 응답에 내 trainCode 자체가 없으면(다른 열차만 응답) 미확증 → 미발사.
+  it('목적지 arvlCd 응답에 내 trainCode가 없으면 발사하지 않는다 (오발사 0)', async () => {
+    mockGetArrival.mockResolvedValue({
+      up: [{ trainCode: '다른열차', arrivalCode: ARRIVAL_CODE.ENTERING }],
+      down: [],
+      isMock: false,
+    });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/utils/__tests__/bgWaypointArvlcdFire.test.ts
+++ b/src/features/alarm/utils/__tests__/bgWaypointArvlcdFire.test.ts
@@ -1,0 +1,340 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+const mockProcessLocationUpdate = jest.fn();
+jest.mock('../stationPipeline', () => ({
+  processLocationUpdate: (...args: unknown[]) => mockProcessLocationUpdate(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../boardingLockStorage', () => ({
+  getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
+}));
+
+const mockGetFiredAlarms = jest.fn();
+jest.mock('../notificationState', () => ({
+  getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
+}));
+
+const mockPersistBgFireResult = jest.fn();
+jest.mock('../bgFirePersist', () => ({
+  persistBgFireResult: (...args: unknown[]) => mockPersistBgFireResult(...args),
+}));
+
+const mockIsMinimalAlarmEnabled = jest.fn();
+jest.mock('../../../../shared/constants/debugFlags', () => ({
+  isMinimalAlarmEnabled: () => mockIsMinimalAlarmEnabled(),
+}));
+
+const mockLogWaypointArvlcdFireDiagnostic = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logWaypointArvlcdFireDiagnostic: (...args: unknown[]) =>
+    mockLogWaypointArvlcdFireDiagnostic(...args),
+}));
+
+const mockPollWaypointArrivalIfDue = jest.fn();
+jest.mock('../../../nearest-station/tasks/bgWaypointArrivalPoll', () => ({
+  pollWaypointArrivalIfDue: (...args: unknown[]) => mockPollWaypointArrivalIfDue(...args),
+}));
+
+const mockFindStationByNameAndLine = jest.fn();
+jest.mock('../../../../shared/utils/stationRoute', () => {
+  const actual = jest.requireActual('../../../../shared/utils/stationRoute');
+  return {
+    ...actual,
+    findStationByNameAndLine: (...args: unknown[]) => mockFindStationByNameAndLine(...args),
+  };
+});
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { evaluateWaypointArvlcdFire } from '../bgWaypointArvlcdFire';
+import {
+  DESTINATION_KEY,
+  SLEEP_MODE_KEY,
+  ROUTE_KEY,
+} from '../../../../shared/constants/storageKeys';
+import { PENDING_TRAIN_CODE } from '../../../../shared/constants/boardingLock';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+
+const DESTINATION = { id: 'dest-1', name: '강남', line: '2', lat: 1, lng: 2 };
+const DIRECT_ROUTE = { type: 'direct', line: '2', stops: 3 };
+const TRANSFER_ROUTE = {
+  type: 'transfer',
+  fromLine: '7',
+  toLine: '2',
+  transferName: '건대입구',
+  stopsToTransfer: 2,
+  stopsFromTransfer: 3,
+};
+const LOCK_TRAIN_CODE = '2026090201';
+const LOCK = {
+  destinationId: 'dest-1',
+  trainCode: LOCK_TRAIN_CODE,
+  boardingStationId: 'S0',
+  boardingLine: '7',
+  boardedAt: 0,
+  expectedDurationMs: 600_000,
+};
+const TARGET_STATION = { id: 'dest-1', name: '강남', line: '2', lat: 37.5, lng: 127.05 };
+
+function mockAsyncStorageGet(map: Record<string, string | null>) {
+  mockGetItem.mockImplementation((key: string) =>
+    Promise.resolve(Object.prototype.hasOwnProperty.call(map, key) ? map[key] : null),
+  );
+}
+
+function imminentArrival(trainCode: string, code: number = ARRIVAL_CODE.ENTERING) {
+  return { up: [{ trainCode, arrivalCode: code }], down: [] };
+}
+
+describe('evaluateWaypointArvlcdFire', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetItem.mockResolvedValue(undefined);
+    mockIsMinimalAlarmEnabled.mockReturnValue(true);
+    mockGetBoardingLock.mockResolvedValue(LOCK);
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: 'false',
+      [ROUTE_KEY]: JSON.stringify(DIRECT_ROUTE),
+    });
+    mockGetFiredAlarms.mockResolvedValue(new Set<string>());
+    mockPollWaypointArrivalIfDue.mockResolvedValue(imminentArrival(LOCK_TRAIN_CODE));
+    mockFindStationByNameAndLine.mockReturnValue(TARGET_STATION);
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+    mockPersistBgFireResult.mockResolvedValue(undefined);
+  });
+
+  it('플래그 OFF면 즉시 false를 반환하고 lock을 조회하지 않는다', async () => {
+    mockIsMinimalAlarmEnabled.mockReturnValue(false);
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockGetBoardingLock).not.toHaveBeenCalled();
+    // 비활성 사용자 전원 스팸 방지 — flag-off는 진단 로그 미적재(#2474와 동일 원칙).
+    expect(mockLogWaypointArvlcdFireDiagnostic).not.toHaveBeenCalled();
+  });
+
+  it('lock이 없으면 false를 반환하고 skip-no-lock을 적재한다', async () => {
+    mockGetBoardingLock.mockResolvedValue(null);
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockPollWaypointArrivalIfDue).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-no-lock', {
+      hasTrainCode: false,
+    });
+  });
+
+  it('lock.trainCode가 빈 문자열이면 false를 반환한다', async () => {
+    mockGetBoardingLock.mockResolvedValue({ ...LOCK, trainCode: '' });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockPollWaypointArrivalIfDue).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-no-lock', {
+      hasTrainCode: false,
+    });
+  });
+
+  // #2407과 동일 가드 — pending sentinel은 imminent 판정에 소비 금지(오발사 방지).
+  it('lock.trainCode가 PENDING sentinel이면 false를 반환한다 (오발사 방지)', async () => {
+    mockGetBoardingLock.mockResolvedValue({ ...LOCK, trainCode: PENDING_TRAIN_CODE });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockPollWaypointArrivalIfDue).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-pending-traincode', {
+      hasTrainCode: true,
+    });
+  });
+
+  it('destination이 없으면 false를 반환한다', async () => {
+    mockAsyncStorageGet({ [DESTINATION_KEY]: null });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockPollWaypointArrivalIfDue).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-no-destination');
+  });
+
+  it('destination JSON 파싱 실패면 false를 반환한다', async () => {
+    mockAsyncStorageGet({ [DESTINATION_KEY]: 'not-json' });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-bad-destination');
+  });
+
+  it('destination에 id가 없으면 false를 반환한다', async () => {
+    mockAsyncStorageGet({ [DESTINATION_KEY]: JSON.stringify({ name: '강남' }) });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-bad-destination');
+  });
+
+  it('route가 없으면 false를 반환한다', async () => {
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: 'false',
+      [ROUTE_KEY]: null,
+    });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockPollWaypointArrivalIfDue).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-no-route');
+  });
+
+  it('모든 waypoint가 이미 발사됐으면(nextTarget 없음) false를 반환하고 폴링하지 않는다', async () => {
+    mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockPollWaypointArrivalIfDue).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-no-next-target');
+  });
+
+  // negative — 오발사 0 보장: 내 열차의 arvlCd가 아직 ENTERING/ARRIVED가 아니면 조용히 false.
+  it('arvlCd가 내 열차 미확증이면(다른 trainCode) false를 반환하고 processLocationUpdate를 호출하지 않는다', async () => {
+    mockPollWaypointArrivalIfDue.mockResolvedValue(imminentArrival('다른열차코드'));
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-not-imminent', {
+      waypointName: '강남',
+    });
+  });
+
+  it('arrival이 null이면(폴링 quota skip 등) false를 반환한다', async () => {
+    mockPollWaypointArrivalIfDue.mockResolvedValue(null);
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-not-imminent', {
+      waypointName: '강남',
+    });
+  });
+
+  it('target station lookup 실패 시 false를 반환한다', async () => {
+    mockFindStationByNameAndLine.mockReturnValue(undefined);
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(false);
+    expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('skip-no-target-station', {
+      waypointName: '강남',
+    });
+  });
+
+  it('sleepJson이 저장되지 않았으면 sleepMode=false로 기본 처리한다', async () => {
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: null,
+      [ROUTE_KEY]: JSON.stringify(DIRECT_ROUTE),
+    });
+
+    await evaluateWaypointArvlcdFire();
+
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ sleepMode: false }),
+    );
+  });
+
+  it('direct route: destination waypoint를 폴링해 lock.trainCode로 imminent 확증 시 processLocationUpdate를 호출한다', async () => {
+    const alarmEvent = { type: 'destination', phaseId: 'imminent', stationName: '강남' };
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent, nearest: null });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(true);
+    expect(mockPollWaypointArrivalIfDue).toHaveBeenCalledWith('강남', '2');
+    expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '2');
+    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lat: TARGET_STATION.lat,
+        lng: TARGET_STATION.lng,
+        destination: DESTINATION,
+        sleepMode: false,
+        storedRoute: DIRECT_ROUTE,
+        speedMps: null,
+        source: 'bg',
+        fusionSource: 'position-train',
+      }),
+    );
+    expect(mockPersistBgFireResult).toHaveBeenCalledWith(
+      expect.objectContaining({ alarmEvent, destination: DESTINATION, storedRoute: DIRECT_ROUTE }),
+    );
+    expect(mockLogWaypointArvlcdFireDiagnostic).toHaveBeenCalledWith('engaged', {
+      waypointName: '강남',
+    });
+  });
+
+  // #2383(evaluatePositionTrainFire)과 동일 계약 — arvlCd로 채택(파이프라인 실행)에 성공했다는
+  // 사실 자체가 반환 기준. 내부 dedup/hop-window/sleep 게이트가 이번 tick 발사만 suppress해도
+  // (alarmEvent=null) GPS-independent 신호로 위치가 확정됐으므로 true를 반환해 호출자가 GPS
+  // 파이프라인으로 fall through하지 않게 한다.
+  it('processLocationUpdate가 alarmEvent를 null로 반환해도(dedup 등) true를 반환한다 (채택 성공 기준)', async () => {
+    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
+
+    const result = await evaluateWaypointArvlcdFire();
+
+    expect(result).toBe(true);
+    // dedup/게이트로 alarmEvent가 없어도 nearest bookkeeping을 위해 persist는 여전히 호출.
+    expect(mockPersistBgFireResult).toHaveBeenCalled();
+  });
+
+  // 환승: transfer waypoint가 아직 미발사면 그것부터 폴링, transfer가 이미 발사됐으면 destination으로 진행.
+  it('transfer route: transfer waypoint가 미발사면 transfer를 다음 폴링 대상으로 삼는다', async () => {
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: 'false',
+      [ROUTE_KEY]: JSON.stringify(TRANSFER_ROUTE),
+    });
+    mockGetFiredAlarms.mockResolvedValue(new Set<string>());
+
+    await evaluateWaypointArvlcdFire();
+
+    expect(mockPollWaypointArrivalIfDue).toHaveBeenCalledWith('건대입구', '7');
+  });
+
+  it('transfer route: transfer가 이미 발사됐으면 destination waypoint로 진행한다', async () => {
+    mockAsyncStorageGet({
+      [DESTINATION_KEY]: JSON.stringify(DESTINATION),
+      [SLEEP_MODE_KEY]: 'false',
+      [ROUTE_KEY]: JSON.stringify(TRANSFER_ROUTE),
+    });
+    mockGetFiredAlarms.mockResolvedValue(new Set(['early:건대입구']));
+
+    await evaluateWaypointArvlcdFire();
+
+    expect(mockPollWaypointArrivalIfDue).toHaveBeenCalledWith('강남', '2');
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -445,6 +445,13 @@ export type AlarmLogReason =
   | 'skip-poll-null'
   | 'skip-no-train-progress'
   | 'skip-locked-gate'
+  // #2480 — waypoint arvlCd 직폴 spine(bgWaypointArvlcdFire.ts) 전용 skip 사유.
+  //   'skip-no-next-target': resolveAllTargets의 모든 waypoint가 이미 발사 완료(nextTarget 없음).
+  //   'skip-not-imminent': 폴링한 arvlCd에 내 trainCode가 없거나 ENTERING/ARRIVED 미확증.
+  //   'skip-no-target-station': waypoint 이름+노선으로 station lookup 실패(stations.json drift 등).
+  | 'skip-no-next-target'
+  | 'skip-not-imminent'
+  | 'skip-no-target-station'
   | 'engaged';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
@@ -1751,6 +1758,41 @@ export function logPositionTrainFireDiagnostic(
     stationName: context.anchorStationName ?? undefined,
     hasTrainCode: context.hasTrainCode,
     candidatesCount: context.candidatesCount,
+  });
+}
+
+/**
+ * #2480 — waypoint arvlCd 직폴 spine(bgWaypointArvlcdFire.ts) 발사/skip 1건 적재.
+ * `logPositionTrainFireDiagnostic`(#2383/#2474)과 동일 취지 — 이 spine이 존재하는 이유 자체가
+ * 9/2 저녁 용마산 도착 0건(#2383/#2381 둘 다 실패) evidence라, 다음 field miss가 발생했을 때
+ * 어느 skip 지점에서 멈췄는지 DebugModal alarmLog로 바로 관측 가능해야 한다.
+ */
+export function logWaypointArvlcdFireDiagnostic(
+  reason: Extract<
+    AlarmLogReason,
+    | 'skip-no-lock'
+    | 'skip-pending-traincode'
+    | 'skip-no-destination'
+    | 'skip-bad-destination'
+    | 'skip-no-route'
+    | 'skip-no-next-target'
+    | 'skip-poll-null'
+    | 'skip-not-imminent'
+    | 'skip-no-target-station'
+    | 'engaged'
+  >,
+  context: {
+    waypointName?: string | null;
+    hasTrainCode?: boolean;
+  } = {},
+): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg',
+    outcome: reason === 'engaged' ? 'received' : 'suppressed',
+    reason,
+    stationName: context.waypointName ?? undefined,
+    hasTrainCode: context.hasTrainCode,
   });
 }
 

--- a/src/features/alarm/utils/bgWaypointArvlcdFire.ts
+++ b/src/features/alarm/utils/bgWaypointArvlcdFire.ts
@@ -1,0 +1,163 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: `bgPositionTrainFire.ts`와 동일하게 여러 features(nearest-station/
+ * arrival/widget)의 util을 조합하는 orchestrator다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { processLocationUpdate } from './stationPipeline';
+import { getBoardingLock } from './boardingLockStorage';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
+import { getFiredAlarms } from './notificationState';
+import { persistBgFireResult } from './bgFirePersist';
+import { alarmKey, resolveAllTargets, type CurrentTarget } from './stationAlarm';
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
+import { isImminentByArrivalCode } from '../../arrival/utils/imminentArrivalSignal';
+import { pollWaypointArrivalIfDue } from '../../nearest-station/tasks/bgWaypointArrivalPoll';
+import { findStationByNameAndLine } from '../../../shared/utils/stationRoute';
+import { DESTINATION_KEY, SLEEP_MODE_KEY, ROUTE_KEY } from '../../../shared/constants/storageKeys';
+import { logWaypointArvlcdFireDiagnostic } from './alarmLog';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import type { AlarmPhaseId } from '../../../shared/types/alarm';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('BgWaypointArvlcdFire');
+
+/**
+ * waypoint 종류별 "완료" 판정 phase. `resolveAllTargets`가 반환하는 `CurrentTarget.alarmType`
+ * (`stationAlarm.ts`)과 `ALARM_PHASES`(`alarmPhases.ts`)의 관계: transfer waypoint는 도착역이
+ * 아니므로 etaSeconds가 항상 null이라 `early` phase만 평가 가능(`evaluateAlarmPhase` 참고,
+ * imminent는 `isFinal`(최종 waypoint)에만 평가된다). destination waypoint는 최종 leg라 `early`→
+ * `imminent` 순으로 진행하며, `imminent`가 곧 "곧 도착" 사용자 노출 알람이므로 완료 기준이다.
+ */
+const COMPLETION_PHASE_ID: Record<CurrentTarget['alarmType'], AlarmPhaseId> = {
+  transfer: 'early',
+  destination: 'imminent',
+};
+
+/** waypoint가 이미 사용자에게 발사됐는지 — 다음 미발사 waypoint로 폴링 대상을 진행시키기 위함. */
+function isTargetAlreadyFired(firedAlarms: Set<string>, target: CurrentTarget): boolean {
+  return firedAlarms.has(alarmKey({ phaseId: COMPLETION_PHASE_ID[target.alarmType], stationName: target.name }));
+}
+
+/**
+ * #2480 — FG #396(`useStationAlarm`)의 waypoint arvlCd 직폴 신호를 BG spine으로 이식.
+ *
+ * 배경: FG는 다음 waypoint의 도착정보를 직접 폴링해 lock된 열차가 ENTERING/ARRIVED면 그 신호를
+ * `evaluateAlarmPhase`(#396) 판정에 흘려보낸다 — GPS/WiFi/열차위치매칭 전부 무관, 셀룰러로 지하도
+ * OK. BG(취침/잠금=실사용 무대)엔 이 클린 신호가 없어 `#2381`(WiFi 필수)/`#2383`(전체 열차위치
+ * 매칭)만으로는 커버 못 하는 케이스(9/2 저녁 용마산 도착 0건)가 남는다. 이 함수는 그 arvlCd
+ * 폴링 자체를 BG에 이식한다 — FG의 imminent 직결 배선(early phase gate 우회)까지 그대로 옮기지는
+ * 않는다. 대신 `processLocationUpdate`(전체 파이프라인: `evaluateAlarmPhase`의 early/imminent
+ * 순차 + hop-window/sleep/dedup 게이트)에 정확한 waypoint 좌표를 주입해 재사용한다 — 첫 발사는
+ * `early`(destination도 동일), 이어지는 tick에서 `imminent`가 발사된다. 사용자 체감(정확한
+ * waypoint에서 알람)은 FG와 동등하되, 기존 dedup/게이트 경로를 우회하지 않는 것이 이 선택의 이유.
+ *
+ * `#2383`(`evaluatePositionTrainFire`)과 병행 — 대체가 아니다. 호출자(`backgroundLocationTask.ts`)
+ * 는 `#2383`을 먼저 시도하고 실패(false)한 tick에서만 이 함수를 시도한다. 둘 다 gate-free이며
+ * fired(true)면 그 tick의 나머지 파이프라인(GPS 경로 등)으로 fall through하지 않는다.
+ *
+ * 경계: 이 spine은 `lock.trainCode`를 소비만 한다 — 어느 leg든 lock.trainCode가 real(PENDING
+ * sentinel 아님)이면 그 waypoint를 발사 대상으로 삼는다. 환승 후 re-lock(`#2323`)은 이 이슈
+ * 밖이다 — 이 함수는 re-lock 결과(트립 진행 중 lock이 갱신된 경우)를 소비할 뿐, re-lock 자체를
+ * 수행하지 않는다.
+ *
+ * 반환값 — true: arvlCd로 내 열차의 도착이 확증돼 `processLocationUpdate`까지 완료(파이프라인
+ * 내부 dedup/hop-window/sleep 게이트로 이번 tick에 실제 발사는 없었을 수 있음 — `evaluatePositionTrainFire`
+ * 와 동일하게 "채택 성공"이 반환 기준). 호출자는 GPS 경로로 fall through하지 말고 이번 tick을
+ * 마쳐야 한다. false: 게이트 미충족/도착 미확증 — 호출자는 기존 파이프라인으로 계속 진행.
+ */
+export async function evaluateWaypointArvlcdFire(): Promise<boolean> {
+  if (!isMinimalAlarmEnabled()) return false;
+
+  const lock = await getBoardingLock();
+  // real trainCode만 소비 — pending(fallback lock, 미확정) sentinel은 imminent 판정에 쓸 수 없다
+  // (`isImminentByArrivalCode`는 trainCode 매칭이므로 sentinel은 항상 미매칭 → false negative만
+  // 쌓인다. `evaluatePositionTrainFire`의 #2407과 동일 가드).
+  if (!lock?.trainCode || isPendingTrainCode(lock.trainCode)) {
+    void logWaypointArvlcdFireDiagnostic(!lock?.trainCode ? 'skip-no-lock' : 'skip-pending-traincode', {
+      hasTrainCode: !!lock?.trainCode,
+    });
+    return false;
+  }
+
+  const destJson = await AsyncStorage.getItem(DESTINATION_KEY);
+  if (!destJson) {
+    void logWaypointArvlcdFireDiagnostic('skip-no-destination');
+    return false;
+  }
+
+  let destinationRaw: unknown;
+  try {
+    destinationRaw = JSON.parse(destJson);
+  } catch {
+    logger.error('목적지 JSON 파싱 실패');
+    void logWaypointArvlcdFireDiagnostic('skip-bad-destination');
+    return false;
+  }
+  if (
+    !destinationRaw ||
+    typeof destinationRaw !== 'object' ||
+    typeof (destinationRaw as { id?: unknown }).id !== 'string'
+  ) {
+    logger.error('목적지에 id가 없음');
+    void logWaypointArvlcdFireDiagnostic('skip-bad-destination');
+    return false;
+  }
+  const destination = destinationRaw as Station;
+
+  const routeJson = await AsyncStorage.getItem(ROUTE_KEY);
+  const storedRoute: Route = routeJson ? JSON.parse(routeJson) : null;
+  if (!storedRoute) {
+    void logWaypointArvlcdFireDiagnostic('skip-no-route');
+    return false;
+  }
+
+  const targets = resolveAllTargets(storedRoute, destination.name);
+  const firedAlarms = await getFiredAlarms(destination.id);
+  const nextTarget = targets.find((t) => !isTargetAlreadyFired(firedAlarms, t));
+  if (!nextTarget) {
+    void logWaypointArvlcdFireDiagnostic('skip-no-next-target');
+    return false;
+  }
+
+  const arrival = await pollWaypointArrivalIfDue(nextTarget.name, nextTarget.approachLine);
+  if (!isImminentByArrivalCode(arrival, lock.trainCode)) {
+    void logWaypointArvlcdFireDiagnostic('skip-not-imminent', { waypointName: nextTarget.name });
+    return false;
+  }
+
+  const targetStation = findStationByNameAndLine(nextTarget.name, nextTarget.approachLine);
+  if (!targetStation) {
+    void logWaypointArvlcdFireDiagnostic('skip-no-target-station', { waypointName: nextTarget.name });
+    return false;
+  }
+
+  const sleepJson = await AsyncStorage.getItem(SLEEP_MODE_KEY);
+  const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
+
+  const { alarmEvent, nearest } = await processLocationUpdate({
+    lat: targetStation.lat,
+    lng: targetStation.lng,
+    destination,
+    firedAlarms,
+    sleepMode,
+    storedRoute,
+    speedMps: null,
+    source: 'bg',
+    // #327 — arvlCd 직폴(GPS 무관)로 확정된 station은 GPS가 아닌 열차 도착정보 기반 확정.
+    fusionSource: 'position-train',
+  });
+
+  await persistBgFireResult({ alarmEvent, nearest, destination, firedAlarms, storedRoute });
+
+  void logWaypointArvlcdFireDiagnostic('engaged', { waypointName: nextTarget.name });
+
+  // #2383(evaluatePositionTrainFire)과 동일 계약 — arvlCd로 채택에 성공(파이프라인 실행 완료)
+  // 했다는 사실 자체가 반환 기준. 내부 dedup/hop-window/sleep 게이트가 이번 tick 발사를
+  // suppress했더라도(alarmEvent=null) 이미 GPS-independent 신호로 위치가 확정된 tick이므로
+  // 호출자는 GPS 파이프라인으로 fall through하지 않아야 한다.
+  return true;
+}

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -142,6 +142,14 @@ jest.mock('../../../alarm/utils/bgPositionTrainFire', () => ({
   evaluatePositionTrainFire: (...args: unknown[]) => mockEvaluatePositionTrainFire(...args),
 }));
 
+// #2480 — waypoint arvlCd 직폴 spine 경로 모킹. 내부 판정은 bgWaypointArvlcdFire.test.ts 전담,
+// 여기서는 backgroundLocationTask가 플래그 상태·호출 순서·반환값에 따라 올바르게 호출/
+// early-return하는지만 검증.
+const mockEvaluateWaypointArvlcdFire = jest.fn().mockResolvedValue(false);
+jest.mock('../../../alarm/utils/bgWaypointArvlcdFire', () => ({
+  evaluateWaypointArvlcdFire: (...args: unknown[]) => mockEvaluateWaypointArvlcdFire(...args),
+}));
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AlarmEvent } from '../../../../shared/types/alarm';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
@@ -258,6 +266,8 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockEvaluateUndergroundConsensusFire.mockResolvedValue(undefined);
     // #2383 — 기본: false(미채택) — 기존 GPS/consensus 파이프라인이 그대로 이어진다.
     mockEvaluatePositionTrainFire.mockResolvedValue(false);
+    // #2480 — 기본: false(미채택) — 기존 GPS/consensus 파이프라인이 그대로 이어진다.
+    mockEvaluateWaypointArvlcdFire.mockResolvedValue(false);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -780,6 +790,76 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     it('evaluatePositionTrainFire가 예외를 던져도 태스크는 크래시하지 않고 기존 파이프라인이 이어진다 (graceful)', async () => {
       mockIsMinimalAlarmEnabled.mockReturnValue(true);
       mockEvaluatePositionTrainFire.mockRejectedValueOnce(new Error('position-train failed'));
+      mockStorageValues(JSON.stringify(mockDestination));
+
+      await expect(
+        runWithLocation(makeLocation(37.498, 127.028, { accuracy: goodAccuracy })),
+      ).resolves.toBeUndefined();
+      expect(mockProcessLocationUpdate).toHaveBeenCalled();
+    });
+  });
+
+  // #2480 — waypoint arvlCd 직폴 spine. #2383(evaluatePositionTrainFire)이 못 잡은 tick에도
+  // lock된 열차의 다음 waypoint 도착정보를 직접 폴링해 발사를 시도한다. #2383과 동일하게
+  // GPS accuracy 게이트보다 먼저(MINIMAL_ALARM 가드 안) 배선된다.
+  describe('#2480 — waypoint arvlCd 직폴 발사 게이트 (EXPO_PUBLIC_MINIMAL_ALARM)', () => {
+    const goodAccuracy = MAX_ACCURACY_M - 1;
+
+    it('플래그 OFF면 evaluateWaypointArvlcdFire를 호출하지 않는다(현행 완전 불변)', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(false);
+      mockStorageValues(null);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: goodAccuracy }));
+
+      expect(mockEvaluateWaypointArvlcdFire).not.toHaveBeenCalled();
+    });
+
+    it('플래그 ON이면 accuracy가 정상인 tick에서도 evaluatePositionTrainFire 이후 evaluateWaypointArvlcdFire를 호출한다', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockStorageValues(null);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: goodAccuracy }));
+
+      expect(mockEvaluateWaypointArvlcdFire).toHaveBeenCalledTimes(1);
+      const positionTrainOrder = mockEvaluatePositionTrainFire.mock.invocationCallOrder[0];
+      const waypointOrder = mockEvaluateWaypointArvlcdFire.mock.invocationCallOrder[0];
+      expect(positionTrainOrder).toBeLessThan(waypointOrder);
+    });
+
+    it('evaluatePositionTrainFire가 true를 반환하면 evaluateWaypointArvlcdFire는 호출하지 않는다', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockEvaluatePositionTrainFire.mockResolvedValue(true);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: goodAccuracy }));
+
+      expect(mockEvaluateWaypointArvlcdFire).not.toHaveBeenCalled();
+    });
+
+    it('evaluateWaypointArvlcdFire가 true를 반환하면 이번 tick을 종료하고 GPS 파이프라인으로 fall through하지 않는다', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockEvaluatePositionTrainFire.mockResolvedValue(false);
+      mockEvaluateWaypointArvlcdFire.mockResolvedValue(true);
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: goodAccuracy }));
+
+      expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+
+    it('evaluateWaypointArvlcdFire가 false를 반환하면 기존 파이프라인이 그대로 이어진다', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockEvaluatePositionTrainFire.mockResolvedValue(false);
+      mockEvaluateWaypointArvlcdFire.mockResolvedValue(false);
+      mockStorageValues(JSON.stringify(mockDestination));
+
+      await runWithLocation(makeLocation(37.498, 127.028, { accuracy: goodAccuracy }));
+
+      expect(mockProcessLocationUpdate).toHaveBeenCalled();
+    });
+
+    it('evaluateWaypointArvlcdFire가 예외를 던져도 태스크는 크래시하지 않고 기존 파이프라인이 이어진다 (graceful)', async () => {
+      mockIsMinimalAlarmEnabled.mockReturnValue(true);
+      mockEvaluatePositionTrainFire.mockResolvedValue(false);
+      mockEvaluateWaypointArvlcdFire.mockRejectedValueOnce(new Error('waypoint arvlCd failed'));
       mockStorageValues(JSON.stringify(mockDestination));
 
       await expect(

--- a/src/features/nearest-station/tasks/__tests__/bgWaypointArrivalPoll.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/bgWaypointArrivalPoll.test.ts
@@ -1,0 +1,143 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+const mockGetArrival = jest.fn();
+const mockCreateArrivalProvider = jest.fn<{ getArrival: jest.Mock }, []>(() => ({
+  getArrival: mockGetArrival,
+}));
+jest.mock('../../../arrival/providers/factory', () => ({
+  createArrivalProvider: () => mockCreateArrivalProvider(),
+}));
+
+import {
+  pollWaypointArrivalIfDue,
+  BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS,
+  __resetBgWaypointArrivalPollForTests,
+} from '../bgWaypointArrivalPoll';
+import {
+  BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY,
+  BG_WAYPOINT_ARRIVAL_CACHE_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+const NOW = 1_000_000;
+
+describe('pollWaypointArrivalIfDue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetBgWaypointArrivalPollForTests();
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+  });
+
+  it('첫 폴링(타임스탬프 없음)은 즉시 fetch하고 캐시에 저장한다', async () => {
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollWaypointArrivalIfDue('용마산', '7', NOW);
+
+    expect(mockGetArrival).toHaveBeenCalledWith('용마산', { lineHint: '7' });
+    expect(mockSetItem).toHaveBeenCalledWith(BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY, String(NOW));
+    expect(mockSetItem).toHaveBeenCalledWith(BG_WAYPOINT_ARRIVAL_CACHE_KEY, JSON.stringify(arrival));
+    expect(result).toEqual(arrival);
+  });
+
+  it('최소 간격 미경과면 fetch 없이 캐시를 반환한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY) return Promise.resolve(String(NOW));
+      if (key === BG_WAYPOINT_ARRIVAL_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify({ up: [], down: [] }));
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await pollWaypointArrivalIfDue(
+      '용마산',
+      '7',
+      NOW + BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS - 1,
+    );
+
+    expect(mockGetArrival).not.toHaveBeenCalled();
+    expect(result).toEqual({ up: [], down: [] });
+  });
+
+  it('최소 간격 경과 시 다시 fetch한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY) return Promise.resolve(String(NOW));
+      return Promise.resolve(null);
+    });
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollWaypointArrivalIfDue(
+      '용마산',
+      '7',
+      NOW + BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS,
+    );
+
+    expect(mockGetArrival).toHaveBeenCalled();
+    expect(result).toEqual(arrival);
+  });
+
+  it('fetch 결과가 mock이면 캐시를 갱신하지 않고 기존 캐시를 반환한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_WAYPOINT_ARRIVAL_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify({ up: [], down: [], isMock: false, cached: true }));
+      }
+      return Promise.resolve(null);
+    });
+    mockGetArrival.mockResolvedValue({ up: [], down: [], isMock: true });
+
+    const result = await pollWaypointArrivalIfDue('용마산', '7', NOW);
+
+    expect(mockSetItem).not.toHaveBeenCalledWith(
+      BG_WAYPOINT_ARRIVAL_CACHE_KEY,
+      expect.anything(),
+    );
+    expect(result).toEqual({ up: [], down: [], isMock: false, cached: true });
+  });
+
+  it('fetch 실패 시 캐시로 graceful fallback한다', async () => {
+    mockGetItem.mockImplementation((key: string) => {
+      if (key === BG_WAYPOINT_ARRIVAL_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify({ up: [], down: [], cached: true }));
+      }
+      return Promise.resolve(null);
+    });
+    mockGetArrival.mockRejectedValue(new Error('network'));
+
+    const result = await pollWaypointArrivalIfDue('용마산', '7', NOW);
+
+    expect(result).toEqual({ up: [], down: [], cached: true });
+  });
+
+  it('now 인자 미전달 시 Date.now() 기본값으로 동작한다', async () => {
+    const arrival = { up: [], down: [], isMock: false };
+    mockGetArrival.mockResolvedValue(arrival);
+
+    const result = await pollWaypointArrivalIfDue('용마산', '7');
+
+    expect(mockGetArrival).toHaveBeenCalledWith('용마산', { lineHint: '7' });
+    expect(result).toEqual(arrival);
+  });
+
+  it('provider는 모듈 스코프에서 재사용된다(재생성 없음)', async () => {
+    mockGetArrival.mockResolvedValue({ up: [], down: [], isMock: false });
+
+    await pollWaypointArrivalIfDue('용마산', '7', NOW);
+    await pollWaypointArrivalIfDue(
+      '용마산',
+      '7',
+      NOW + BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS,
+    );
+
+    expect(mockCreateArrivalProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('최소 간격은 20s(#2381 25s보다 짧다)', () => {
+    expect(BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS).toBe(20_000);
+  });
+});

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -58,6 +58,10 @@ import { evaluateUndergroundConsensusFire } from '../../alarm/utils/undergroundC
 // #2383 (Part of #2381) — position-train-lock BG 발사 경로. 환경(지상/지하) 오분류·GPS accuracy
 // 상태에 독립적으로 lock.trainCode를 arvlCd로 직접 추적한다 (#2382 WiFi/consensus 경로보다 우선).
 import { evaluatePositionTrainFire } from '../../alarm/utils/bgPositionTrainFire';
+// #2480 — FG #396(useStationAlarm)의 waypoint arvlCd 직폴 발사를 BG spine으로 이식. GPS/WiFi/
+// 열차위치매칭 전부 무관 — "내 목적지(다음 waypoint)에 내 열차가 도착하나"만 셀룰러로 직접 폴한다.
+// #2383과 병행(대체 아님) — #2383이 실패(false)한 tick에서만 시도.
+import { evaluateWaypointArvlcdFire } from '../../alarm/utils/bgWaypointArvlcdFire';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -174,6 +178,16 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       if (fired) return;
     } catch (e) {
       logger.warn('position-train lock 처리 실패 (graceful)', e);
+    }
+
+    // #2480 — waypoint arvlCd 직폴 spine. #2383이 이번 tick에서 못 잡은 경우(열차위치 매칭
+    // 실패 등)에도, lock된 열차의 다음 waypoint 도착정보를 직접 폴링해 발사를 시도한다.
+    // GPS accuracy 게이트보다 먼저 — 지하에서도 셀룰러로 동작해야 하는 것이 이 경로의 핵심.
+    try {
+      const waypointFired = await evaluateWaypointArvlcdFire();
+      if (waypointFired) return;
+    } catch (e) {
+      logger.warn('waypoint arvlCd 처리 실패 (graceful)', e);
     }
   }
 

--- a/src/features/nearest-station/tasks/bgWaypointArrivalPoll.ts
+++ b/src/features/nearest-station/tasks/bgWaypointArrivalPoll.ts
@@ -1,0 +1,72 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature: `createArrivalProvider()`(arrival feature 소유)를 nearest-station BG task가
+ * 그대로 재사용한다 — `bgUndergroundArrivalPoll.ts`(#2381)와 동일한 이유의 본질적 cross-feature
+ * 의존. Phase 5 enforce 모드에서 file-level disable로 옵트인.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #2480 — BG waypoint arvlCd 직폴링. FG(`useStationAlarm` #396)가 목적지 도착정보를 직접
+ * 폴링(`useArrivalInfo`)해 lock된 열차가 ENTERING/ARRIVED면 발사하는 클린 신호를 BG spine
+ * (`bgWaypointArvlcdFire.ts`)이 그대로 이식할 수 있도록 조건부 폴링만 담당한다.
+ *
+ * `bgUndergroundArrivalPoll.ts`(#2381)와 거의 동일한 skeleton이지만 지하+WiFi 후보 게이트에
+ * 묶이지 않고, 호출자가 이미 lock.trainCode(real)로 정한 "다음 waypoint" 역을 그대로 조회 대상
+ * 으로 받는다 — 별도 station 모듈(각 도메인 전용 캐시/타임스탬프 키)로 분리해 두 폴링이 서로의
+ * 쿨다운/캐시를 침범하지 않도록 한다.
+ *
+ * Provider는 `createArrivalProvider()`(순수 fetch, `useArrivalInfo`/`bgUndergroundArrivalPoll`과
+ * 동일 factory)를 그대로 재사용 — 새 fetch 로직 발명 없음.
+ *
+ * 공통 쿨다운-폴링 스켈레톤은 `pollWithCooldown.ts`(#2383)를 그대로 재사용 — 본 모듈은 provider
+ * 싱글톤 관리 + 도메인 특화 fetcher/키만 주입하는 thin wrapper다.
+ *
+ * 호출자(`evaluateWaypointArvlcdFire`)가 게이트(플래그/lock/waypoint 선정 등)를 이미 통과한
+ * tick에서만 호출한다 — 본 모듈 자체는 그 게이트를 걸지 않는다(단일 책임: 폴링 주기 관리 +
+ * graceful fetch/캐시만).
+ */
+import type { ArrivalProvider } from '../../arrival/providers/types';
+import { createArrivalProvider } from '../../arrival/providers/factory';
+import type { StationArrival } from '../../../shared/types/arrival';
+import type { LineNumber } from '../../../shared/types/station';
+import {
+  BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY,
+  BG_WAYPOINT_ARRIVAL_CACHE_KEY,
+} from '../../../shared/constants/storageKeys';
+import { pollWithCooldown } from './pollWithCooldown';
+
+/**
+ * 최소 폴링 간격 — #2381(25s)보다 짧게. 도착창(ENTERING→ARRIVED)이 좁아 폴링 간격이 길면
+ * 그 창을 통째로 놓칠 위험이 있어(도착 자동알림 척추 목적) 더 촘촘한 간격을 쓴다.
+ */
+export const BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS = 20_000;
+
+let arrivalProvider: ArrivalProvider | null = null;
+function getProvider(): ArrivalProvider {
+  if (!arrivalProvider) arrivalProvider = createArrivalProvider();
+  return arrivalProvider;
+}
+
+/** 테스트 격리용 — 본 모듈 사용처 외에는 호출하지 말 것. */
+export function __resetBgWaypointArrivalPollForTests(): void {
+  arrivalProvider = null;
+}
+
+/**
+ * 다음 waypoint(환승역 또는 도착역)의 arvlCd를 조건부 폴링한다. 정책 상세는
+ * `pollWithCooldown.ts` 참고.
+ */
+export async function pollWaypointArrivalIfDue(
+  stationName: string,
+  lineHint: LineNumber,
+  now: number = Date.now(),
+): Promise<StationArrival | null> {
+  return pollWithCooldown<StationArrival>({
+    polledAtKey: BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY,
+    cacheKey: BG_WAYPOINT_ARRIVAL_CACHE_KEY,
+    minIntervalMs: BG_WAYPOINT_ARRIVAL_POLL_MIN_INTERVAL_MS,
+    now,
+    fetcher: () => getProvider().getArrival(stationName, { lineHint }),
+    logLabel: 'waypoint arvlCd',
+  });
+}

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -284,3 +284,12 @@ export const BG_POSITION_TRAIN_POLLED_AT_KEY = 'subway-now:bg-position-train-pol
 // tick 또는 fetch 실패 시 이 캐시를 trackTrainProgress 입력으로 재사용(quota 보호 + graceful
 // fallback). 형식: LinePositions JSON. 키 부재 = 캐시 없음(null).
 export const BG_POSITION_TRAIN_CACHE_KEY = 'subway-now:bg-position-train-cache';
+// #2480 — waypoint arvlCd 직폴 BG spine의 폴링 최소 간격 가드용 마지막 폴링 시각(epoch ms).
+// BG_UNDERGROUND_ARRIVAL_POLLED_AT_KEY와 동일 패턴이나, 두 폴링이 서로의 쿨다운을 침범하지
+// 않도록 별도 키로 분리한다.
+// 형식: 숫자 문자열. 키 부재 = 첫 폴링(즉시 fetch).
+export const BG_WAYPOINT_ARRIVAL_POLLED_AT_KEY = 'subway-now:bg-waypoint-arrival-polled-at';
+// #2480 — waypoint arvlCd 직폴 BG spine의 폴링 결과 캐시. 최소 간격 미경과 tick 또는 fetch
+// 실패 시 이 캐시를 isImminentByArrivalCode 입력으로 재사용(quota 보호 + graceful fallback).
+// 형식: StationArrival JSON. 키 부재 = 캐시 없음(null).
+export const BG_WAYPOINT_ARRIVAL_CACHE_KEY = 'subway-now:bg-waypoint-arrival-cache';


### PR DESCRIPTION
## Summary

FG #396(useStationAlarm)이 목적지 도착정보를 직접 폴링(GPS/WiFi/열차위치매칭 전부 무관, 셀룰러로 지하도 OK)해 lock된 열차가 ENTERING/ARRIVED면 발사하는 신호를 BG spine으로 이식한다. 9/2 저녁 건대입구→용마산 직행에서 garbage GPS로 #2383(realtimePosition 열차 매칭)과 GPS accuracy 게이트가 모두 실패해 도착 알림이 0건이었던 근본을 메운다. 새 로직 발명 없이 기존 자산(`isImminentByArrivalCode`, `resolveAllTargets`, `pollWithCooldown`, `processLocationUpdate`, `persistBgFireResult`)만 조립.

- 신규 `bgWaypointArrivalPoll.ts` (`pollWaypointArrivalIfDue`, 20s 쿨다운 — #2381 25s보다 짧게, 도착창 놓침 방지)
- 신규 `bgWaypointArvlcdFire.ts` (`evaluateWaypointArvlcdFire`, `bgPositionTrainFire.ts` 형제 패턴)
- `backgroundLocationTask.ts`: `#2383 evaluatePositionTrainFire` 직후(gate-accuracy보다 먼저), MINIMAL_ALARM 가드 안에 배선. fired면 early-return, #2383과 병행(대체 아님)
- `alarmLog.ts`: `logWaypointArvlcdFireDiagnostic` + skip 사유 3종 추가(V/X dashboard 관측성, code-review P1 반영)

Closes #2480

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. 신규 export(`evaluateWaypointArvlcdFire`/`pollWaypointArrivalIfDue`/`logWaypointArvlcdFireDiagnostic`)는 `backgroundLocationTask.ts`/자기 모듈이 즉시 caller.
- [x] **2. V/X dashboard** — DebugModal alarmLog: `logWaypointArvlcdFireDiagnostic`가 매 tick skip 사유(`skip-no-lock`/`skip-pending-traincode`/`skip-no-destination`/`skip-bad-destination`/`skip-no-route`/`skip-no-next-target`/`skip-not-imminent`/`skip-no-target-station`) 또는 `engaged`를 적재. 또한 fired 시 `processLocationUpdate` 내부 `logFiredAlarm`이 기존 alarmLog 파이프라인에 정상 통합.
- [x] **3. 의존 PR** — N/A (additive, backend/device 의존 없음).
- [x] **4. 측정 plan** — 다음 지하 직행 탑승에서 DebugModal alarmLog `bgWaypointArvlcdFire` reason 분포(특히 `engaged` vs `skip-*`) 확인. red fixture(`bgWaypointArvlcdFire.dumpReplay.e2eFire.test.ts`)가 CI 상시 회귀 가드.
- [x] **5. Device verify** — 🔴 필요. 실기기 지하 직행 1회(예: 건대입구→용마산류 경로) — arvlCd 폴 셀룰러 응답 + 도착 발사(fireLocalAlarmNotification) 확인. 코드-only 검증(type+unit)은 완료했으나 지하 셀룰러/BG task 실제 동작은 실기기에서만 확인 가능.

### V/X dashboard URL

DebugModal → alarmLog 섹션, reason=`skip-no-lock`|`skip-pending-traincode`|`skip-no-destination`|`skip-bad-destination`|`skip-no-route`|`skip-no-next-target`|`skip-not-imminent`|`skip-no-target-station`|`engaged`, source=`bg`.

### 의존 PR

N/A

---

## 계약 변경 체크리스트 (push kind 추가/은퇴 시 — ADR-029 Phase 4 / #2252)

N/A — pushContract.ts 미변경.

---

## Test plan

- [x] `npm test` 100% coverage pass (10000 tests)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] red fixture: 9/2 저녁 직행(건대입구→용마산, 7호선) 재현 — garbage GPS 상황(구현 stub 시 RED 확인: `fireLocalAlarmNotification` 미호출) → 구현 원복 시 GREEN(destination 발사)
- [x] negative: PENDING trainCode → 미발사, arvlCd 미확증(다른 trainCode/미ENTERING) → 미발사, target station lookup 실패 → 미발사 (오발사 0)
- [x] 환승 route: transfer waypoint 미발사 시 transfer 우선 폴링 → transfer 발사 후 destination으로 진행
- [ ] 실기기 지하 직행 탑승 검증 (사용자 담당)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9