### PR TITLE
fix(#2501): pending lock deadlock — explicit train 선택 UI로 유도

### DIFF
--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -26,6 +26,7 @@ import {
   FALLBACK_BOARDING_DURATION_MINUTES,
   FREE_TRIP_DESTINATION_SENTINEL,
   isPendingTrainCode,
+  isRealBoardingLock,
 } from '../../../shared/constants/boardingLock';
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 import { useLockSuggestion } from '../api/useLockSuggestion';
@@ -126,9 +127,10 @@ const isReachable = (train: ArrivalInfo): boolean => train.arrivalSeconds >= 0;
 /**
  * #2407 — lock이 이미 확정된(pending 아닌) trainCode로 존재하면 lockSuggestion 채택을 skip.
  * pending fallback lock(trainCode 미확정)은 upgrade 대상이라 skip하지 않는다.
+ * `isRealBoardingLock`(shared, Gap B)와 동일 predicate — 소비처가 늘어나며 단일 SSOT로 위임.
  */
 function shouldSkipExistingLock(lock: BoardingLock | null): boolean {
-  return lock !== null && !isPendingTrainCode(lock.trainCode);
+  return isRealBoardingLock(lock);
 }
 
 /**

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -102,6 +102,7 @@ import { useTransferAutoDetect } from '../features/route/hooks/useTransferAutoDe
 import {
   BOARDING_PROXIMITY_THRESHOLD_M,
   TRANSFER_WALKING_BUFFER_SECONDS,
+  isRealBoardingLock,
 } from '../shared/constants/boardingLock';
 import { getTransferSeconds } from '../shared/utils/transferTimes';
 import { BoardingTrainList } from '../features/alarm/components/BoardingTrainList';
@@ -1654,7 +1655,12 @@ export default function HomeScreen() {
                           renderHopSlot={(stop, i) => {
                             // #758 — origin hop slot에 BoardingLock 활성 상태 카드 렌더.
                             // BoardingLockBanner 별도 카드는 제거되고 timeline 안 hop으로 통합.
-                            if (i === 0 && stop.mark === 'filled' && boardingLock) {
+                            // #2407 Gap B (root fix) — pending fallback lock(trainCode 미확정)은
+                            // backend에 절대 도달하지 못하는 sentinel이라(buildBoardingLockMeta
+                            // skip) "실 lock"이 아니다. isRealBoardingLock=false면 이 hop card
+                            // 대신 아래 BoardingTrainList 분기로 흘러 사용자가 실제 열차를 직접
+                            // 선택하게 한다 — lockSuggestion만 기다리는 deadlock을 UI에서 차단.
+                            if (i === 0 && stop.mark === 'filled' && isRealBoardingLock(boardingLock)) {
                               // #897 Seam A: lock.trainCode 매칭 train의 잔여 ETA → 지연 칩 계산 input.
                               // 매칭 없으면 undefined → 칩 미노출 (graceful).
                               // #1326: 표시 전용 lookup이라 boardingListArrivals 사용(Gate 1 무관). 방향 폴백
@@ -1673,7 +1679,9 @@ export default function HomeScreen() {
                             // #649 — origin hop slot: 현재역에서 다음 인접역 방면 boarding list.
                             // #758 — 탑승역 GPS 근접 게이트(BOARDING_PROXIMITY_THRESHOLD_M). custom origin은
                             //  사용자 명시 설정이라 게이트 면제. 게이트 미통과 시 list 비노출 + 안내 텍스트.
-                            if (i === 0 && stop.mark === 'filled' && !boardingLock && effectiveOrigin) {
+                            // #2407 Gap B — pending fallback lock도 이 분기(train picker)로
+                            // 흘러야 하므로 !boardingLock 대신 !isRealBoardingLock 사용.
+                            if (i === 0 && stop.mark === 'filled' && !isRealBoardingLock(boardingLock) && effectiveOrigin) {
                               const distanceToCurrentM = (result?.distanceKm ?? Infinity) * 1000;
                               const nearBoardingStation =
                                 isCustomOrigin || distanceToCurrentM < BOARDING_PROXIMITY_THRESHOLD_M;

--- a/src/shared/constants/__tests__/boardingLock.test.ts
+++ b/src/shared/constants/__tests__/boardingLock.test.ts
@@ -1,4 +1,5 @@
-import { PENDING_TRAIN_CODE, isPendingTrainCode } from '../boardingLock';
+import { PENDING_TRAIN_CODE, isPendingTrainCode, isRealBoardingLock } from '../boardingLock';
+import type { BoardingLock } from '../../types/boardingLock';
 
 describe('isPendingTrainCode (#2407)', () => {
   it('PENDING_TRAIN_CODE sentinel → true', () => {
@@ -11,5 +12,31 @@ describe('isPendingTrainCode (#2407)', () => {
 
   it('빈 문자열 → false (sentinel은 명시 상수만 인정, falsy coercion에 의존하지 않음)', () => {
     expect(isPendingTrainCode('')).toBe(false);
+  });
+});
+
+// #2407 Gap B (root fix) — pending fallback lock은 backend 관점에서 lockless와 동일 취급돼야
+// 한다. UI가 "실 lock"으로 오인해 train picker를 숨기면(BoardingLockHopCard) 사용자가 실
+// trainCode를 고를 기회를 영영 잃는 deadlock이 생긴다.
+describe('isRealBoardingLock (#2407 Gap B)', () => {
+  const BASE_LOCK: BoardingLock = {
+    destinationId: 'dst',
+    trainCode: '2026082601',
+    boardingStationId: 'S1',
+    boardingLine: '2',
+    boardedAt: Date.now(),
+    expectedDurationMs: 600_000,
+  };
+
+  it('lock=null → false', () => {
+    expect(isRealBoardingLock(null)).toBe(false);
+  });
+
+  it('실 trainCode lock → true', () => {
+    expect(isRealBoardingLock(BASE_LOCK)).toBe(true);
+  });
+
+  it('pending trainCode lock(PENDING_TRAIN_CODE) → false', () => {
+    expect(isRealBoardingLock({ ...BASE_LOCK, trainCode: PENDING_TRAIN_CODE })).toBe(false);
   });
 });

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -2,6 +2,8 @@
  * BoardingLock 관련 상수 — PR C/D에서 scheduler/알람도 참조해 drift 방지 (#584).
  */
 
+import type { BoardingLock } from '../types/boardingLock';
+
 /**
  * trip ETA 미상 시 lock 생성에 사용할 fallback 지속시간(분).
  * 자동 만료는 expectedDurationMs × BOARDING_LOCK_EXPIRY_FACTOR(=1.5)이므로
@@ -214,6 +216,20 @@ export const PENDING_TRAIN_CODE = 'PENDING-TRAIN-CODE';
 /** lock.trainCode가 #2407 fallback lock의 미확정 sentinel인지 판별. */
 export function isPendingTrainCode(trainCode: string): boolean {
   return trainCode === PENDING_TRAIN_CODE;
+}
+
+/**
+ * #2407 Gap B (root fix) — lock이 backend에 도달 가능한 "실" lock인지 판별.
+ *
+ * pending fallback lock(trainCode=PENDING_TRAIN_CODE)은 `buildBoardingLockMeta`가 backend 등록을
+ * 보류하는 sentinel이라 존재해도 backend 관점에서는 lockless와 동일하다. UI가 이를 "탑승
+ * 확정됨"처럼 렌더하면(BoardingLockHopCard) 사용자가 실 trainCode를 고를 기회(BoardingTrainList)를
+ * 영영 못 만나 deadlock(lockSuggestion만이 유일한 upgrade 경로인데 backend evidence가 없으면
+ * lockSuggestion도 안 옴)에 빠진다. 소비처는 이 predicate로 "실 lock" vs "미확정 lock"을
+ * 구분해, 미확정이면 lockless와 동일하게 취급(원 train 선택 UI로 유도)해야 한다.
+ */
+export function isRealBoardingLock(lock: BoardingLock | null): lock is BoardingLock {
+  return lock !== null && !isPendingTrainCode(lock.trainCode);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Closes #2501
- `tryAutoLock`이 실 trainCode 확정에 실패하면(#2407) `PENDING_TRAIN_CODE` sentinel lock을 만드는데, 이 lock은 backend에 절대 도달 못하고(`buildBoardingLockMeta.ts:112`가 등록 skip) UI는 이를 "탑승 확정"처럼 렌더해(`BoardingLockHopCard`) 사용자가 실제 열차를 고를 수 있는 `BoardingTrainList`를 영영 보지 못하는 deadlock을 fix.
- `isRealBoardingLock(lock)` shared predicate 추가 → `HomeScreen.tsx`의 origin hop slot 두 분기(`BoardingLockHopCard` vs `BoardingTrainList`) 조건을 `boardingLock` → `isRealBoardingLock(boardingLock)`로 교체. `useBoardingLockController.ts`의 기존 동일 로직(`shouldSkipExistingLock`)도 이 shared 함수로 위임(SSOT 통합).
- 사용자가 `BoardingTrainList`에서 직접 탭 → `createLockFromTrain`이 실 trainCode lock을 생성 → `POST /trips`로 backend 정상 도달(store의 "기존 Lock 자동 교체" 정책으로 PENDING lock을 덮어씀).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 0건 확인.
2. **V/X dashboard** — UI 전이(HopCard↔TrainList)는 실기기 화면에서만 직접 관측 가능. `isRealBoardingLock` 판정 자체는 unit test로 커버(코드 레벨 V). backend 도달 여부는 기존 `POST /trips` 로그/D1로 관측(신규 채널 아님).
3. **의존 PR** — N/A (frontend-only).
4. **측정 plan** — 1주 production: PENDING lock 생성 후 `createLockFromTrain`으로 실 lock 전환되는 비율(현재는 lockSuggestion 도착에만 의존해 거의 0에 수렴했을 것으로 추정) 증가 확인.
5. **Device verify** — **UX-critical, 실기기 확인 필요.** PENDING lock 발생 시나리오(도착정보 API 일시 실패/ambiguity)를 재현해 BoardingTrainList가 HopCard 대신 노출되는지, 탭 시 실 lock으로 정상 전환되는지 확인. `src/screens/`는 coverage/RTL 제외 대상(CLAUDE.md 컨벤션)이라 코드-only 검증(type-check + unit)만으로는 이 UI 전이를 볼 수 없음 — 에이전트가 검증 불가한 갭.

## Test plan
- [x] `isRealBoardingLock` unit test: null → false / 실 lock → true / pending lock → false
- [x] `useBoardingLockController.test.tsx` 전체 green (predicate 교체 회귀 없음, 94 tests)
- [x] `npm test` 전체 green, 100% coverage
- [x] `npm run type-check` clean
- [x] `npm run lint:orphan` 0 orphans
- [ ] 실기기: 환승역/도착정보 실패 시나리오에서 BoardingTrainList 노출 + 탭 후 lock 전환 확인 (사용자 담당)

## 결정 사항 (사용자 리뷰 요청)
tryAutoLock 실패 시 "explicit train 선택으로 유도"하는 방법으로, 새 모달/네비게이션을 추가하는 대신 기존에 이미 같은 위치(origin hop slot)에 조건부로 존재하던 `BoardingTrainList`가 PENDING lock 상태에서도 노출되도록 조건만 수정했습니다. 별도 강제 팝업/네비게이션이 아니라 "지금 보고 있는 화면에 이미 열차 목록이 있다"는 형태입니다 — BOARDING_PROXIMITY_THRESHOLD_M(500m) 게이트 안에 있을 때만 리스트가 뜨고, 게이트 밖이면 기존과 동일하게 hint 텍스트만 보입니다. 더 적극적인 유도(예: 강제 모달)가 필요하면 후속 이슈로 분리 가능합니다.

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9