### PR TITLE
backend-authority 모드서 device LA content 덮어쓰기 억제 — backend push 단독 저자(Wave 2)

### DIFF
--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -25,6 +25,7 @@ import {
   __resetLiveActivityPushChannelForTests,
   endLiveActivityWithDeregister,
   ensureLiveActivityRegistered,
+  shouldSkipDeviceLiveActivityWrite,
   startLiveActivityWithRegistration,
 } from '../liveActivityPushChannel';
 
@@ -411,6 +412,52 @@ describe('liveActivityPushChannel', () => {
       expect(mockStartLiveActivity).toHaveBeenCalledTimes(2);
       second.emit('tok');
       expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-2', 'tok');
+    });
+  });
+
+  // #2481 (backend-authority device 쓰기 억제 게이트, Wave 2) — device W2/W3 두 writer가 공유하는
+  // 판정 함수 단독 검증. flag는 EXPO_PUBLIC_MINIMAL_ALARM(isMinimalAlarmEnabled SSoT)로 제어한다.
+  describe('shouldSkipDeviceLiveActivityWrite (#2481)', () => {
+    const originalFlag = process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+
+    afterEach(() => {
+      if (originalFlag === undefined) {
+        delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      } else {
+        process.env.EXPO_PUBLIC_MINIMAL_ALARM = originalFlag;
+      }
+    });
+
+    it('backend-authority(flag OFF) + 이 trip의 LA push 세션이 이미 등록됨 → true(스킵)', async () => {
+      delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      expect(shouldSkipDeviceLiveActivityWrite('trip-1')).toBe(true);
+    });
+
+    it('dogfood 모드(flag ON)면 세션이 등록돼 있어도 false(device가 계속 쓴다) — 회귀 방지', async () => {
+      process.env.EXPO_PUBLIC_MINIMAL_ALARM = 'true';
+      setupListener();
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      expect(shouldSkipDeviceLiveActivityWrite('trip-1')).toBe(false);
+    });
+
+    it('backend-tracked trip 자체가 없으면(tripToken null) false — pre-boarding 등 lock 전 구간', () => {
+      delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      expect(shouldSkipDeviceLiveActivityWrite(null)).toBe(false);
+    });
+
+    it('trip은 있지만 이 프로세스에서 아직 LA push 세션을 등록 못한 상태(첫 write)면 false — blank LA 방지', () => {
+      delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      __resetLiveActivityPushChannelForTests();
+      expect(shouldSkipDeviceLiveActivityWrite('trip-never-registered')).toBe(false);
+    });
+
+    it('다른 tripToken의 세션이 등록돼 있으면(불일치) false — 새 trip 부트스트랩 허용', async () => {
+      delete process.env.EXPO_PUBLIC_MINIMAL_ALARM;
+      setupListener();
+      await startLiveActivityWithRegistration('trip-old', SAMPLE_DATA);
+      expect(shouldSkipDeviceLiveActivityWrite('trip-new')).toBe(false);
     });
   });
 

--- a/src/features/alarm/utils/__tests__/refreshLiveActivityFromBackgroundContext.test.ts
+++ b/src/features/alarm/utils/__tests__/refreshLiveActivityFromBackgroundContext.test.ts
@@ -29,6 +29,15 @@ jest.mock('../laDismissSentinel', () => ({
   isLaDismissed: () => mockIsLaDismissed(),
 }));
 
+// #2481 — 기본값 false(=device가 계속 쓴다). 게이트 로직 자체는 liveActivityPushChannel.test.ts가
+// 단독 검증하고, 여기서는 refreshLiveActivityFromBackgroundContext가 판정 결과를 존중해 조기
+// return하는지만 wire-up 검증한다.
+const mockShouldSkipDeviceLiveActivityWrite = jest.fn((..._args: unknown[]) => false);
+jest.mock('../liveActivityPushChannel', () => ({
+  shouldSkipDeviceLiveActivityWrite: (...args: unknown[]) =>
+    mockShouldSkipDeviceLiveActivityWrite(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -50,6 +59,7 @@ import {
   __test__,
 } from '../refreshLiveActivityFromBackgroundContext';
 import {
+  ACTIVE_TRIP_KEY,
   BG_LAST_STATION_KEY,
   DESTINATION_KEY,
   ROUTE_KEY,
@@ -153,6 +163,37 @@ describe('refreshLiveActivityFromBackgroundContext', () => {
     expect(isMock).toBe(false);
     expect(alarm).toBeNull();
     expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  // #2481 — backend-authority(dogfood 플래그 OFF) + backend가 이 trip의 LA push 채널을 이미
+  // 쥐고 있으면(shouldSkipDeviceLiveActivityWrite=true) BG silent-push refresh는 LA content를
+  // 전혀 쓰지 않는다 — backend push가 단독 저자(Wave 2). 이게 이 파일이 고치는 W3 writer다.
+  describe('#2481 backend-authority device 쓰기 억제 게이트', () => {
+    it('게이트가 true를 반환하면 buildLiveActivityData/updateLiveActivity 둘 다 호출 안 함', async () => {
+      setupStorage({
+        [DESTINATION_KEY]: JSON.stringify(destination),
+        [BG_LAST_STATION_KEY]: JSON.stringify(bgStation),
+        [ROUTE_KEY]: JSON.stringify(directRoute),
+        [ACTIVE_TRIP_KEY]: 'apns-token-abc',
+      });
+      mockShouldSkipDeviceLiveActivityWrite.mockReturnValueOnce(true);
+      await refreshLiveActivityFromBackgroundContext();
+      expect(mockShouldSkipDeviceLiveActivityWrite).toHaveBeenCalledWith('apns-token-abc');
+      expect(mockBuild).not.toHaveBeenCalled();
+      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    });
+
+    it('게이트가 false면(기본값) 기존처럼 updateLiveActivity로 계속 진행 — blank LA 방지', async () => {
+      setupStorage({
+        [DESTINATION_KEY]: JSON.stringify(destination),
+        [BG_LAST_STATION_KEY]: JSON.stringify(bgStation),
+        [ROUTE_KEY]: JSON.stringify(directRoute),
+        [ACTIVE_TRIP_KEY]: null,
+      });
+      await refreshLiveActivityFromBackgroundContext();
+      expect(mockShouldSkipDeviceLiveActivityWrite).toHaveBeenCalledWith(null);
+      expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('bg 없으면 no-op (마지막 정상 LA 유지) — updateLiveActivity 미호출', async () => {

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -59,11 +59,17 @@ jest.mock('live-activity', () => ({
 
 const mockEnsureLiveActivityRegistered = jest.fn().mockResolvedValue(undefined);
 const mockEndLiveActivityWithDeregister = jest.fn().mockResolvedValue(undefined);
+// #2481 — 기본값 false(=device가 계속 쓴다). 게이트 자체 로직은 liveActivityPushChannel.test.ts가
+// 단독 검증하고, 여기서는 updateStationNotification이 이 판정 결과를 존중해 조기 return하는지만
+// wire-up 검증한다.
+const mockShouldSkipDeviceLiveActivityWrite = jest.fn().mockReturnValue(false);
 jest.mock('../liveActivityPushChannel', () => ({
   ensureLiveActivityRegistered: (...args: unknown[]) =>
     mockEnsureLiveActivityRegistered(...args),
   endLiveActivityWithDeregister: (...args: unknown[]) =>
     mockEndLiveActivityWithDeregister(...args),
+  shouldSkipDeviceLiveActivityWrite: (...args: unknown[]) =>
+    mockShouldSkipDeviceLiveActivityWrite(...args),
 }));
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -486,6 +492,34 @@ describe('stationNotification', () => {
       mockEnsureLiveActivityRegistered.mockRejectedValueOnce(new Error('LA 등록 실패'));
       await updateStationNotification(mockStation, 154);
       expectNotificationContent('시청역', '1호선 · 약 154m');
+    });
+
+    // #2481 — backend-authority(dogfood 플래그 OFF) + backend가 이 trip의 LA push 채널을 이미
+    // 쥐고 있으면(shouldSkipDeviceLiveActivityWrite=true) device는 LA content를 전혀 쓰지 않는다
+    // (backend push가 단독 저자, Wave 2).
+    describe('#2481 backend-authority device 쓰기 억제 게이트', () => {
+      it('게이트가 true를 반환하면 ensureLiveActivityRegistered/updateLiveActivity 둘 다 호출 안 함', async () => {
+        await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'apns-token-abc');
+        mockShouldSkipDeviceLiveActivityWrite.mockReturnValueOnce(true);
+        await updateStationNotification(mockStation, 154);
+        expect(mockShouldSkipDeviceLiveActivityWrite).toHaveBeenCalledWith('apns-token-abc');
+        expect(mockEnsureLiveActivityRegistered).not.toHaveBeenCalled();
+        expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+        expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+      });
+
+      it('게이트가 false면(기본값) 기존처럼 ensureLiveActivityRegistered 경로로 진행한다', async () => {
+        await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'apns-token-abc');
+        await updateStationNotification(mockStation, 154);
+        expect(mockShouldSkipDeviceLiveActivityWrite).toHaveBeenCalledWith('apns-token-abc');
+        expect(mockEnsureLiveActivityRegistered).toHaveBeenCalledTimes(1);
+      });
+
+      it('ACTIVE_TRIP_KEY 없을 때도 게이트에 null을 넘기고, 게이트가 false면 updateLiveActivity로 계속 진행(blank LA 방지)', async () => {
+        await updateStationNotification(mockStation, 154);
+        expect(mockShouldSkipDeviceLiveActivityWrite).toHaveBeenCalledWith(null);
+        expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('updateLiveActivity를 호출한다', async () => {

--- a/src/features/alarm/utils/liveActivityPushChannel.ts
+++ b/src/features/alarm/utils/liveActivityPushChannel.ts
@@ -28,6 +28,7 @@ import {
   registerLiveActivityToken,
 } from '../api/alarmBackend';
 import { createLogger } from '../../../shared/utils/logger';
+import { isMinimalAlarmEnabled } from '../../../shared/constants/debugFlags';
 
 const log = createLogger('liveActivityPushChannel');
 
@@ -164,6 +165,30 @@ export async function startLiveActivityWithRegistration(
     }
     throw e;
   }
+}
+
+/**
+ * #2481 (backend-authority device 쓰기 억제 게이트, Wave 2) — backend-authority 모드
+ * (`isMinimalAlarmEnabled() === false`)에서 device가 LA content-state를 써도 되는지 판정한다.
+ * device W2(`updateStationNotification`)/W3(`refreshLiveActivityFromBackgroundContext`)가
+ * 공유하는 단일 게이트 — backend가 이미 이 trip의 LA push 채널(`activeTripToken`)을 쥐고 있으면
+ * device GPS 추정치로 backend의 정확한 "N정거장"을 덮어쓰지 않는다.
+ *
+ * true(스킵)는 다음이 모두 성립할 때만:
+ *   - backend-authority 모드(dogfood 플래그 OFF)
+ *   - tripToken이 존재하고, 이미 이 프로세스에서 LA push 세션이 등록된(`activeTripToken`과 일치)
+ *     상태 — backend가 이 trip의 push 채널로 LA를 갱신할 수 있는 상태.
+ *
+ * false(계속 device가 쓴다)는 blank LA 회귀를 막는 3개 케이스를 모두 커버한다:
+ *   - dogfood 모드(flag ON) — 기존 device 동작 100% 유지.
+ *   - backend-tracked trip 자체가 없음(tripToken null) — pre-boarding 등 lock 전 구간.
+ *   - trip은 있지만 아직 이 프로세스에서 LA push 세션을 등록 못한 상태(첫 write가 곧 세션
+ *     부트스트랩이므로 스킵하면 LA가 영영 시작되지 않는다).
+ */
+export function shouldSkipDeviceLiveActivityWrite(tripToken: string | null): boolean {
+  if (isMinimalAlarmEnabled()) return false;
+  if (!tripToken) return false;
+  return activeTripToken === tripToken;
 }
 
 /**

--- a/src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts
+++ b/src/features/alarm/utils/refreshLiveActivityFromBackgroundContext.ts
@@ -28,6 +28,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import * as LiveActivity from 'live-activity';
 import {
+  ACTIVE_TRIP_KEY,
   BG_LAST_STATION_KEY,
   DESTINATION_KEY,
   ROUTE_KEY,
@@ -37,6 +38,7 @@ import type { Route } from '../../../shared/utils/stationRoute';
 import { createLogger } from '../../../shared/utils/logger';
 import { buildLiveActivityData } from './stationNotification';
 import { isLaDismissed } from './laDismissSentinel';
+import { shouldSkipDeviceLiveActivityWrite } from './liveActivityPushChannel';
 
 const logger = createLogger('SilentPushLaRefresh');
 
@@ -104,10 +106,11 @@ export async function refreshLiveActivityFromBackgroundContext(): Promise<void> 
       logger.info('LA dismiss sentinel active — skip refresh');
       return;
     }
-    const [destRaw, routeRaw, bgRaw] = await Promise.all([
+    const [destRaw, routeRaw, bgRaw, tripToken] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(ROUTE_KEY),
       AsyncStorage.getItem(BG_LAST_STATION_KEY),
+      AsyncStorage.getItem(ACTIVE_TRIP_KEY),
     ]);
 
     const destination = readDestination(destRaw);
@@ -124,6 +127,12 @@ export async function refreshLiveActivityFromBackgroundContext(): Promise<void> 
     // lockscreen에 의도치 않은 LA를 띄울 위험. 둘 다 본 가드로 차단.
     if (!bg) {
       logger.info('BG_LAST_STATION absent — skip refresh (preserve last LA state)');
+      return;
+    }
+    // #2481 — backend-authority 모드 + 이미 backend가 이 trip의 LA push 채널을 쥐고 있으면
+    // device GPS 추정치로 backend의 정확한 "N정거장"을 덮어쓰지 않는다(Wave 2).
+    if (shouldSkipDeviceLiveActivityWrite(tripToken)) {
+      logger.info('backend-authority active trip — skip BG LA refresh write');
       return;
     }
     const currentStation = bg.station;

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -19,6 +19,7 @@ import { ACTIVE_TRIP_KEY, APNS_TOKEN_KEY } from '../../../shared/constants/stora
 import {
   ensureLiveActivityRegistered,
   endLiveActivityWithDeregister,
+  shouldSkipDeviceLiveActivityWrite,
 } from './liveActivityPushChannel';
 import { stopVibration } from './alarmSound';
 import { createLogger } from '../../../shared/utils/logger';
@@ -564,6 +565,12 @@ export async function updateStationNotification(
       // #1288 — 활성 trip이 있으면 LA push 토큰 등록 채널을 거친다. 활성 trip이 없으면
       // 기존처럼 update만 호출(LA push 미등록은 silent, LA 자체는 정상 동작).
       const tripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+      // #2481 — backend-authority 모드 + 이미 backend가 이 trip의 LA push 채널을 쥐고 있으면
+      // device GPS 추정치로 backend의 정확한 "N정거장"을 덮어쓰지 않는다(Wave 2).
+      if (shouldSkipDeviceLiveActivityWrite(tripToken)) {
+        liveActivityLogger.info('backend-authority 활성 trip — device LA 쓰기 스킵(backend push 단독 저자)');
+        return;
+      }
       if (tripToken) {
         await ensureLiveActivityRegistered(tripToken, data);
       } else {


### PR DESCRIPTION
Closes #2498

## 요약

확정 아키텍처(backend추적 → Live Activity "N정거장" 표시, device는 탭만): 단일 iOS Live Activity 인스턴스를 3개 writer가 last-writer-wins로 덮어쓰고 있었다.

- **W1** = backend APNs LA push (authoritative "N정거장")
- **W2** = `stationNotification.ts`의 `updateStationNotification` — device GPS 기반 `stopsRemaining`으로 LA를 갱신
- **W3** = `refreshLiveActivityFromBackgroundContext.ts` — device BG_LAST_STATION 기반으로 LA를 재구성해 갱신

device GPS가 부정확한 지하 구간에서 W2/W3이 backend의 정확한 "N정거장"을 device 오차값으로 덮어썼다.

## 변경

`liveActivityPushChannel.ts`에 신규 export `shouldSkipDeviceLiveActivityWrite(tripToken)` 추가 — W2/W3가 공유하는 단일 게이트.

```ts
export function shouldSkipDeviceLiveActivityWrite(tripToken: string | null): boolean {
  if (isMinimalAlarmEnabled()) return false;
  if (!tripToken) return false;
  return activeTripToken === tripToken;
}
```

- `true`(device 쓰기 스킵) — backend-authority 모드(`isMinimalAlarmEnabled() === false`) **AND** 이 tripToken의 LA push 세션이 이미 이 프로세스의 `activeTripToken`(liveActivityPushChannel 모듈 상태, `ensureLiveActivityRegistered`가 채움)과 일치. 즉 backend가 실제로 이 trip의 LA push 채널을 쥐고 있는 상태.
- `false`(device가 계속 씀) — 3개 blank-LA 방지 케이스:
  1. dogfood 모드(flag ON) — 기존 동작 100% 불변
  2. backend-tracked trip 자체가 없음(tripToken null) — pre-boarding 등 lock 전 구간
  3. trip은 있지만 이 프로세스에서 아직 LA push 세션을 등록 못한 상태(첫 write=세션 부트스트랩 자체이므로 스킵하면 LA가 영영 안 뜬다)

W2(`updateStationNotification`)와 W3(`refreshLiveActivityFromBackgroundContext`)에 동일 게이트를 배선 — `true`면 `buildLiveActivityData`/`ensureLiveActivityRegistered`/`updateLiveActivity` 호출 전에 조기 return.

pre-boarding 라이터(`useLiveActivityPreBoardingLifecycle`)는 `LiveActivity.updateLiveActivity`를 직접 호출하고 `updateStationNotification`을 거치지 않으므로 이 게이트의 영향을 받지 않는다(스코프 밖, 변경 없음).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 로컬 0건. `shouldSkipDeviceLiveActivityWrite`는 `stationNotification.ts`(W2)·`refreshLiveActivityFromBackgroundContext.ts`(W3) 양쪽에서 caller 존재.
2. **V/X dashboard** — DebugModal 표면 없음(내부 순수 게이트 함수, 부수효과는 조기 return뿐). 관측은 로그(`liveActivityLogger.info('backend-authority 활성 trip — device LA 쓰기 스킵...')` / 동일 패턴 BG logger) + 아래 테스트.
3. **의존 PR** — N/A. backend가 이미 LA push 채널로 갱신하고 있다는 전제(기존 확정 아키텍처, 이 PR은 device 쪽 억제만).
4. **측정 plan** — 다음 dogfood 실탑승(flag OFF) 1회에서 LA가 backend 값("N정거장")을 유지하고 device 숫자로 튀지 않는지 관찰. wrangler tail로 backend LA push 발사 시각과 device 로그의 스킵 시각 대조 가능.
5. **Device verify** — **필요**. 시나리오: flag OFF 상태 실탑승 1회 —
   - LA가 backend push의 "N정거장"을 유지(device GPS 흔들려도 안 튐)
   - **pre-boarding 상태에서 LA blank 안 됨** (destination만 설정, lock 전)
   - **backend trip 없는 상태에서 LA blank 안 됨** (게이트가 오탐하면 안 됨)
   - dogfood 빌드(flag ON) 별도 검증 시 기존과 동일하게 device 숫자가 뜨는지 회귀 확인

## 테스트

- `liveActivityPushChannel.test.ts` — 게이트 함수 단독 5케이스: backend-authority+세션등록→true / dogfood ON→false / trip 없음→false / 세션 미등록(첫 write)→false / 다른 tripToken 세션→false
- `stationNotification.test.ts` (W2) — 게이트 true→`ensureLiveActivityRegistered`/`updateLiveActivity`/알림 fallback 전부 미호출, false(기본)→기존 경로 진행, ACTIVE_TRIP_KEY 없어도(null) 게이트 통과해 blank 안 됨
- `refreshLiveActivityFromBackgroundContext.test.ts` (W3) — 게이트 true→`buildLiveActivityData`/`updateLiveActivity` 미호출, false(기본)→기존처럼 진행(blank LA 방지 케이스)

`npm test` 전체 10017 tests pass, coverage 100% 유지. `npm run type-check` pass. `npm run lint:orphan` 0 orphans.

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9