### PR TITLE
fix(#2489): LA update push에 apnsEnv self-heal(env-fallback) 적용

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -490,6 +490,86 @@ describe('fireLiveActivityUpdate', () => {
     expect(trip.activityPushToken).toBe('la-token');
     expect(stats.laTokenCleared).toBe(0);
   });
+
+  // apnsEnv self-heal (#2064 계열) — silent/alert push의 sendWithEnvHeal과 동일 패턴을 LA update에도
+  // 적용. 첫 시도가 BadDeviceToken(400, env mismatch 신호)이면 즉시 clear하지 않고 opposite host로
+  // 1회 retry한다. retry가 성공하면 token은 살아있는 것이 확인됐으므로 clear하지 않고, 대신
+  // trip.apnsEnv를 정정해 다음 push부터는 첫 시도로 바로 성공하도록 한다.
+  it('retries on opposite host on 400 BadDeviceToken and does not clear token when retry succeeds (env self-heal)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 200 }));
+    const stats = makeStats();
+    const trip = makeTrip({ apnsEnv: 'sandbox' });
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const [firstUrl] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const [secondUrl] = fetchImpl.mock.calls[1] as unknown as [string, RequestInit];
+    expect(firstUrl).toBe(`https://${APNS_HOSTS.sandbox}/3/device/la-token`);
+    expect(secondUrl).toBe(`https://${APNS_HOSTS.production}/3/device/la-token`);
+    // token은 유효했음이 확인됐으므로 clear하지 않는다.
+    expect(trip.activityPushToken).toBe('la-token');
+    expect(trip.activityState).toBe('live');
+    expect(stats.laTokenCleared).toBe(0);
+    expect(stats.laPushSent).toBe(1);
+    // apnsEnv 정정 + dirty=true → 호출자가 putTrip으로 정정된 env를 영속화해야 함.
+    expect(trip.apnsEnv).toBe('production');
+    expect(r.dirty).toBe(true);
+  });
+
+  it('clears token only when BOTH envs fail with BadDeviceToken (env self-heal exhausted)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip({ apnsEnv: 'sandbox' });
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(r.dirty).toBe(true);
+    expect(trip.activityPushToken).toBeUndefined();
+    expect(trip.activityState).toBe('ended');
+    expect(stats.laTokenCleared).toBe(1);
+  });
+
+  // 410 Unregistered는 env mismatch 신호가 아니다 — 어느 host로 보내도 결과가 같으므로 retry 없이
+  // 즉시 clear한다 (기존 동작 유지, self-heal 도입으로 회귀 없음을 보장).
+  it('clears immediately on 410 without retrying opposite host (410 is not env-specific)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip({ apnsEnv: 'sandbox' });
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(r.dirty).toBe(true);
+    expect(trip.activityPushToken).toBeUndefined();
+    expect(trip.activityState).toBe('ended');
+    expect(stats.laTokenCleared).toBe(1);
+  });
 });
 
 describe('fireLiveActivityDismissal', () => {

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -140,14 +140,19 @@ export interface LiveActivityFireResult {
  * LA update push 발사. trip에 activity token이 없거나 state가 live가 아니면 no-op.
  * APNs token-invalid 응답 시 token clear + state='ended'로 전이 (dirty=true).
  *
- * silent/reschedule push의 env-heal(#482)은 LA에 적용하지 않는다 — LA token은 register 시점에
- * 디바이스가 apnsEnv를 확정 통지(`POST /live-activity/register`가 trip의 apnsEnv를 신뢰)하므로,
- * 토큰/환경 불일치는 곧 토큰 자체 무효를 의미. token-invalid 분기에서 단순 clear로 흡수.
+ * #2064 계열 — silent/reschedule/trip-ended push와 동일한 apnsEnv self-heal(#482,
+ * `sendWithEnvHeal`)을 LA update에도 적용한다. LA token은 register 시점에 디바이스가 apnsEnv를
+ * 통지하지만, 로컬 sandbox 빌드 vs production trip처럼 그 통지가 실제 발사 환경과 어긋나는
+ * 경우(#2064) 첫 시도가 400 BadDeviceToken으로 실패한다 — 과거엔 이를 즉시 token-invalid로
+ * 오판해 clear했다. opposite host로 1회 retry해 진짜 무효(양쪽 env 모두 실패)인지 확인 후에만
+ * clear한다. retry가 성공하면 trip.apnsEnv를 정정(dirty=true)해 다음 push부터 첫 시도로 성공한다.
  *
  * #1899 — token-invalid 판정 확장: 410 Unregistered + 400 BadDeviceToken 둘 다 처리.
- * APNs는 rotation 직후 짧은 window에서 옛 token으로 400 BadDeviceToken을 반환하다가 410로
- * 전환되는 패턴이 있다(T2/T3 trip 경계 race). 400을 clear 안 하면 다음 cron cycle도 같은
- * stale token으로 재시도 → BadDeviceToken 폭증 + LA UI desync. reason 문자열이 SSoT.
+ * 410은 env-specific이 아니므로(양쪽 host 모두 동일 결과) retry 없이 즉시 clear한다.
+ * 400 BadDeviceToken은 env mismatch 신호일 수 있어 `sendWithEnvHeal`의 retry를 거친 뒤,
+ * 양쪽 env 모두 실패(envMismatchExhausted)했을 때만 clear한다 — rotation race(T2/T3 trip
+ * 경계)에서 옛 token이 400으로 응답되는 패턴도 결국 양쪽 env 모두 실패로 귀결되어 기존
+ * 즉시-clear 동작과 결과가 동일하게 유지된다.
  */
 export async function fireLiveActivityUpdate(
   trip: Trip,
@@ -161,19 +166,32 @@ export async function fireLiveActivityUpdate(
   if (!trip.activityPushToken || trip.activityState !== 'live') {
     return { dirty: false };
   }
-  const host = pickApnsHost(trip.apnsEnv, deps.apnsHosts);
-  const result = await sendLiveActivityUpdate({
-    activityToken: trip.activityPushToken,
-    contentState,
-    event: 'update',
-    staleDate: Math.floor(now / 1000) + staleDurationSecForKind(waypointKind),
-    config: deps.apnsConfig,
-    host,
-    fetchImpl: deps.fetchImpl,
-    now,
-  });
+  const activityToken = trip.activityPushToken;
+  const staleDate = Math.floor(now / 1000) + staleDurationSecForKind(waypointKind);
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendLiveActivityUpdate({
+        activityToken,
+        contentState,
+        event: 'update',
+        staleDate,
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
+  const result = heal.result;
   if (result.ok) {
     stats.laPushSent += 1;
+    if (heal.correctedEnv) {
+      trip.apnsEnv = heal.correctedEnv;
+      return { dirty: true };
+    }
     return { dirty: false };
   }
   stats.laPushFailed += 1;
@@ -182,7 +200,9 @@ export async function fireLiveActivityUpdate(
     status: result.status,
     reason: result.reason,
   });
-  if (isApnsTokenInvalid(result.status, result.reason)) {
+  // 410은 env-specific이 아니라 retry 없이 바로 clear. 400 BadDeviceToken은 sendWithEnvHeal이
+  // 이미 opposite host로 1회 retry했으므로, 양쪽 env 모두 실패했을 때(envMismatchExhausted)만 clear.
+  if (isApnsTokenInvalid(result.status, result.reason) && (result.status === 410 || heal.envMismatchExhausted)) {
     trip.activityPushToken = undefined;
     trip.activityState = 'ended';
     stats.laTokenCleared += 1;


### PR DESCRIPTION
Closes #2489

## Summary
- LA update push("N정거장 남음" 표시)는 silent/alert push가 이미 쓰는 `sendWithEnvHeal`(env mismatch self-heal)을 안 쓰고, 400 BadDeviceToken/410 응답 시 retry 없이 즉시 token을 clear하던 결함을 수정.
- `fireLiveActivityUpdate`(`backend/alarm-worker/src/liveActivity.ts`)가 `sendLiveActivityUpdate`를 직접 호출하던 것을 `sendWithEnvHeal`로 라우팅. 로직 중복 없이 기존 메커니즘 재사용.
- 400 BadDeviceToken → opposite host 1회 retry. 성공 시 token 유지 + `trip.apnsEnv` 정정(dirty=true, 호출자가 putTrip으로 영속화). 양쪽 env 모두 실패해야만 token clear.
- 410(Unregistered)은 env-specific 신호가 아니므로 기존처럼 retry 없이 즉시 clear — 회귀 없음.

## TDD
RED: `fireLiveActivityUpdate`가 400 BadDeviceToken 첫 응답 후 opposite host retry를 시도하는지/양쪽 실패 시에만 clear하는지/410은 retry 안 하는지 3개 테스트를 먼저 추가 → 구현 전 `toHaveBeenCalledTimes(2)` 단언이 `1`로 FAIL 확인.
GREEN: `sendWithEnvHeal` 라우팅 구현 후 3개 신규 + 기존 `liveActivity.test.ts` 75개 전체 통과.

## Wire-completion 5단
1. **Orphan 없음** — 신규 export 없음(기존 함수 내부 구현만 변경). `sendWithEnvHeal`/`isApnsTokenInvalid` 기존 export 재사용.
2. **V/X dashboard** — `wrangler tail`에서 `apns env mismatch — retry with opposite host` / `apns env corrected` 로그(env-heal 공통 헬퍼가 이미 남김) + `la update failed` 로그의 status/reason으로 관측. Cloudflare Dashboard KV `laTokenCleared` stat으로 clear 빈도 추적 가능.
3. **의존 PR** — N/A. 백엔드 단독 변경, 프론트/디바이스 코드 변경 없음.
4. **측정 plan** — 배포 후 1주간 `wrangler tail`에서 LA update 경로의 `apns env mismatch` 로그 발생 시 뒤이어 `apns env corrected`(retry 성공) 또는 `la update failed`(양쪽 실패) 로그가 따라오는지 확인. `laTokenCleared` 카운터가 기존 대비 급증하지 않는지(양쪽 실패로만 좁혀졌는지) 확인.
5. **Device verify** — 단위 테스트로 retry/clear 로직 자체는 커버되나, 실제 sandbox↔production 오설정 디바이스에서 LA 표시가 복구되는지는 실기기 mismatch 빌드 필요(에이전트가 재현 불가). 사용자 실기기 검증 권장.

## Test plan
- [x] `npx vitest run src/__tests__/liveActivity.test.ts` — 75 passed
- [x] `npm test` (backend/alarm-worker 전체) — 3096 passed
- [x] `npm run type-check` — clean

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9