### PR TITLE
fix(#2486): /boarding-lock/sync에 PENDING 센티넬 trainCode 누출 가드

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -413,6 +413,30 @@ describe('useBoardingLockSync (#901)', () => {
       expect(mockedSync).toHaveBeenCalledTimes(1);
     });
 
+    // #2407 sentinel leak (신규) — buildBoardingLockMeta는 pending sentinel을 이미 걸러내지만
+    // /boarding-lock/sync 경로(fireSync)는 동일 가드가 없어 PENDING-TRAIN-CODE가 그대로
+    // payload.trainCode로 나간다. backend가 이 sentinel로 실시간 API를 조회하면 못 찾아
+    // 정상 trainCode를 덮어쓰는 회귀 — payload에서 반드시 생략돼야 한다.
+    it('#2407 — boardingLockTrainCode가 PENDING 센티넬이면 payload에서 trainCode 생략', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: 10,
+          tripActive: true,
+          boardingLockTrainCode: 'PENDING-TRAIN-CODE',
+          boardingLockLine: '2',
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      const sent = mockedSync.mock.calls[0][0];
+      expect(sent).not.toHaveProperty('trainCode');
+      // line은 trainCode 없이는 backend에서 무시되지만(D4 주석), sentinel 자체가 노선 정보로
+      // 오인되지 않도록 함께 생략한다.
+      expect(sent).not.toHaveProperty('boardingLine');
+    });
+
     it('tripActive false → true 전환 시 trainCode dedup ref도 reset', async () => {
       const { rerender } = renderHook(
         ({ active }: { active: boolean }) =>

--- a/src/features/alarm/hooks/useBoardingLockSync.ts
+++ b/src/features/alarm/hooks/useBoardingLockSync.ts
@@ -22,6 +22,7 @@ import { useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { syncBoardingLock } from '../../nearest-station/api/boardingLockSync';
+import { isPendingTrainCode } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useBoardingLockSync');
@@ -212,14 +213,20 @@ async function fireSync(input: FireSyncInput): Promise<void> {
     logger.info('skip — apns or trip token missing', { reason: input.reason });
     return;
   }
+  // #2407 — pending fallback lock의 sentinel trainCode(PENDING-TRAIN-CODE)는 backend 실시간 API에서
+  // 절대 찾을 수 없다. buildBoardingLockMeta(/trips 등록 경로)는 이미 이 sentinel을 걸러내는데
+  // /boarding-lock/sync 경로는 가드가 없어 그대로 새어나가 backend가 정상 anchor를 덮어쓰는 회귀가
+  // 있었다 — 같은 predicate로 여기서도 생략한다. boardingLine은 trainCode 없이는 backend가 무시하지만
+  // (D4 주석) sentinel 페어를 절반만 보내는 모호함을 피하기 위해 함께 생략한다.
+  const isPending = input.trainCode ? isPendingTrainCode(input.trainCode) : false;
   const payload = {
     token,
     observedStationName: input.observedStationName,
     observedAtMs: Date.now(),
     accuracy: input.accuracy,
     ...(input.subsurface !== undefined ? { subsurface: input.subsurface } : {}),
-    ...(input.trainCode ? { trainCode: input.trainCode } : {}),
-    ...(input.boardingLine ? { boardingLine: input.boardingLine } : {}),
+    ...(input.trainCode && !isPending ? { trainCode: input.trainCode } : {}),
+    ...(input.boardingLine && !isPending ? { boardingLine: input.boardingLine } : {}),
   };
   const res = await syncBoardingLock(payload);
   logger.info('boarding-lock sync sent', {


### PR DESCRIPTION
## Summary

- `/boarding-lock/sync` 경로(`fireSync`)가 `PENDING-TRAIN-CODE` sentinel을 필터 없이 backend에 POST하던 누출을 막는다.
- `buildBoardingLockMeta`(`/trips` 등록 경로)가 이미 쓰는 `isPendingTrainCode` 헬퍼를 재사용해 동일 가드를 적용.
- pending일 때 payload에서 `trainCode`/`boardingLine` 둘 다 생략(반쪽 sentinel 페어 전송 방지).

Closes #2486

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` 로컬 pass ("No orphan exports detected."). 신규 export 없음 — 기존 `isPendingTrainCode` import만 추가.
- [x] **2. V/X dashboard** — 별도 신규 지표 아님. 기존 `useBoardingLockSync` 훅의 `logger.info('boarding-lock sync sent', ...)` 로그(wrangler tail로 관측 가능)가 payload 구성 변경을 그대로 반영 — trainCode 필드가 pending일 때 로그 payload에서도 빠진다.
- [x] **3. 의존 PR** — N/A. device-only 변경, backend 코드 변경 없음.
- [x] **4. 측정 plan** — 회귀 재발 시 backend D1 `trip_events`에서 `boardingLock.trainCode === 'PENDING-TRAIN-CODE'`로 갱신된 trip을 조회해 확인 (`docs`의 backend D1 query 패턴). 정상 동작이면 pending lock 상태에서 sync 로그에 trainCode 필드 자체가 없어야 한다.
- [x] **5. Device verify** — N/A — type+unit only. 이 fix는 payload 구성 로직만 변경, 게이트/트리거 조건은 손대지 않음.

### V/X dashboard URL

wrangler tail 또는 로컬 `logger.info('boarding-lock sync sent', ...)` 콘솔 로그 — pending trainCode 케이스에서 `trainCode` 필드 부재로 확인.

### 의존 PR

N/A

---

## Test plan

- [x] `npx jest src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts` — 34/34 pass, 파일 100% coverage
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass — "No orphan exports detected."
- [x] RED 테스트: `boardingLockTrainCode: 'PENDING-TRAIN-CODE'`로 sync 발사 시 payload에 `trainCode`가 그대로 노출되는 회귀를 재현 → fix 후 GREEN (payload에서 `trainCode`/`boardingLine` 생략 확인)

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9