### PR TITLE
fix(#2492): 환승 후 잔여 leg 노선 라벨 origin line 오표시 수정 (U2)

### DIFF
--- a/src/features/route/utils/__tests__/journeyAdapter.test.ts
+++ b/src/features/route/utils/__tests__/journeyAdapter.test.ts
@@ -131,6 +131,26 @@ describe('journeyDisplayToStops', () => {
     expect(stops[1].station).toBe('용산');
   });
 
+  it('U2(#2492) 환승 lead window: origin 재앵커링 직후 route.stopsToTransfer가 아직 0으로 갱신되지 않아도(예: 2, stale) 출발 노드는 이전 leg 노선(A)이 아니라 다음 leg 노선(B)으로 표시된다', () => {
+    // resolveJourneyOriginStation이 boardingLock/legAdvance로 origin을 환승역(건대입구)에 조기
+    // 재앵커링 → buildJourneyDisplay seg0 fromName===toName('건대입구')이지만 stale stopsToTransfer(2)가
+    // 아직 남아있는 lead window. isCollapsedZeroFirstHop이 stops===0을 요구하면 collapse 미발동 →
+    // 출발 노드가 seg.line('7', A leg 잔재)으로 오표시됨. 기대: 'gyeongui'(B, 다음 leg).
+    const journey: JourneyDisplay = {
+      segments: [
+        { line: '7', lineColor: '#747F00', fromName: '건대입구', toName: '건대입구', stops: 2 },
+        { line: 'gyeongui', lineColor: '#77C4A3', fromName: '건대입구', toName: '용산', stops: 5 },
+      ],
+      totalStops: 7,
+    };
+    const stops = journeyDisplayToStops(journey);
+    // 출발 노드 1개 + 도착 노드 1개 = 2개. phantom/중복 환승 노드가 없어야 한다.
+    expect(stops).toHaveLength(2);
+    expect(stops[0]).toEqual({ station: '건대입구', line: 'gyeongui', mark: 'filled' });
+    expect(stops[1].mark).toBe('dest');
+    expect(stops[1].station).toBe('용산');
+  });
+
   it('#665 출발역과 환승역 이름이 다르면 흡수하지 않음 (기존 동작 유지)', () => {
     const journey: JourneyDisplay = {
       segments: [

--- a/src/features/route/utils/journeyAdapter.ts
+++ b/src/features/route/utils/journeyAdapter.ts
@@ -55,11 +55,16 @@ export function journeyDisplayToStops(
     const isFirst = i === 0;
     const isLast = i === segments.length - 1;
 
-    // #665: 출발=첫 환승역(stops=0)인 경우 transfer 노드를 출발 노드에 흡수.
+    // #665: 출발=첫 환승역인 경우 transfer 노드를 출발 노드에 흡수.
     // 출발 마크의 line을 다음 segment의 line으로 두면 환승 후 노선이 시각적으로 그대로 표시되고
     // "0정거장" 표기가 사라진다. 흡수 후에는 아래 transfer push 분기를 skip.
+    // #2492(U2): 판정을 seg.stops===0이 아니라 fromName===toName만으로 한다. journeyOrigin.ts의
+    // resolveJourneyOriginStation이 boardingLock/legAdvance로 origin을 환승역에 조기
+    // 재앵커링하면 fromName===toName은 즉시 참이 되지만, route.stopsToTransfer(seg.stops)는
+    // 아직 0으로 갱신되지 않는 lead window가 생긴다. stops===0을 추가 요구하면 이 lead window
+    // 동안 collapse가 발동하지 않아 출발 노드가 이전 leg 노선(A)으로 오표시된다.
     const isCollapsedZeroFirstHop =
-      isFirst && !isLast && seg.stops === 0 && isSameStationName(seg.fromName, seg.toName);
+      isFirst && !isLast && isSameStationName(seg.fromName, seg.toName);
 
     if (isFirst) {
       const nextSeg = segments[i + 1];


### PR DESCRIPTION
Closes #2492

## 요약
경로: 출발 A → 환승 B → 목적지 C. 환승 후 B→C 구간이 여전히 A호선으로 표시되던 버그(U2) 수정.

## 근본 원인
- `resolveJourneyOriginStation`(`src/features/route/utils/journeyOrigin.ts:27-47`)이 지하 구간 등 route-progress 지연을 메꾸기 위해 journey origin을 환승역 B로 조기 재앵커링한다(의도된 설계).
- `buildJourneyDisplay`(`src/shared/utils/stationRoute.ts:855-874`)는 seg0 `line: route.fromLine`(A), `stops: route.stopsToTransfer`를 그대로 방출한다.
- `journeyDisplayToStops`의 `isCollapsedZeroFirstHop`(`src/features/route/utils/journeyAdapter.ts:61-62`, 수정 전)이 `seg.stops===0 && fromName===toName` 둘 다 요구 — 재앵커링 직후 lead window(`fromName===toName`=true이지만 `route.stopsToTransfer`가 아직 0으로 갱신 안됨)에는 collapse가 발동하지 않아 origin 노드가 `seg.line`(A)로 오표시됨.

## 선택한 fix — Candidate 1 (minimal)
`isCollapsedZeroFirstHop`을 `isSameStationName(seg.fromName, seg.toName)`만으로 판정하도록 완화. origin 재앵커링과 동일 신호를 재사용해 desync를 제거.

Candidate 2(root fix — `buildJourneyDisplay`에서 `current.name===route.transferName`이면 seg0을 아예 드롭)는 검토했으나 불필요 — candidate 1을 적용해도 phantom/중복 환승 노드가 생기지 않음을 테스트로 확인했다(collapse 발동 시 기존 브랜치와 동일하게 seg0 전체를 skip하므로 새 아티팩트 없음).

## 테스트
- RED(사전 확인, 수정 전 FAIL): 환승 lead window(재앵커링 완료 + `stops` 잔류) — 출발 노드가 B호선(다음 leg)으로 표시되어야 함을 assert.
- 가드: 환승 전 A-leg 정상 표시(기존 테스트 유지), 완전 진행된 전환(`stops===0`) 정상 동작(기존 테스트 유지), phantom/중복 환승 노드 미발생(신규 RED 테스트에서 `stops.length===2` 확인).
- 파일: `src/features/route/utils/__tests__/journeyAdapter.test.ts`

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 0 orphans.
2. **V/X dashboard** — 순수 display-logic 함수(`journeyDisplayToStops`) 변경. 시각 확인은 앱 홈 화면 타임라인(`EditorialTimeline.tsx:157`)에서 환승 후 origin 노드 노선 배지로 관측 가능. 별도 로그/대시보드 신호 없음.
3. **의존 PR** — N/A. 프론트엔드 순수 로직 변경만.
4. **측정 plan** — 실제 환승 trip에서 환승역 통과 직후(재앵커링 시점) 타임라인 origin 노드 노선 배지가 새 leg 노선으로 즉시 바뀌는지 확인. 회귀 시 U2 재현.
5. **Device verify** — 권장: 실제 환승 포함 trip에서 환승 직후 타임라인 확인. 코드 자체는 순수 함수 unit 테스트로 완결.

## 테스트 결과
- `npx jest src/features/route/utils/__tests__/journeyAdapter.test.ts` — 32 passed
- `npx jest` (전체) — 473 suites / 10007 tests passed, coverage 100%
- `npm run type-check` — clean
- `npm run lint:orphan` — 0 orphans

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9