### PR TITLE
fix(#2494): 통과역서 환승감지 모달 오출현 — 활성 route 경로상 역 억제(U1)

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -284,6 +284,72 @@ describe('useTransferAutoDetect', () => {
     expect(onAutoLock).not.toHaveBeenCalled();
   });
 
+  /**
+   * #U1 — 통과역(pass-through) 오출현 회귀 가드. 군자(5/7호선)는 물리적 환승역이지만 활성
+   * route(7호선 direct)가 이미 그 line을 안다 — 재확인 모달이 뜨면 안 된다. 군자를 벗어나
+   * route가 모르는 line(다른 물리 환승역)으로 진짜 갈아탄 경우엔 계속 detect되어야 한다(과억제 방지).
+   */
+  describe('#U1 활성 route 경로상 통과역 억제', () => {
+    const GUNJA_7: Station = { id: '0720', name: '군자', line: '7', lineColor: '#747F00', lat: 37.557, lng: 127.079 };
+    const GUNJA_5: Station = { id: '0547', name: '군자', line: '5', lineColor: '#996CAC', lat: 37.557, lng: 127.079 };
+    const gunjaNearest: NearestStationsResult = {
+      primary: GUNJA_7,
+      variants: [GUNJA_7, GUNJA_5],
+      distanceKm: 0.03,
+      isTransfer: true,
+    };
+    const directRouteLine7 = {
+      type: 'direct' as const,
+      stops: 4,
+      line: '7' as const,
+      travelSeconds: 480,
+    };
+
+    it('route가 아는 line 위의 통과역(군자) → 5호선 임박이 있어도 모달 안 뜸', () => {
+      const onAutoLock = jest.fn();
+      const arrival = makeArrival([
+        makeArrivalInfo({ destination: '까치산', arrivalSeconds: 60, line: '5', trainCode: 'T-5' }),
+      ]);
+      const { result } = renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: gunjaNearest,
+            arrival,
+            boardingLock: makeLock({ boardingLine: '7', boardingStationId: GUNJA_7.id }),
+            route: directRouteLine7,
+            destinationName: '용마산',
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(result.current.modalVisible).toBe(false);
+      expect(result.current.candidateLines).toEqual([]);
+      expect(onAutoLock).not.toHaveBeenCalled();
+    });
+
+    it('route가 모르는 line으로의 진짜 환승(off-route)은 계속 detect됨(과억제 아님)', () => {
+      const onAutoLock = jest.fn();
+      // 동대문역사문화공원(2/4/5호선)은 line 7 route와 무관 — currentStation.line(2)이 route에 없음.
+      const arrival = makeArrival([
+        makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+      ]);
+      const { result } = renderHook(() =>
+        useTransferAutoDetect(
+          baseInputs({
+            nearestStations: transferNearest,
+            arrival,
+            boardingLock: makeLock({ boardingLine: '2', boardingStationId: DDP_2.id }),
+            route: directRouteLine7,
+            destinationName: '용마산',
+            onAutoLock,
+          }),
+        ),
+      );
+      expect(result.current.modalVisible).toBe(true);
+      expect(result.current.candidateLines).toEqual(['4']);
+    });
+  });
+
   it('variants에 candidate line 없음 → 모달 후보 0 (selectLine 호출해도 no-op)', () => {
     const onAutoLock = jest.fn();
     const arrival = multiCandidateArrival();

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -33,7 +33,7 @@ import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSy
 import type { StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber, NearestStationsResult, Station } from '../../../shared/types/station';
-import { normalizeStationName, type Route } from '../../../shared/utils/stationRoute';
+import { isStationOnRoute, normalizeStationName, type Route } from '../../../shared/utils/stationRoute';
 
 export interface UseTransferAutoDetectInputs {
   /** 환승역 신호 + 후보 산출에 필요한 현재 fusion 결과. */
@@ -87,6 +87,14 @@ export function useTransferAutoDetect({
     [boardingLock, route, destinationName, currentStation],
   );
 
+  // #U1 — 현재 역이 활성 route가 이미 아는 line 위의 통과역이면 detect skip. 물리적 환승역(예:
+  // 군자 5/7호선)이라도 route가 그 line을 포함하면 재확인 불필요(#2479 원인). route가 모르는
+  // line으로의 진짜 환승은 currentStation.line이 route에 없어 계속 detect된다(과억제 방지).
+  const onRouteStation = useMemo(
+    () => (route && currentStation ? isStationOnRoute(currentStation, route) : false),
+    [route, currentStation],
+  );
+
   // #1281 — FG/BG 공유 pure 결정 로직. hook은 결과를 모달/idempotency state와 묶기만 한다.
   const detection = useMemo(
     () =>
@@ -97,8 +105,17 @@ export function useTransferAutoDetect({
         boardingLine,
         destinationName,
         onPlannedTransfer,
+        onRouteStation,
       }),
-    [nearestStations, motionStationary, arrival, boardingLine, destinationName, onPlannedTransfer],
+    [
+      nearestStations,
+      motionStationary,
+      arrival,
+      boardingLine,
+      destinationName,
+      onPlannedTransfer,
+      onRouteStation,
+    ],
   );
 
   const candidateLines = detection.candidateLines;

--- a/src/features/route/utils/__tests__/transferSwap.test.ts
+++ b/src/features/route/utils/__tests__/transferSwap.test.ts
@@ -54,6 +54,7 @@ function baseInput(overrides: Partial<Parameters<typeof evaluateTransferSwap>[0]
     boardingLine: '2' as const,
     destinationName: null as string | null,
     onPlannedTransfer: false,
+    onRouteStation: false,
     ...overrides,
   };
 }
@@ -62,6 +63,27 @@ describe('evaluateTransferSwap', () => {
   it('onPlannedTransfer이면 즉시 빈 결과(detect 안 함)', () => {
     const result = evaluateTransferSwap(baseInput({ onPlannedTransfer: true }));
     expect(result).toEqual({ candidateLines: [], candidate: null });
+  });
+
+  // #U1 — 통과역(pass-through) 오출현 회귀 가드. 군자(5/7호선)처럼 물리적 환승역이라도
+  // 활성 route가 이미 그 line을 알고 있으면(=onRouteStation) 재확인 모달을 띄우지 않는다.
+  it('onRouteStation이면 즉시 빈 결과(활성 route 경로상 통과역, 재확인 불필요)', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+    ]);
+    const result = evaluateTransferSwap(baseInput({ arrival, onRouteStation: true }));
+    expect(result).toEqual({ candidateLines: [], candidate: null });
+  });
+
+  // 과억제 방지 가드: route가 모르는 line으로의 진짜(off-route) 환승은 onRouteStation=false로
+  // 계속 detect되어야 한다 — 위 테스트와 짝을 이뤄 guard가 정확히 route-known line만 억제함을 검증.
+  it('onRouteStation=false(route가 모르는 line) → 진짜 환승은 계속 detect됨(과억제 아님)', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4' }),
+    ]);
+    const result = evaluateTransferSwap(baseInput({ arrival, onRouteStation: false }));
+    expect(result.candidateLines).toEqual(['4']);
+    expect(result.candidate).toEqual({ trainCode: 'T-4', line: '4', subwayId: expect.any(String) });
   });
 
   it('비환승 역이면 빈 결과', () => {

--- a/src/features/route/utils/transferSwap.ts
+++ b/src/features/route/utils/transferSwap.ts
@@ -48,6 +48,13 @@ export interface EvaluateTransferSwapInput {
    * 자동 detect skip. FG hook은 `findActiveTransferContext`로 산출, BG task는 항상 false.
    */
   readonly onPlannedTransfer: boolean;
+  /**
+   * #U1 — 현재 역이 활성 route 경로상의(known) line이다. true면 통과역(pass-through)으로 보고
+   * 자동 detect skip. 물리적 환승역(예: 군자 5/7호선)이라도 route가 이미 그 line을 알고 있으면
+   * 사용자에게 불필요한 재확인을 요구하지 않는다(진짜 route-off 환승은 currentStation의 line이
+   * route에 없으므로 계속 detect됨). FG hook은 `isStationOnRoute`로 산출, BG task는 항상 false.
+   */
+  readonly onRouteStation: boolean;
 }
 
 export interface EvaluateTransferSwapResult {
@@ -68,9 +75,17 @@ const EMPTY_RESULT: EvaluateTransferSwapResult = { candidateLines: [], candidate
 export function evaluateTransferSwap(
   input: EvaluateTransferSwapInput,
 ): EvaluateTransferSwapResult {
-  const { nearestStations, motionStationary, arrival, boardingLine, destinationName, onPlannedTransfer } = input;
+  const {
+    nearestStations,
+    motionStationary,
+    arrival,
+    boardingLine,
+    destinationName,
+    onPlannedTransfer,
+    onRouteStation,
+  } = input;
 
-  if (onPlannedTransfer) return EMPTY_RESULT;
+  if (onPlannedTransfer || onRouteStation) return EMPTY_RESULT;
 
   const otherLineArrivals = collectOtherLineArrivals(arrival, boardingLine);
   const detection = detectTransfer({


### PR DESCRIPTION
## Summary
Closes #2494

- ACTIVE trip 진행 중 통과역(pass-through, 예: 7호선 route에서 군자역)에서 환승 자동 detect 모달(`CurrentStationConfirmModal`)이 잘못 뜨던 버그 수정.
- 원인: `evaluateTransferSwap`의 유일한 억제 조건 `onPlannedTransfer`는 route의 **planned transfer waypoint**일 때만 true. 물리적 다중노선 환승역이지만 route가 이미 그 line을 아는 **통과역**은 억제되지 않았다.
- 수정: `onPlannedTransfer`와 나란히 새 조건 `onRouteStation`을 추가. `useTransferAutoDetect`가 `isStationOnRoute`(`src/shared/utils/stationRoute.ts:545`, 기존 helper 재사용)로 계산해 pure 함수(`evaluateTransferSwap`)에 boolean 주입 — 같은 패턴, pure 함수는 그대로 pure 유지.
- 과억제 방지: route가 **모르는** line으로의 진짜(off-route) 환승은 `onRouteStation=false`로 계속 detect됨(가드 테스트로 검증).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 0.
2. **V/X dashboard** — 순수 로직 변경, UI 신호는 기존 `transferDetectModalVisible`(HomeScreen.tsx) 그대로. 관측: `candidateLines`/`modalVisible`이 DebugModal 기존 노출 경로 그대로.
3. **의존 PR** — N/A. 프론트엔드 전용 pure 로직 변경.
4. **측정 plan** — 다음 지상 다중노선 환승역(예: 군자, 동대문역사문화공원, 왕십리 등) 통과 trip에서 모달 미출현 확인. 회귀(진짜 환승 미검출) 여부는 실제 off-route 환승 trip에서 모달 정상 출현으로 확인.
5. **Device verify** — FG 모달 동작이라 실기기 검증 권장(다중노선 통과역 실 trip). Unit은 pure 로직 커버(RED→GREEN + 과억제 가드).

## Test plan
- [x] `evaluateTransferSwap` RED(억제 미구현 시 실패) → GREEN(구현 후 통과) 확인
- [x] 과억제 가드: route가 모르는 line 변경은 여전히 candidate 반환 확인
- [x] `useTransferAutoDetect` 군자류 통합 테스트(route 아는 line 통과역 억제 / route 모르는 line 진짜 환승 유지)
- [x] `npm run type-check` pass
- [x] `npx jest` 대상 파일 pass (52/52), 전체 스위트 `npm test` 10010/10010 pass, coverage 100%
- [x] `npm run lint:orphan` 0 orphans

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9