### PR TITLE
fix(#2496): device 로컬 boarding-prompt를 MINIMAL_ALARM 마스터 스위치 뒤로

### DIFF
--- a/src/features/alarm/__tests__/localBoardingPromptWholeWire.test.ts
+++ b/src/features/alarm/__tests__/localBoardingPromptWholeWire.test.ts
@@ -47,6 +47,12 @@ jest.mock('../../../shared/utils/logger', () => ({
   }),
 }));
 
+// 이 fixture는 dogfood(MINIMAL_ALARM ON) 전제의 device 로컬 발사 wire를 검증한다 — flag OFF
+// 케이스는 useLocalBoardingPromptGate.test.ts가 별도로 커버.
+jest.mock('../../../shared/constants/debugFlags', () => ({
+  isMinimalAlarmEnabled: () => true,
+}));
+
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useLocalBoardingPromptGate } from '../hooks/useLocalBoardingPromptGate';
 import { getStationById } from '../../../shared/utils/stationRoute';

--- a/src/features/alarm/hooks/__tests__/useLocalBoardingPromptGate.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLocalBoardingPromptGate.test.ts
@@ -36,6 +36,11 @@ jest.mock('../../utils/stationNotification', () => ({
     mockFireLocalBoardingPromptNotification(...args),
 }));
 
+const mockIsMinimalAlarmEnabled = jest.fn();
+jest.mock('../../../../shared/constants/debugFlags', () => ({
+  isMinimalAlarmEnabled: () => mockIsMinimalAlarmEnabled(),
+}));
+
 const currentStation = getStationById('2-020')!; // 중곡
 const destination = getStationById('2-022')!; // 건대입구
 const route = makeDirectRoute(4, '2');
@@ -68,9 +73,47 @@ const context = {
 describe('useLocalBoardingPromptGate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // 기존 시나리오는 전부 dogfood(MINIMAL_ALARM ON) 전제 — 아래 OFF 전용 테스트에서만 override.
+    mockIsMinimalAlarmEnabled.mockReturnValue(true);
     mockBuildBoardingPromptContext.mockReturnValue(context);
     mockEvaluateLocalBoardingPromptGate.mockReturnValue({ pass: true });
     mockFireLocalBoardingPromptNotification.mockResolvedValue(true);
+  });
+
+  it('MINIMAL_ALARM 플래그가 OFF면 게이트가 pass여도 로컬 발사하지 않는다 (backend가 유일 소스)', () => {
+    mockIsMinimalAlarmEnabled.mockReturnValue(false);
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    expect(mockFireLocalBoardingPromptNotification).not.toHaveBeenCalled();
+  });
+
+  it('MINIMAL_ALARM 플래그가 ON이면 기존과 동일하게 발사한다 (dogfood 회귀 없음)', async () => {
+    mockIsMinimalAlarmEnabled.mockReturnValue(true);
+    renderHook(() =>
+      useLocalBoardingPromptGate({
+        route,
+        currentStation,
+        destination,
+        lock: null,
+        gpsFix: null,
+        arrival,
+      }),
+    );
+    await waitFor(() => {
+      expect(mockFireLocalBoardingPromptNotification).toHaveBeenCalledWith(
+        currentStation.name,
+        '2',
+        'up',
+      );
+    });
   });
 
   it('lock이 활성이면 게이트 평가 자체를 스킵한다 (context 빌드/발사 모두 안 함)', () => {

--- a/src/features/alarm/hooks/useLocalBoardingPromptGate.ts
+++ b/src/features/alarm/hooks/useLocalBoardingPromptGate.ts
@@ -30,6 +30,7 @@ import { evaluateLocalBoardingPromptGate } from '../utils/localBoardingPromptGat
 import { fireLocalBoardingPromptNotification } from '../utils/stationNotification';
 import { createLogger } from '../../../shared/utils/logger';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 
 const log = createLogger('localBoardingPromptGate');
 
@@ -50,6 +51,10 @@ export function useLocalBoardingPromptGate(params: UseLocalBoardingPromptGatePar
   const inFlightRef = useRef(false);
 
   useEffect(() => {
+    // MINIMAL_ALARM이 마스터 스위치 — 다른 device-local ALARM 발사 경로(bgPositionTrainFire.ts,
+    // undergroundConsensusFire.ts)와 동일하게 OFF면 device가 로컬 boarding-prompt를 발사하지
+    // 않는다. backend `evaluateAndMaybeFireBoardingPrompt`가 유일 소스가 된다.
+    if (!isMinimalAlarmEnabled()) return;
     if (lock != null) return; // #1921/#1921류 F2 defense와 동형 — 탑승 확정 trip은 스킵.
     if (!arrival) return;
     if (inFlightRef.current) return;


### PR DESCRIPTION
## Summary

`useLocalBoardingPromptGate`의 device-local boarding-prompt 발사(`fireLocalBoardingPromptNotification`)가 다른 device-local ALARM 발사 경로(`bgPositionTrainFire.ts`, `undergroundConsensusFire.ts`)와 달리 `isMinimalAlarmEnabled()` 게이트를 안 타고 있던 오버사이트를 수정한다. 이제 `EXPO_PUBLIC_MINIMAL_ALARM=false`(backend-authority, 프로덕션 유저 기본 상태)에서는 device가 로컬 boarding-prompt를 발사하지 않고 backend `evaluateAndMaybeFireBoardingPrompt`가 유일 소스가 된다. ON(dogfood)에서는 기존 동작 불변.

Closes #2496

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass (0 orphan). 신규 export 없음(기존 `isMinimalAlarmEnabled` re-import만).
- [x] **2. V/X dashboard** — 플래그 OFF에서 미발사는 `useLocalBoardingPromptGate.test.ts`의 신규 RED/GREEN 테스트로 관측(단위 레벨). 런타임 관측은 기존 `local_boarding_prompt_fired` breadcrumb 부재로 확인 가능(Sentry breadcrumb 미기록 = 미발사).
- [x] **3. 의존 PR** — N/A. device-only 변경, backend `evaluateAndMaybeFireBoardingPrompt`는 이미 운영 중.
- [x] **4. 측정 plan** — `EXPO_PUBLIC_MINIMAL_ALARM=false`(기본) 실기기 dogfood ride에서 `local_boarding_prompt_fired` breadcrumb가 더 이상 기록되지 않는지 확인(1주 관측). backend prompt push만 수신되면 정상.
- [x] **5. Device verify** — 필요. 플래그 OFF 상태로 실기기 탑승해 device가 로컬 boarding-prompt를 더 이상 발사하지 않고(중복/방향오탐 없음) backend prompt push만 도착하는지 확인 권장. (dogfood 빌드에서 플래그 ON으로 회귀 없는지도 별도 확인 가능하나, 기존 테스트가 커버.)

### V/X dashboard URL

DebugModal 없음(로컬 breadcrumb 기반) — Sentry breadcrumb `boarding: local_boarding_prompt_fired` 발생 여부로 관측.

### 의존 PR

N/A

---

## 계약 변경 체크리스트

N/A — push kind 추가/은퇴 없음.

---

## Test plan

- [x] `npx jest src/features/alarm/hooks/__tests__/useLocalBoardingPromptGate.test.ts` 10/10 pass
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (0 orphan)
- [ ] 실기기 dogfood ride (플래그 OFF) — device local boarding-prompt 미발사, backend prompt만 수신 확인

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9