### PR TITLE
fix(#2483): movement 게이트 우회를 arvlCd-확증(fusionSource=position-train)으로 좁힘

### DIFF
--- a/src/features/alarm/__tests__/replay_20260902_movement_bypass_narrow.test.ts
+++ b/src/features/alarm/__tests__/replay_20260902_movement_bypass_narrow.test.ts
@@ -1,0 +1,253 @@
+/**
+ * #2483 — MINIMAL_ALARM 승격(#2482) 시뮬로 잡은 ship-blocker: `stationPipeline.ts`의 movement
+ * 게이트가 `!isMinimalAlarmEnabled()` 조건이라 flag ON이면 movement 검증을 조건 없이 전면
+ * 제거했다. lock 유무/dedup 무관 — 신규 trip 첫 tick에 정적(GPS-static) destination-early가
+ * phantom 발사된다(건대입구→뚝섬, #2200과 동일 좌표를 flag ON으로 재현).
+ *
+ * ## fix (#2483)
+ * movement 게이트 우회 조건을 `isMinimalAlarmEnabled() && fusionSource === 'position-train'`로
+ * 좁힌다 — flag ON이어도 arvlCd/열차 확증(fusionSource=position-train) 없이는 정적 상태에서
+ * 우회하지 않는다.
+ *
+ * ## 동작 매트릭스 (이슈 #2483)
+ * | flag | 정적 | fusionSource     | 기대       |
+ * |------|------|-------------------|-----------|
+ * | OFF  | static | any             | 억제(불변, #2200) |
+ * | ON   | static | gps              | 억제(FIXED, 본 fixture) |
+ * | ON   | static | position-train   | 발사(불변, arvlCd 확증) |
+ * | any  | moving | any              | 발사(불변) |
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { NearestStationResult } from '../../../shared/types/station';
+import type { DirectRoute } from '../../../shared/utils/stationRoute';
+import { makeDirectRoute } from '../../../testUtils/routeFixtures';
+import {
+  PHANTOM_NEAREST_STATION,
+  PHANTOM_DESTINATION,
+  PHANTOM_ALARM_EVENT,
+  PHANTOM_STATIONARY_SPEED_MPS,
+} from './fixtures/replay_20260807_phantom';
+
+// ==========================================================================
+// Mock 정의 — replay_20260807_phantom.test.ts 패턴 재사용해 격리.
+// ==========================================================================
+
+const mockFindNearestStation = jest.fn();
+jest.mock('../../nearest-station/utils/findNearestStation', () => ({
+  findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
+}));
+
+const mockFindRoute = jest.fn();
+const mockCalculateStaticETA = jest.fn();
+const mockUpdateRouteFromPosition = jest.fn();
+const mockIsStationOnRoute = jest.fn();
+const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
+const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
+const mockGetRouteRemainingSeconds = jest.fn((..._args: unknown[]) => 120);
+jest.mock('../../../shared/utils/stationRoute', () => ({
+  findRoute: (...args: unknown[]) => mockFindRoute(...args),
+  calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
+  updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
+  isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
+  isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
+  getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
+  getRouteRemainingSeconds: (...args: unknown[]) => mockGetRouteRemainingSeconds(...args),
+}));
+
+const mockEvaluateAlarmPhase = jest.fn();
+const mockResolveAllTargets = jest.fn(
+  (..._args: unknown[]) =>
+    [] as Array<{ name: string; stops: number; alarmType: 'destination' | 'transfer'; approachLine: string }>,
+);
+jest.mock('../utils/stationAlarm', () => ({
+  evaluateAlarmPhase: (...args: unknown[]) => mockEvaluateAlarmPhase(...args),
+  resolveAllTargets: (...args: unknown[]) => mockResolveAllTargets(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../utils/boardingLockStorage', () => ({
+  getBoardingLock: () => mockGetBoardingLock(),
+}));
+
+const mockGetDismissSilence = jest.fn();
+const mockClearDismissSilence = jest.fn();
+jest.mock('../utils/dismissSilenceStorage', () => ({
+  getDismissSilence: (...args: unknown[]) => mockGetDismissSilence(...args),
+  clearDismissSilence: (...args: unknown[]) => mockClearDismissSilence(...args),
+}));
+
+const mockCancelSafetyNetByStationKind = jest.fn().mockResolvedValue(undefined);
+jest.mock('../utils/safetyNetScheduler', () => ({
+  cancelSafetyNetByStationKind: (...args: unknown[]) => mockCancelSafetyNetByStationKind(...args),
+}));
+
+const mockUpdateStationNotification = jest.fn();
+const mockFireLocalAlarmNotification = jest.fn();
+const mockFireFgAuxStationPassedNotification = jest.fn();
+jest.mock('../utils/stationNotification', () => ({
+  updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
+  fireLocalAlarmNotification: (...args: unknown[]) => mockFireLocalAlarmNotification(...args),
+  fireFgAuxStationPassedNotification: (...args: unknown[]) =>
+    mockFireFgAuxStationPassedNotification(...args),
+}));
+
+const mockGetLastNotifiedStationId = jest.fn();
+const mockSetLastNotifiedStationId = jest.fn();
+jest.mock('../utils/notificationState', () => ({
+  getLastNotifiedStationId: (...args: unknown[]) => mockGetLastNotifiedStationId(...args),
+  setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
+}));
+
+const mockLogFiredAlarm = jest.fn();
+const mockLogFiredStationPassed = jest.fn();
+const mockLogSuppressedDedupStation = jest.fn();
+const mockLogSuppressedDedupAlarm = jest.fn();
+const mockLogSuppressedSleepFirstTransfer = jest.fn();
+const mockLogSuppressedSleepStationPassed = jest.fn();
+const mockLogSuppressedDismissSilence = jest.fn();
+const mockLogSuppressedCrossCategoryDedup = jest.fn();
+const mockLogSuppressedCrossCategoryRecent = jest.fn();
+const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
+const mockLogSuppressedChannelAgnosticDedup = jest.fn();
+const mockLogSuppressedMovement = jest.fn();
+jest.mock('../utils/alarmLog', () => ({
+  logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
+  logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
+  logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
+  logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
+  logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
+    mockLogSuppressedSleepFirstTransfer(...args),
+  logSuppressedSleepStationPassed: (...args: unknown[]) =>
+    mockLogSuppressedSleepStationPassed(...args),
+  logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
+  logSuppressedMovement: (...args: unknown[]) => mockLogSuppressedMovement(...args),
+  logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryDedup(...args),
+  logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryRecent(...args),
+  logSuppressedPhaseToPhaseDedup: (...args: unknown[]) =>
+    mockLogSuppressedPhaseToPhaseDedup(...args),
+  logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
+    mockLogSuppressedChannelAgnosticDedup(...args),
+}));
+
+// ==========================================================================
+// Import (mocks after setup)
+// ==========================================================================
+import { processLocationUpdate } from '../utils/stationPipeline';
+
+const mockNearestResult: NearestStationResult = {
+  station: PHANTOM_NEAREST_STATION,
+  distanceKm: 0.15,
+};
+
+const mockRoute: DirectRoute = makeDirectRoute(3, '2');
+
+describe('#2483 — movement 게이트 우회를 arvlCd-확증(fusionSource=position-train)으로 좁힘', () => {
+  const originalFlag = process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // #2373 hop-window state는 AsyncStorage 영속 — 4개 테스트가 같은 destinationId를 재사용하므로
+    // 매 테스트 "첫 tick(기준 없음)" 상태로 초기화해야 getStationsOnLine 경로(실 미모킹)로 새지 않는다.
+    await AsyncStorage.clear();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
+    mockUpdateStationNotification.mockResolvedValue(undefined);
+    mockFireLocalAlarmNotification.mockResolvedValue(undefined);
+    mockFireFgAuxStationPassedNotification.mockResolvedValue(undefined);
+    mockCalculateStaticETA.mockReturnValue(10);
+    mockIsStationOnRoute.mockReturnValue(true);
+    mockGetLastNotifiedStationId.mockResolvedValue(null);
+    mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+    mockGetBoardingLock.mockResolvedValue(null);
+    mockResolveAllTargets.mockReturnValue([
+      { name: PHANTOM_DESTINATION.name, stops: 1, alarmType: 'destination', approachLine: '2' },
+    ]);
+    mockGetFirstLeg.mockReturnValue({ line: '2', endName: PHANTOM_DESTINATION.name });
+    mockGetDismissSilence.mockResolvedValue(null);
+    mockClearDismissSilence.mockResolvedValue(undefined);
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockEvaluateAlarmPhase.mockReturnValue(PHANTOM_ALARM_EVENT);
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+    } else {
+      process.env.EXPO_PUBLIC_MINIMAL_ALARM = originalFlag;
+    }
+  });
+
+  it('flag ON + 정적 + fusionSource=gps → destination-early 억제 (phantom 차단, #2483 본 fix)', async () => {
+    process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+
+    await processLocationUpdate({
+      lat: PHANTOM_NEAREST_STATION.lat,
+      lng: PHANTOM_NEAREST_STATION.lng,
+      destination: PHANTOM_DESTINATION,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      source: 'bg',
+      speedMps: PHANTOM_STATIONARY_SPEED_MPS,
+      fusionSource: 'gps',
+    });
+
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('flag OFF + 정적 + fusionSource=gps → 억제 (불변, #2200)', async () => {
+    delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+
+    await processLocationUpdate({
+      lat: PHANTOM_NEAREST_STATION.lat,
+      lng: PHANTOM_NEAREST_STATION.lng,
+      destination: PHANTOM_DESTINATION,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      source: 'bg',
+      speedMps: PHANTOM_STATIONARY_SPEED_MPS,
+      fusionSource: 'gps',
+    });
+
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+  });
+
+  it('flag ON + 정적 + fusionSource=position-train → 발사 (불변, arvlCd 확증 우회)', async () => {
+    process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+
+    await processLocationUpdate({
+      lat: PHANTOM_NEAREST_STATION.lat,
+      lng: PHANTOM_NEAREST_STATION.lng,
+      destination: PHANTOM_DESTINATION,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      source: 'bg',
+      speedMps: PHANTOM_STATIONARY_SPEED_MPS,
+      fusionSource: 'position-train',
+    });
+
+    expect(mockLogFiredAlarm).toHaveBeenCalled();
+    expect(mockFireLocalAlarmNotification).toHaveBeenCalled();
+  });
+
+  it('flag ON + moving + fusionSource=gps → 발사 (불변)', async () => {
+    process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+
+    await processLocationUpdate({
+      lat: PHANTOM_NEAREST_STATION.lat,
+      lng: PHANTOM_NEAREST_STATION.lng,
+      destination: PHANTOM_DESTINATION,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      source: 'bg',
+      speedMps: 10,
+      fusionSource: 'gps',
+    });
+
+    expect(mockLogFiredAlarm).toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -1710,26 +1710,52 @@ describe('processLocationUpdate', () => {
         );
       });
 
-      it('정적 사용자(movement unreliable)여도 게이트를 우회해 phase 알람을 발사한다', async () => {
+      // #2483 — 우회는 arvlCd/열차 확증(fusionSource=position-train)일 때만. flag ON 단독으로는
+      // 더 이상 우회하지 않는다(GPS-static phantom 차단, 아래 "확증 없으면 억제" 테스트 참고).
+      it('정적 사용자(movement unreliable) + fusionSource=position-train(arvlCd 확증)이면 게이트를 우회해 phase 알람을 발사한다', async () => {
         mockFindNearestStation.mockReturnValue(mockNearestResult);
         mockFindRoute.mockReturnValue(mockRoute);
         mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
 
-        await call({ speedMps: 0.1 });
+        await call({ speedMps: 0.1, fusionSource: 'position-train' });
 
         expect(mockLogSuppressedMovement).not.toHaveBeenCalled();
         expect(mockLogFiredAlarm).toHaveBeenCalled();
         expect(mockFireLocalAlarmNotification).toHaveBeenCalled();
       });
 
-      it('정적 사용자(movement unreliable)여도 게이트를 우회해 station-passed를 발사한다', async () => {
+      it('정적 사용자(movement unreliable) + fusionSource=position-train(arvlCd 확증)이면 게이트를 우회해 station-passed를 발사한다', async () => {
         mockFindNearestStation.mockReturnValue(mockNearestResult);
         mockFindRoute.mockReturnValue(mockRoute);
 
-        await call({ speedMps: 0.1 });
+        await call({ speedMps: 0.1, fusionSource: 'position-train' });
 
         expect(mockLogSuppressedMovement).not.toHaveBeenCalled();
         expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalled();
+      });
+
+      // #2483 — flag ON이어도 fusionSource가 arvlCd 확증(position-train)이 아니면 정적 상태에서
+      // 여전히 억제한다(승격 시뮬 ship-blocker였던 GPS-static phantom 차단, replay_20260902 fixture).
+      it('정적 사용자(movement unreliable) + fusionSource=gps(arvlCd 미확증)이면 flag ON이어도 phase 알람을 억제한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+        mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
+
+        await call({ speedMps: 0.1, fusionSource: 'gps' });
+
+        expect(mockLogSuppressedMovement).toHaveBeenCalled();
+        expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+        expect(mockFireLocalAlarmNotification).not.toHaveBeenCalled();
+      });
+
+      it('정적 사용자(movement unreliable) + fusionSource=gps(arvlCd 미확증)이면 flag ON이어도 station-passed를 억제한다', async () => {
+        mockFindNearestStation.mockReturnValue(mockNearestResult);
+        mockFindRoute.mockReturnValue(mockRoute);
+
+        await call({ speedMps: 0.1, fusionSource: 'gps' });
+
+        expect(mockLogSuppressedMovement).toHaveBeenCalled();
+        expect(mockFireFgAuxStationPassedNotification).not.toHaveBeenCalled();
       });
 
       it('target.isTransfer === true이면 targetKind="transfer"로 발사한다 (환승 전 구간)', async () => {

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -480,10 +480,12 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       sleepMode,
       isFirstHop,
     });
-    if (!movementSignal.reliable && !isMinimalAlarmEnabled()) {
+    if (!movementSignal.reliable && !(isMinimalAlarmEnabled() && fusionSource === 'position-train')) {
       // #2204 — FG와 동일 정적 misfire 가드. destination/transfer early가 정적 사용자에게
       // 발사되던 phantom fire(뚝섬 evidence)를 차단.
       // #2379 — EXPO_PUBLIC_MINIMAL_ALARM ON일 때는 이 과억제 게이트를 우회한다(스펙 B).
+      // #2483 — 우회를 arvlCd/열차 확증(fusionSource=position-train)으로 좁힌다. flag ON만으로는
+      // 우회하지 않는다 — GPS-static 정적 phantom(fusionSource=gps 등)은 flag ON에서도 억제 유지.
       logSuppressedMovement({
         source,
         stationName: alarmEvent.stationName,
@@ -611,9 +613,10 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     // dedup(lastNotifiedStationId) 위에 위치 — sleep으로 차단되면 lastNotifiedStationId 갱신 안 함
     // → sleep OFF 토글 후 정상 첫 hop 알림이 재발사 가능.
     // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
-    if (!movementSignal.reliable && !isMinimalAlarmEnabled()) {
+    if (!movementSignal.reliable && !(isMinimalAlarmEnabled() && fusionSource === 'position-train')) {
       // #2204 — FG와 동일 정적 misfire 가드. 정적 사용자에게 station-passed가 발사되던 회귀 차단.
       // #2379 — EXPO_PUBLIC_MINIMAL_ALARM ON일 때는 이 과억제 게이트를 우회한다(스펙 B).
+      // #2483 — 우회를 arvlCd/열차 확증(fusionSource=position-train)으로 좁힌다.
       logSuppressedMovement({
         source,
         stationName: nearest.station.name,


### PR DESCRIPTION
## 요약

Closes #2483

MINIMAL_ALARM 승격(#2482) 시뮬 결과 발견된 ship-blocker fix. `stationPipeline.ts`의 movement 정적-misfire 게이트가 `!isMinimalAlarmEnabled()` 조건이라 flag ON이면 movement 검증을 조건 없이 전면 제거 — lock 유무/dedup 무관하게 신규 trip 첫 tick에 GPS-static destination-early가 phantom 발사됐다.

## fix (surgical)

`stationPipeline.ts` movement 게이트 2곳(구 라인 483, 614 — 현재 483, 616):

```ts
// 지금:  !movementSignal.reliable && !isMinimalAlarmEnabled()
// 고침:  !movementSignal.reliable && !(isMinimalAlarmEnabled() && fusionSource === 'position-train')
```

의미: 정적이면 억제하되, (flag ON + arvlCd/열차 확증(`fusionSource === 'position-train'`))일 때만 우회. `fusionSource`는 `processLocationUpdate` inputs에 이미 존재하며, 실 caller 3곳(`bgPositionTrainFire.ts`, `undergroundConsensusFire.ts` = position-train / `backgroundLocationTask.ts` = gps)과 정확히 대응 — 좁힌 조건이 우회 필요/불필요 caller를 정확히 가른다.

## 동작 매트릭스 (테스트로 커버)

| flag | 정적 | fusionSource | 기대 | 검증 |
|---|---|---|---|---|
| OFF | static | any | 억제(불변, #2200) | `replay_20260807_phantom.test.ts` green 유지 |
| ON | static | gps | **억제(FIXED)** | `replay_20260902_movement_bypass_narrow.test.ts` RED→GREEN |
| ON | static | position-train | 발사(불변, arvlCd 확증) | 신규 테스트 |
| any | moving | any | 발사(불변) | 신규 테스트 |

## TDD 증거

1. RED: 수정 전 `flag ON + 정적 + fusionSource=gps` 시나리오에서 `mockLogFiredAlarm`이 호출됨(phantom 발사 확인) — 신규 fixture 실행 결과 3개 불변 테스트 pass, 대상 테스트만 fail(발사됨)로 명확히 재현.
2. fix 적용 후 GREEN — 4개 테스트 전부 pass.
3. 기존 `stationPipeline.test.ts`의 `#2379 EXPO_PUBLIC_MINIMAL_ALARM` describe 안 "게이트 우회" 테스트 2개는 구 스펙(flag ON 단독 우회) 전제였으므로 `fusionSource: 'position-train'`을 명시해 새 스펙으로 갱신했고, `fusionSource: 'gps'`로 억제되는 회귀 테스트 2개를 신규 추가했다.

## 검증

- `npm test` — 470 suites / 9966 tests all pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — no orphan exports
- code-review 서브에이전트 리뷰 완료 — P1 없음. P2(우회 판별식 공통 helper 추출 권고)는 머지 블로커 아님, 이슈 스펙이 "최소 변경 우선"을 명시해 이번 PR에서는 미적용.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. stationPipeline 내부 수정만, 신규 export 없음.
2. **V/X dashboard** — DebugModal alarmLog에서 flag ON + GPS-static 시 `logSuppressedMovement`(reason=movement-static-speed) 관측 가능.
3. **의존 PR** — #2482(승격)가 이 fix에 의존(전제 관계, 역방향 아님). 이 PR 자체는 독립 머지 가능. spine #2481 병행 트랙, 의존 없음.
4. **측정 plan** — 승격(#2482) 이후 production phantom 0건을 1주 관측. 본 RED fixture(`replay_20260902_movement_bypass_narrow.test.ts`)가 CI 상시 회귀 가드로 작동.
5. **Device verify** — N/A — 순수 로직 변경, 시뮬(RED→GREEN unit fixture)로 확정. type+unit only.