### PR TITLE
feat(#2504): backend realtimePosition trainCode resolver — lockless 명시 탑승 anchor → lock 승격

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingAnchorResolver.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingAnchorResolver.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Backend-authority boarding trainCode resolver — 단위 테스트 (committed architecture, 2026-09-03).
+ *
+ * `resolveTrainCodeFromPositions`(pure) + `attemptBoardingAnchorResolution`(seoul.fetchPositions
+ * 호출 wrapper) 둘 다 검증한다. 안전 불변식 최우선: 0개/2개+ 후보는 절대 resolved를 반환하지
+ * 않는다(틀린 열차를 lock하는 것이 이 기능이 막아야 하는 핵심 위험).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  attemptBoardingAnchorResolution,
+  POSITION_FRESHNESS_MS,
+  resolveTrainCodeFromPositions,
+  type BoardingAnchor,
+} from '../boardingAnchorResolver';
+import { SeoulArrivalClient, type PositionEntry } from '../seoul';
+import type { Trip } from '../types';
+
+const NOW = 1_700_000_000_000;
+
+function position(overrides: Partial<PositionEntry> & { trainCode: string }): PositionEntry {
+  return {
+    stationName: '중곡',
+    trainSttus: 1, // ARRIVED
+    isUp: false,
+    recptnMs: NOW,
+    ...overrides,
+  };
+}
+
+const ANCHOR: BoardingAnchor = { line: '7', boardingStation: '중곡', direction: 'down' };
+
+describe('resolveTrainCodeFromPositions', () => {
+  it('정확히 1개(ARRIVED) 매칭 → resolved', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246' })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'resolved', trainCode: '7246' });
+  });
+
+  it('정확히 1개(APPROACHING) 매칭, ARRIVED 없음 → resolved', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', trainSttus: 0 })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'resolved', trainCode: '7246' });
+  });
+
+  it('후보 0개 → none', () => {
+    expect(resolveTrainCodeFromPositions(ANCHOR, [], NOW)).toEqual({ status: 'none' });
+  });
+
+  it('같은 tier(ARRIVED) 2개+ → ambiguous (틀린 열차 추측 금지)', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [
+        position({ trainCode: '7246' }),
+        position({ trainCode: '7248' }),
+      ],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'ambiguous' });
+  });
+
+  it('DEPARTED(2)만 있으면 → none (제외, ambiguous 아님)', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', trainSttus: 2 })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'none' });
+  });
+
+  it('방향 불일치(isUp 반대) → 후보에서 제외', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', isUp: true })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'none' });
+  });
+
+  it('direction=null이면 양방향 모두 허용', () => {
+    const anchor: BoardingAnchor = { ...ANCHOR, direction: null };
+    const result = resolveTrainCodeFromPositions(
+      anchor,
+      [position({ trainCode: '7246', isUp: true })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'resolved', trainCode: '7246' });
+  });
+
+  it('stationName 불일치 → 후보에서 제외', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', stationName: '군자' })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'none' });
+  });
+
+  it('recptnMs=0(누락) → 신뢰 불가로 제외', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', recptnMs: 0 })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'none' });
+  });
+
+  it('recptnMs가 freshness 임계 초과(stale) → 제외', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', recptnMs: NOW - POSITION_FRESHNESS_MS - 1 })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'none' });
+  });
+
+  it('freshness 임계 이내(경계) → 포함', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [position({ trainCode: '7246', recptnMs: NOW - POSITION_FRESHNESS_MS })],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'resolved', trainCode: '7246' });
+  });
+
+  it('ARRIVED 1개 + APPROACHING 1개(다른 trainCode) → ARRIVED tier 우선 채택 (APPROACHING 무시)', () => {
+    const result = resolveTrainCodeFromPositions(
+      ANCHOR,
+      [
+        position({ trainCode: '7246', trainSttus: 1 }),
+        position({ trainCode: '7248', trainSttus: 0 }),
+      ],
+      NOW,
+    );
+    expect(result).toEqual({ status: 'resolved', trainCode: '7246' });
+  });
+});
+
+describe('attemptBoardingAnchorResolution', () => {
+  function makeTrip(overrides: Partial<Trip> = {}): Trip {
+    return {
+      token: 'tok',
+      route: { type: 'direct', line: '7', stops: 1 },
+      destination: '어린이대공원',
+      waypoints: [{ stationName: '어린이대공원', line: '7', kind: 'destination' }],
+      expiresAt: NOW + 60 * 60_000,
+      createdAt: NOW,
+      alarmAtEpochMs: NOW + 60_000,
+      infoModeEnabled: true,
+      promptDisplay: { originStation: '중곡', line: '7' },
+      ...overrides,
+    };
+  }
+
+  function makeSeoulWithPositions(
+    positions: Array<Partial<PositionEntry> & { trainCode: string }>,
+  ): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimePositionList: positions.map((p) => ({
+              trainNo: p.trainCode,
+              statnNm: p.stationName ?? '중곡',
+              trainSttus: p.trainSttus ?? 1,
+              updnLine: p.isUp === true ? '상행' : '하행',
+              lastRecptnDt: recptnDtFor(p.recptnMs ?? NOW),
+            })),
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+  }
+
+  /** seoul.ts parseRecptnDt는 `<recptnDt 공백구분> + '+09:00'`을 Date.parse한다 — 역산해서
+   * 주어진 epoch ms를 그대로 복원하는 문자열을 만든다. */
+  function recptnDtFor(ms: number): string {
+    return new Date(ms + 9 * 60 * 60_000).toISOString().slice(0, 19).replace('T', ' ');
+  }
+
+  it('정확히 1개 매칭 → BoardingLockMeta 반환 (trainCode/line/segmentStations)', async () => {
+    const seoul = makeSeoulWithPositions([{ trainCode: '7246' }]);
+    const trip = makeTrip();
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).not.toBeNull();
+    expect(result?.trainCode).toBe('7246');
+    expect(result?.line).toBe('7');
+    expect(result?.segmentStations[0]).toBe('중곡');
+    expect(result?.segmentStations).toContain('어린이대공원');
+    expect(result?.expiresAt).toBeGreaterThan(NOW);
+  });
+
+  it('infoModeEnabled !== true → null (seoul 호출 안 함)', async () => {
+    const seoul = makeSeoulWithPositions([{ trainCode: '7246' }]);
+    const trip = makeTrip({ infoModeEnabled: false });
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).toBeNull();
+    expect(seoul.stats.callCount).toBe(0);
+  });
+
+  it('promptDisplay 없음 → null (seoul 호출 안 함)', async () => {
+    const seoul = makeSeoulWithPositions([{ trainCode: '7246' }]);
+    const trip = makeTrip({ promptDisplay: undefined });
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).toBeNull();
+    expect(seoul.stats.callCount).toBe(0);
+  });
+
+  it('후보 2개(ambiguous) → null, lock 승격 안 함', async () => {
+    const seoul = makeSeoulWithPositions([
+      { trainCode: '7246' },
+      { trainCode: '7248' },
+    ]);
+    const trip = makeTrip();
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).toBeNull();
+  });
+
+  it('후보 0개(none) → null', async () => {
+    const seoul = makeSeoulWithPositions([]);
+    const trip = makeTrip();
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).toBeNull();
+  });
+
+  it('line 매핑 실패(subwayId 없음) → null', async () => {
+    const seoul = makeSeoulWithPositions([{ trainCode: '7246' }]);
+    const trip = makeTrip({ promptDisplay: { originStation: '중곡', line: 'not-a-line' } });
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).toBeNull();
+  });
+
+  it('waypoints[0].line이 promptDisplay.line과 다름(direction=null fallback) → legSegment 빈 배열 → null', async () => {
+    // 첫 waypoint의 line이 다르면 direction 추론은 null-fallback되고(#1719 정책),
+    // buildLegSegmentStations도 첫 waypoint에서 즉시 멈춰 빈 배열을 반환한다 → null.
+    const seoul = makeSeoulWithPositions([{ trainCode: '7246' }]);
+    const trip = makeTrip({
+      waypoints: [{ stationName: '어린이대공원', line: '다른선', kind: 'destination' }],
+    });
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).toBeNull();
+  });
+
+  it('waypoints[0].stationName === origin(동일역) → direction=null이어도 resolved + segmentStations prepend 생략', async () => {
+    const seoul = makeSeoulWithPositions([{ trainCode: '7246' }]);
+    const trip = makeTrip({
+      waypoints: [{ stationName: '중곡', line: '7', kind: 'destination' }],
+    });
+    const result = await attemptBoardingAnchorResolution(trip, seoul, NOW);
+    expect(result).not.toBeNull();
+    expect(result?.trainCode).toBe('7246');
+    expect(result?.segmentStations).toEqual(['중곡']);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3404,6 +3404,175 @@ describe('POST /boarding-lock/sync (#901)', () => {
     });
   });
 
+  // 백엔드 realtimePosition trainCode resolver (committed architecture, 2026-09-03) — tap-시점
+  // (register) 즉시 시도 wiring. cron(≤60s)만 기다리면 열차가 이미 탑승역을 떠나 dwell window를
+  // 놓칠 위험이 있어, anchor가 처음 도달하는 이 시점에 1회 즉시 resolve를 시도한다.
+  describe('boarding-anchor tap-time resolution at POST /trips (backend-authority)', () => {
+    function makeExecutionContext(): ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> } {
+      return {
+        waitUntil: vi.fn(),
+        passThroughOnException: () => {},
+        props: {},
+      } as unknown as ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> };
+    }
+
+    async function postWithCtx(
+      path: string,
+      body: unknown,
+      env: Env,
+      ctx: ExecutionContext,
+    ): Promise<Response> {
+      return app.fetch(
+        new Request(`http://example.com${path}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+        env,
+        ctx,
+      );
+    }
+
+    /** seoul.ts parseRecptnDt는 `<recptnDt 공백구분> + '+09:00'`을 Date.parse한다 — 역산. */
+    function recptnDtFor(ms: number): string {
+      return new Date(ms + 9 * 60 * 60_000).toISOString().slice(0, 19).replace('T', ' ');
+    }
+
+    function anchorTripBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        token: 'anchor-tok',
+        route: { type: 'direct', line: '7', stops: 1 },
+        destination: '어린이대공원',
+        waypoints: [{ stationName: '어린이대공원', line: '7', kind: 'destination' }],
+        expiresAt: FUTURE,
+        alarmAtEpochMs: FUTURE - 30 * 60 * 1000,
+        infoModeEnabled: true,
+        promptDisplay: { originStation: '중곡', line: '7' },
+        ...overrides,
+      };
+    }
+
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('정확히 1개 매칭 → waitUntil 완료 후 trip.boardingLock 승격 + register 응답은 지장 없음', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            realtimePositionList: [
+              {
+                trainNo: '7246',
+                statnNm: '중곡',
+                trainSttus: 1,
+                updnLine: '하행',
+                lastRecptnDt: recptnDtFor(Date.now()),
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+      const env = makeKvEnv();
+      const ctx = makeExecutionContext();
+      const res = await postWithCtx('/trips', anchorTripBody(), env, ctx);
+      expect(res.status).toBe(200);
+
+      // register 응답 자체는 tap-resolve 완료를 기다리지 않는다 — register 직후 KV에는 아직
+      // boardingLock이 없어야 한다(waitUntil 완료 전).
+      const beforeAwait = JSON.parse((await env.TRIPS.get('trip:anchor-tok')) as string);
+      expect(beforeAwait.boardingLock).toBeUndefined();
+
+      const scheduled = ctx.waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>);
+      expect(scheduled.length).toBeGreaterThan(0);
+      await Promise.all(scheduled);
+
+      const stored = JSON.parse((await env.TRIPS.get('trip:anchor-tok')) as string);
+      expect(stored.boardingLock?.trainCode).toBe('7246');
+      expect(stored.boardingLock?.line).toBe('7');
+    });
+
+    it('resolver가 예외를 던져도(fetch reject) register 응답은 정상 200 (register 절대 안 깨짐)', async () => {
+      fetchSpy.mockRejectedValue(new Error('network down'));
+      const env = makeKvEnv();
+      const ctx = makeExecutionContext();
+      const res = await postWithCtx('/trips', anchorTripBody(), env, ctx);
+      expect(res.status).toBe(200);
+
+      const scheduled = ctx.waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>);
+      // waitUntil로 스케줄된 프로미스가 reject 없이(swallow) 완료돼야 한다.
+      await expect(Promise.all(scheduled)).resolves.toBeDefined();
+
+      const stored = JSON.parse((await env.TRIPS.get('trip:anchor-tok')) as string);
+      expect(stored.boardingLock).toBeUndefined();
+    });
+
+    it('infoModeEnabled !== true → tap-resolve 시도 자체 안 함 (기존 register 동작 무변경)', async () => {
+      const env = makeKvEnv();
+      const ctx = makeExecutionContext();
+      const res = await postWithCtx('/trips', anchorTripBody({ infoModeEnabled: false }), env, ctx);
+      expect(res.status).toBe(200);
+      await Promise.all(ctx.waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+      // infoModeEnabled=false라 SeoulArrivalClient(fetch)가 전혀 호출되지 않아야 한다.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      const stored = JSON.parse((await env.TRIPS.get('trip:anchor-tok')) as string);
+      expect(stored.boardingLock).toBeUndefined();
+    });
+
+    it('이미 boardingLock 있는 trip → tap-resolve 시도 안 함 (active lock 재평가 금지)', async () => {
+      const env = makeKvEnv();
+      const ctx = makeExecutionContext();
+      const res = await postWithCtx(
+        '/trips',
+        anchorTripBody({
+          boardingLock: {
+            trainCode: '9999',
+            line: '7',
+            subwayId: '1007',
+            selectedDepartureTime: Date.now(),
+            segmentStations: ['중곡', '어린이대공원'],
+            expiresAt: Date.now() + 60 * 60_000,
+          },
+        }),
+        env,
+        ctx,
+      );
+      expect(res.status).toBe(200);
+      await Promise.all(ctx.waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>));
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('executionCtx 미제공(기존 단위 테스트 관례) 시에도 throw 없이 정상 응답 + fire-and-forget 완료', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            realtimePositionList: [
+              {
+                trainNo: '7246',
+                statnNm: '중곡',
+                trainSttus: 1,
+                updnLine: '하행',
+                lastRecptnDt: recptnDtFor(Date.now()),
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+      const env = makeKvEnv();
+      const res = await post('/trips', anchorTripBody(), env);
+      expect(res.status).toBe(200);
+      // fire-and-forget(마이크로태스크) 완료를 기다린다 — executionCtx 없이도 throw 없이 진행.
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  });
 });
 
 // #2308 — applyProgress/resolveProgressWaypoints 단조 전진 불변식.

--- a/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
+++ b/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
@@ -119,7 +119,7 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
 function makeFullEmptyStats(): ScheduledStats {
   return {
     scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-    lockMissing: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    lockMissing: 0, boardingAnchorResolved: 0, boardingAnchorUnresolved: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
     laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -175,7 +175,7 @@ function makeEstimateArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
 function makeFullEmptyStats(): ScheduledStats {
   return {
     scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-    lockMissing: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    lockMissing: 0, boardingAnchorResolved: 0, boardingAnchorUnresolved: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
     laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
@@ -1208,6 +1208,108 @@ describe('runScheduled', () => {
         expect(apnsFetch).toHaveBeenCalled();
       });
     });
+  });
+});
+
+// 백엔드 realtimePosition trainCode resolver (committed architecture, 2026-09-03) — cron 배선 검증.
+// `boardingAnchorResolver.test.ts`가 resolver pure function 자체를 검증하므로, 여기서는
+// `runScheduled`가 실제로 그 결과를 `trip.boardingLock`으로 승격 + persist하고 다음 cycle의
+// `isBoardingLockActive` 판정에 반영되는지(=매역 push 경로 진입 가능 여부)를 검증한다.
+describe('runScheduled — boarding anchor trainCode resolution (backend-authority)', () => {
+  /** seoul.ts parseRecptnDt는 `<recptnDt 공백구분> + '+09:00'`을 Date.parse한다 — 역산. */
+  function recptnDtFor(ms: number): string {
+    return new Date(ms + 9 * 60 * 60_000).toISOString().slice(0, 19).replace('T', ' ');
+  }
+
+  function makeSeoulPositions(
+    positions: Array<Partial<PositionEntry> & { trainCode: string }>,
+  ): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [],
+            realtimePositionList: positions.map((p) => ({
+              trainNo: p.trainCode,
+              statnNm: p.stationName ?? '중곡',
+              trainSttus: p.trainSttus ?? 1,
+              updnLine: p.isUp === true ? '상행' : '하행',
+              lastRecptnDt: recptnDtFor(p.recptnMs ?? NOW),
+            })),
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+  }
+
+  function anchorTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'anchor-tok',
+      route: { type: 'direct', line: '7', stops: 1 },
+      destination: '어린이대공원',
+      waypoints: [{ stationName: '어린이대공원', line: '7', kind: 'destination' }],
+      infoModeEnabled: true,
+      promptDisplay: { originStation: '중곡', line: '7' },
+      ...overrides,
+    });
+  }
+
+  it('anchor + 후보 1개 → boardingLock 승격 + persist + boardingAnchorResolved 카운트', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, anchorTrip());
+    const seoul = makeSeoulPositions([{ trainCode: '7246' }]);
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.boardingAnchorResolved).toBe(1);
+    expect(stats.boardingAnchorUnresolved).toBe(0);
+    const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:anchor-tok')) as string);
+    expect(stored.boardingLock?.trainCode).toBe('7246');
+    expect(stored.boardingLock?.line).toBe('7');
+    expect(stored.boardingLock?.segmentStations[0]).toBe('중곡');
+    // 다음 cycle의 isBoardingLockActive 판정과 동일 조건 — 승격된 lock이 활성이어야 매역 추적 재개.
+    expect(stored.boardingLock?.expiresAt).toBeGreaterThan(NOW);
+  });
+
+  it('anchor + 후보 2개(ambiguous) → boardingLock 승격 안 함, boardingAnchorUnresolved 카운트', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, anchorTrip());
+    const seoul = makeSeoulPositions([{ trainCode: '7246' }, { trainCode: '7248' }]);
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.boardingAnchorResolved).toBe(0);
+    expect(stats.boardingAnchorUnresolved).toBe(1);
+    const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:anchor-tok')) as string);
+    expect(stored.boardingLock).toBeUndefined();
+  });
+
+  it('infoModeEnabled=false → resolver 평가 자체를 skip (기존 lockMissing 동작 무변경)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, anchorTrip({ infoModeEnabled: false }));
+    const seoul = makeSeoulPositions([{ trainCode: '7246' }]);
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.boardingAnchorResolved).toBe(0);
+    expect(stats.boardingAnchorUnresolved).toBe(0);
+    const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:anchor-tok')) as string);
+    expect(stored.boardingLock).toBeUndefined();
   });
 });
 
@@ -10669,7 +10771,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
     if (opts.setupSsot) await opts.setupSsot(kv, trip);
     const stats: ScheduledStats = {
       scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-      lockMissing: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+      lockMissing: 0, boardingAnchorResolved: 0, boardingAnchorUnresolved: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
       laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,

--- a/backend/alarm-worker/src/boardingAnchorResolver.ts
+++ b/backend/alarm-worker/src/boardingAnchorResolver.ts
@@ -1,0 +1,188 @@
+/**
+ * Backend-authority boarding trainCode resolver (committed architecture, 2026-09-03 결정).
+ *
+ * 배경
+ * ====
+ * 사용자가 "탑승했어요"를 탭해도(#819 boarding-prompt 응답 또는 배너 탭, 또는 BoardingTrainList
+ * 직접 탭 / C 토글) device는 `promptDisplay`(originStation + line) + `infoModeEnabled=true`
+ * (ADR-014 사용자 명시 의향 stamp)만 backend로 forward한다 — trainCode는 device가 로컬에서
+ * arrivals API로 자체 resolve를 시도하지만(`useBoardingPromptResponder.tryAutoLock`), 실패하면
+ * `PENDING-TRAIN-CODE` sentinel lock을 로컬에만 만들고 `buildBoardingLockMeta.ts`가
+ * `isPendingTrainCode` sentinel을 만나면 `boardingLock` 필드 자체를 생략한다(#2407) — backend는
+ * 이 trainCode를 절대 받지 않는다. 즉 이 시점의 trip은 backend 관점에서 완전히 lockless다.
+ *
+ * lockless trip은 `isBoardingLockActive`가 false라 `runTrainCodeTracking`(매역 arvlCd push의
+ * 유일한 경로)에 절대 도달하지 못한다 — trainCode 단위 추적이 시작되지 않으면 매역 push가
+ * 0건인 채로 trip이 표류한다.
+ *
+ * 본 모듈은 이 gap을 메운다: `promptDisplay` + `infoModeEnabled=true`(명시 탑승 anchor)가
+ * 있는 lockless trip에서 realtimePosition(Seoul API)을 조회해 "지금 이 역에 서 있는 열차"를
+ * 확정하고, 정확히 1개만 매칭되면(ambiguity 없음) `BoardingLockMeta`를 합성해 caller
+ * (`scheduled.ts`)가 `trip.boardingLock`으로 승격시킬 수 있게 한다. 승격되면 다음 cron
+ * cycle부터 `isBoardingLockActive` → `runTrainCodeTracking` 정상 경로로 진입한다.
+ *
+ * #1729 auto-lock 폐기와의 차이 — 안전 근거
+ * ==========================================
+ * #1729는 "사용자가 확인하지 않은 trainCode에 backend가 자동으로 lock 부착"을 금지했다.
+ * 본 모듈은 다르다:
+ *   1. 트리거 자체가 `infoModeEnabled===true`(ADR-014 "사용자 명시 의향" stamp)가 있어야만
+ *      평가된다 — lockless라고 아무 trip이나 대상이 아니다. `infoModeEnabled`는 이 코드베이스
+ *      전역에서 이미 boarding-prompt 응답 / BoardingTrainList 직접 탭 / C 토글(네비게이션 시작)
+ *      3개 경로를 **동급**으로 취급한다(ADR-014 "사용자 명시 의향 trip = lock 활성과 동급
+ *      정확도 보장 의무", `runLocklessIntermediate`/`tryFireConsensusTrainLeg`와 동일 게이트) —
+ *      본 모듈만 더 좁게 "진짜 탑승 탭"만 골라내는 별도 신호는 두지 않았다(그런 필드가 아직 없다).
+ *   2. 정확히 1개의 unambiguous 후보가 나올 때만 승격한다 — 0개(none) 또는 2개+(ambiguous)는
+ *      승격하지 않고 다음 cycle 재시도 또는 device BoardingTrainList fallback에 맡긴다
+ *      (틀린 열차를 추측해 lock 잠그는 것은 절대 금지 — 이 기능이 막아야 하는 바로 그 위험).
+ *
+ * 잔존 위험 (PR 리뷰 요청) — "역에 서 있는 열차"가 "사용자가 탄 열차"라는 보장은 없음
+ * ============================================================================
+ * C 토글만 켠 채 아직 플랫폼에 도착하지 않은 사용자가 있다면, 마침 그 역에 정차/진입 중인
+ * 열차 1대와 우연히 매칭되어 lock이 승격될 수 있다 — realtimePosition만으로는 "이 열차가 그
+ * 역에 있다"는 사실만 확인되지, "사용자가 물리적으로 그 열차 안에 있다"는 것까지 확인하지
+ * 못한다(GPS boarding 근접 게이트 없음). 이 위험은 새로 생긴 것이 아니라 이미
+ * `runLocklessIntermediate`/`tryFireConsensusTrainLeg`가 같은 `infoModeEnabled` 게이트만으로
+ * 매역 push를 발사하는 것과 동일한 신뢰 수준이다 — 본 PR이 그 수준을 낮추지는 않지만 새로
+ * 높이지도 않는다는 점을 리뷰어가 판단할 수 있도록 명시한다.
+ *
+ * 판정 규칙 (resolveTrainCodeFromPositions)
+ * =========================================
+ * realtimePosition(anchor.line) snapshot에서:
+ *   1. `isUp` 이 anchor.direction과 일치 (direction=null이면 양방향 허용)
+ *   2. `stationName` 이 anchor.boardingStation과 정확히 일치
+ *   3. `recptnMs` 신선(POSITION_FRESHNESS_MS 이내) — 0(누락)은 신뢰 불가로 제외
+ *   4. `trainSttus` ∈ {ARRIVED(1), APPROACHING(0)} — DEPARTED(2)는 제외(이미 그 역을 떠난
+ *      열차는 사용자가 방금 탑승한 대상일 수 없다는 실측 신뢰도 기준, 사전 검증 완료)
+ * 우선순위 ARRIVED > APPROACHING 타이 안에서 정확히 1개만 남으면 resolved, 2개+ 는 ambiguous,
+ * 0개는 none.
+ *
+ * 이 우선순위(ARRIVED가 최우선)는 `pickAutoTrainCode`(arrivals API, DEPARTED=2가 최우선)와
+ * 의도적으로 다르다 — arrivals API는 "곧 도착 예측"이 목적이라 "방금 출발"이 가장 강한 신호지만,
+ * realtimePosition 기반 탑승 확정은 "지금 이 역에 있는 열차"가 목적이라 이미 DEPARTED한 열차는
+ * 애초에 후보에서 배제한다. 같은 `pickAutoTrainCode`를 재사용하면 정반대 우선순위가 뒤섞여
+ * 잘못된 열차를 고를 위험이 있어 별도 함수로 분리했다 (재사용 대신 의도적 비-중복).
+ *
+ * express 타이브레이크 (design decision — PR 리뷰 요청)
+ * ======================================================
+ * 원 설계 노트는 "express contention 시 directAt으로 tie-break" 를 언급했으나, 급행/일반 열차
+ * 중 어느 쪽을 우선해야 하는지 뒷받침할 신뢰 가능한 근거(실측 evidence)가 없다. 틀린 열차를
+ * lock하는 것이 이 기능이 막아야 할 핵심 위험이므로, 이 PR은 trainType 기반 임의 tie-break를
+ * 구현하지 않는다 — ARRIVED/APPROACHING 타이 안에서 2개+ 남으면 그대로 ambiguous 로 판정한다.
+ * 향후 evidence가 쌓이면 별도 PR로 추가.
+ */
+
+import { TRAIN_STATUS } from './alarm';
+import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
+import { inferLegDirection } from './legDirection';
+import { subwayIdForLine } from './lineAlias';
+import type { PositionEntry, SeoulArrivalClient } from './seoul';
+import type { BoardingLockMeta, Trip } from './types';
+
+/** realtimePosition 항목을 신뢰 가능한 최신 관측으로 볼 임계값(ms). seoul.ts의 arrivals용
+ * MAX_RECPTN_DRIFT_SEC(120s)와 동일 정책 — 두 값은 각자 로컬 모듈에 선언해 순환 import를
+ * 피한다(`arrivalsFromPositions.ts`의 HOP_SEC 중복 선언과 동일 선례). */
+export const POSITION_FRESHNESS_MS = 120_000;
+
+export interface BoardingAnchor {
+  /** 탑승 확정 대상 노선 (Waypoint.line / BoardingLockMeta.line과 동일 표기). */
+  line: string;
+  /** 사용자가 탑승했다고 명시한 역 (promptDisplay.originStation). */
+  boardingStation: string;
+  /** #1719 leg 진행 방향. 추론 불가 노선은 null(양방향 허용). */
+  direction: 'up' | 'down' | null;
+}
+
+export type BoardingResolution =
+  | { status: 'resolved'; trainCode: string }
+  | { status: 'ambiguous' }
+  | { status: 'none' };
+
+/**
+ * realtimePosition snapshot에서 anchor 조건에 맞는 정확히 1개의 trainCode를 찾는다. Pure —
+ * KV/네트워크 의존 없음. caller(`attemptBoardingAnchorResolution`)가 `seoul.fetchPositions`
+ * 결과를 전달한다.
+ */
+export function resolveTrainCodeFromPositions(
+  anchor: BoardingAnchor,
+  positions: readonly PositionEntry[],
+  now: number,
+): BoardingResolution {
+  const directional =
+    anchor.direction !== null
+      ? positions.filter((p) => p.isUp === (anchor.direction === 'up'))
+      : positions;
+  const atStation = directional.filter((p) => p.stationName === anchor.boardingStation);
+  const fresh = atStation.filter(
+    (p) => p.recptnMs > 0 && now - p.recptnMs <= POSITION_FRESHNESS_MS,
+  );
+
+  // ARRIVED(1) 우선 — "지금 이 역에 서 있음" 확정 신호. APPROACHING(0)은 차선.
+  // DEPARTED(2)/그 외는 priority list 밖이라 자연히 후보에서 배제된다.
+  const priority: readonly number[] = [TRAIN_STATUS.ARRIVED, TRAIN_STATUS.APPROACHING];
+  for (const trainSttus of priority) {
+    const tier = fresh.filter((p) => p.trainSttus === trainSttus);
+    if (tier.length === 1) return { status: 'resolved', trainCode: tier[0].trainCode };
+    if (tier.length > 1) return { status: 'ambiguous' };
+  }
+  return { status: 'none' };
+}
+
+/**
+ * lockless trip이 명시 탑승 anchor(`promptDisplay` + `infoModeEnabled===true`)를 가지고 있을 때
+ * realtimePosition으로 trainCode를 확정해 승격 가능한 `BoardingLockMeta`를 합성한다.
+ *
+ * 전제(caller 책임, #902 Seam F `attachTrainCodeForLeg`와 동일 계약): `isBoardingLockActive(trip,
+ * now) === false`. 본 함수는 그 판정을 재검증하지 않는다 — `scheduled.ts` 순환 import를 피하기
+ * 위해 의도적으로 분리(이미 `lockSwap.ts`가 같은 패턴).
+ *
+ * null 반환 사유: anchor 정보 부재(promptDisplay 없음/infoModeEnabled!==true) / line 매핑 실패
+ * / 후보 0개 또는 ambiguous(2개+) / segmentStations 산출 실패(route 불일치).
+ */
+export async function attemptBoardingAnchorResolution(
+  trip: Trip,
+  seoul: SeoulArrivalClient,
+  now: number,
+): Promise<BoardingLockMeta | null> {
+  if (trip.infoModeEnabled !== true) return null;
+  const { promptDisplay, waypoints } = trip;
+  if (!promptDisplay) return null;
+
+  const subwayId = subwayIdForLine(promptDisplay.line);
+  if (!subwayId) return null;
+
+  // #1719 — direction 추론. waypoints[0]은 route 상 origin 다음 정차역(origin 자체는 waypoints에
+  // 포함되지 않는다, `dijkstraRoute.ts:routeToInferredWaypoints` "출발역 — push 안 함" 계약).
+  // origin(promptDisplay.originStation) → waypoints[0]로 방향을 추론한다. 추론 불가 노선/
+  // 매칭 실패는 null(양방향 허용) — 기존 `attachTrainCodeForLeg`와 동일 fallback 정책.
+  const nextWaypoint = waypoints[0];
+  const direction =
+    nextWaypoint && nextWaypoint.line === promptDisplay.line
+      ? inferLegDirection(promptDisplay.line, promptDisplay.originStation, nextWaypoint.stationName)
+      : null;
+
+  const positions = await seoul.fetchPositions(promptDisplay.line);
+  const resolution = resolveTrainCodeFromPositions(
+    { line: promptDisplay.line, boardingStation: promptDisplay.originStation, direction },
+    positions,
+    now,
+  );
+  if (resolution.status !== 'resolved') return null;
+
+  // segmentStations — 탑승역(origin) + 현재 leg의 나머지 정차역(환승/도착까지 포함).
+  // `buildLegSegmentStations`는 waypoints[0]부터 수집하므로 origin이 빠져 있다 — prepend.
+  const legSegment = buildLegSegmentStations(waypoints, promptDisplay.line);
+  if (legSegment.length === 0) return null;
+  const segmentStations =
+    legSegment[0] === promptDisplay.originStation
+      ? legSegment
+      : [promptDisplay.originStation, ...legSegment];
+
+  return {
+    trainCode: resolution.trainCode,
+    line: promptDisplay.line,
+    subwayId,
+    selectedDepartureTime: now,
+    segmentStations,
+    expiresAt: now + SWAP_LOCK_TTL_MS,
+  };
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -13,6 +13,7 @@
 
 import { Hono, type Context } from 'hono';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
+import { attemptBoardingAnchorResolution } from './boardingAnchorResolver';
 import { isNearOrigin, markPromptSilenced, shouldStampOriginProximity } from './boardingPrompt';
 import {
   recordBoardingPromptOutcome,
@@ -191,6 +192,55 @@ function scheduleTripEvent(c: Context<{ Bindings: Env }>, promise: Promise<void>
     c.executionCtx.waitUntil(promise);
   } catch {
     void promise;
+  }
+}
+
+/**
+ * 백엔드 realtimePosition trainCode resolver — tap-시점(register) 즉시 시도 (POST /trips 참고).
+ * `scheduleTripEvent`로 waitUntil 스케줄되므로 응답 반환 이후 실행된다.
+ *
+ * `getTrip`으로 최신 trip을 재조회 후 write한다 — waitUntil 실행 시점까지 cron(`scheduled.ts`
+ * 의 동일 resolver 재시도)이나 다른 register가 먼저 lock을 승격/변경했을 수 있는 race를
+ * 방어한다(이미 lock 있으면 skip — 어느 쪽이 먼저 승격했든 결과는 동일한 정책이라 덮어쓸
+ * 필요가 없다).
+ *
+ * 모든 실패(네트워크/파싱/KV)는 여기서 swallow — register 응답은 이미 반환된 이후이므로
+ * 예외가 밖으로 나가도 사용자에게 영향은 없지만, unhandled rejection 로그 노이즈를 막기 위해
+ * 명시적으로 처리한다.
+ */
+async function resolveBoardingAnchorAtRegister(env: Env, trip: Trip): Promise<void> {
+  try {
+    const seoul = new SeoulArrivalClient({ apiKey: env.SEOUL_API_KEY, host: env.SEOUL_API_HOST });
+    const anchorLock = await attemptBoardingAnchorResolution(trip, seoul, Date.now());
+    if (!anchorLock) return;
+
+    const latest = await getTrip(env.TRIPS, trip.token);
+    if (!latest || latest.boardingLock !== undefined) return;
+
+    const resolvedTrip: Trip = {
+      ...latest,
+      boardingLock: anchorLock,
+      consecutiveEtaMissing: 0,
+      lastTrackedArrivalEpoch: undefined,
+      lastLaPushEpoch: undefined,
+      lastLaPushAt: undefined,
+    };
+    await putTrip(env.TRIPS, resolvedTrip);
+    console.log(
+      JSON.stringify({
+        msg: 'boarding-anchor: trainCode resolved at register (tap-time)',
+        tokenPrefix: tokenPrefix(trip.token),
+        trainCode: anchorLock.trainCode,
+      }),
+    );
+  } catch (e) {
+    console.log(
+      JSON.stringify({
+        msg: 'boarding-anchor: tap-time resolution error (register unaffected)',
+        tokenPrefix: tokenPrefix(trip.token),
+        error: String(e),
+      }),
+    );
   }
 }
 
@@ -1046,6 +1096,19 @@ app.post('/trips', async (c) => {
   // #2264 (Epic #2260, ADR-031 Phase 1) — TripDO shadow dual-write. flag off(default)면
   // no-op. KV write(putTrip)는 이미 위에서 완료됐으므로 실패해도 trip 등록에 영향 없다.
   await dualWriteTripDo(c.env, trip);
+
+  // 백엔드 realtimePosition trainCode resolver (committed architecture, 2026-09-03) — tap-시점
+  // 즉시 시도. 실제 열차는 탑승역에서 ~20-30s 안에 떠난다 — cron(≤60s 주기)만 기다리면 dwell
+  // window를 놓쳐 station 정확 일치 매칭이 영구 실패할 위험이 있다(열차가 이미 다음 역으로
+  // 넘어가 버림). anchor(promptDisplay + infoModeEnabled=true)가 backend에 처음 도달하는 이
+  // 시점 — 즉 탭 직후, 열차가 아직 탑승역에 있을 가능성이 가장 높은 시점 — 에 1회 즉시 시도해
+  // 그 창을 잡는다. `scheduleTripEvent`와 동일 waitUntil 패턴으로 register 응답 latency에
+  // 얹지 않고, 실패/예외는 전부 swallow — register 자체(위에서 이미 persist 완료)는 절대
+  // 실패시키지 않는다. cron(`scheduled.ts`)은 retry로 그대로 유지 — 이 tap-time 시도가
+  // 실패해도(dwell window를 못 잡았거나 ambiguous) 다음 cycle이 계속 재평가한다.
+  if (trip.infoModeEnabled === true && trip.boardingLock === undefined) {
+    scheduleTripEvent(c, resolveBoardingAnchorAtRegister(c.env, trip));
+  }
 
   // #1897 (RC-5) — KV에 박힌 권위 apnsEnv 를 device로 echo. device 는 이를 stamp 해 다음
   // register 시 build env 대신 송신 → backend self-heal(envCorrected) 발동을 0에 수렴.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -4,6 +4,7 @@
 
 import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
 import { evaluateAccelWindow, readAccelSeries } from './accelSeries';
+import { attemptBoardingAnchorResolution } from './boardingAnchorResolver';
 import {
   buildSilentPushData,
   sendAlertPush,
@@ -549,6 +550,20 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   lockMissing: number;
   /**
+   * 백엔드 realtimePosition trainCode resolver (committed architecture, 2026-09-03) — 명시 탑승
+   * anchor(`promptDisplay` + `infoModeEnabled===true`)를 가진 lockless trip에서 정확히 1개의
+   * unambiguous trainCode를 찾아 `trip.boardingLock`을 승격시킨 누적 횟수. 다음 cycle부터
+   * `isBoardingLockActive` → `runTrainCodeTracking` 정상 경로로 매역 push가 시작된다.
+   * `boardingAnchorResolver.ts` 참고.
+   */
+  boardingAnchorResolved: number;
+  /**
+   * 위와 동일 anchor 조건에서 resolver가 0개(none) 또는 2개+(ambiguous) 후보를 만나 승격을
+   * 보류한 누적 횟수. 틀린 열차를 추측해 lock하지 않는다는 안전 게이트가 실제로 작동한 빈도
+   * 측정 — 사용자는 다음 cycle 재시도 또는 device BoardingTrainList manual fallback으로 이어진다.
+   */
+  boardingAnchorUnresolved: number;
+  /**
    * #1933 — `lastLaPushAt`이 `LA_STALE_AUTO_END_MS` 이상 침묵해 cron이 자동 cleanup한 trip 수.
    * lockMissing 분기 진입 시 평가. 정상 운영(silent push + LA heartbeat 작동)에서 0건 기대 —
    * 0이 아니면 `lockMissing` 분기 잔여 케이스(advance gate freeze + heartbeat self-referential gap)에서
@@ -1073,6 +1088,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     etaMissing: 0,
     envCorrected: 0,
     lockMissing: 0,
+    boardingAnchorResolved: 0,
+    boardingAnchorUnresolved: 0,
     laStaleAutoEnded: 0,
     laStaleSurvivedSilence: 0,
     killSwitchLocklessIntermediateSkipped: 0,
@@ -1348,6 +1365,38 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // Seoul polling/push 모두 skip. 디바이스는 lock 등록 후 train-code 단위로 정확히 추적하며,
     // lock 부재 상태에서의 phase-based push는 "탑승 전 노이즈"였다.
     if (!isBoardingLockActive(trip, now)) {
+      // 백엔드 realtimePosition trainCode resolver (committed architecture, 2026-09-03) —
+      // 명시 탑승 anchor(promptDisplay + infoModeEnabled=true)를 가진 lockless trip을 우선
+      // 시도한다. 정확히 1개 unambiguous trainCode가 나오면 즉시 lock을 승격 + persist하고
+      // 이번 cycle은 여기서 종료한다 — 다음 cycle부터 위 `isBoardingLockActive` 판정이 true가
+      // 되어 정상 `runTrainCodeTracking` 경로(매역 push)로 진입한다. ambiguous/none은 그대로
+      // lockMissing 분기(boarding-prompt / lockless-intermediate fallback)로 흘려보낸다 —
+      // 틀린 열차를 추측해 lock하지 않는다(#1729 auto-lock 폐기와 동일 안전 원칙).
+      try {
+        const anchorLock = await attemptBoardingAnchorResolution(trip, deps.seoul, now);
+        if (anchorLock) {
+          trip.boardingLock = anchorLock;
+          trip.consecutiveEtaMissing = 0;
+          trip.lastTrackedArrivalEpoch = undefined;
+          trip.lastLaPushEpoch = undefined;
+          trip.lastLaPushAt = undefined;
+          await putTrip(env.TRIPS, trip);
+          stats.boardingAnchorResolved += 1;
+          log('boarding-anchor: trainCode resolved, lock promoted', {
+            token: trip.token.slice(0, 8),
+            station: trip.promptDisplay?.originStation,
+            line: trip.promptDisplay?.line,
+            trainCode: anchorLock.trainCode,
+          });
+          continue;
+        }
+        if (trip.infoModeEnabled === true && trip.promptDisplay) {
+          stats.boardingAnchorUnresolved += 1;
+        }
+      } catch (e) {
+        stats.errors += 1;
+        log('boarding-anchor: resolution error', { error: String(e), token: trip.token.slice(0, 8) });
+      }
       // #1933 — LA push 침묵 자동 종료 backstop. lockMissing 분기 진입 시 평가.
       // backend SSoT가 advance 게이트로 frozen된 채 `maybeFireLiveActivityUpdate`가 ΔETA=0 분기
       // dedup으로 새 push 미발사 → ActivityKit이 last content-state를 영구 유지하는


### PR DESCRIPTION
## Closes #2504

## 설계 (STEP 0)

### 현재 anchor 흐름 — 재확인한 실제 배선

당초 가정("device가 PENDING-TRAIN-CODE lock을 backend로 보낸다")은 틀렸다. 실제로는:

1. 사용자가 "탑승했어요" 탭(boarding-prompt 응답 / 배너 탭 / BoardingTrainList 직접 탭 / C 토글) → device가 로컬 arrivals API로 trainCode 자체 resolve 시도(`useBoardingPromptResponder.tryAutoLock`).
2. 실패하면 로컬에 `PENDING-TRAIN-CODE` sentinel lock 생성(#2407) — 이건 **로컬 전용**이다.
3. `buildBoardingLockMeta.ts`가 다음 `POST /trips` 직전에 이 sentinel을 만나면 **`boardingLock` 필드 자체를 생략**한다(“skip backend register — pending trainCode”, #2407 주석). backend는 이 sentinel을 절대 받지 않는다.
4. 결과: backend 관점에서 trip은 **완전히 lockless**다. `isBoardingLockActive`가 false라 `runTrainCodeTracking`(매역 arvlCd push의 유일 경로)에 도달 못 함 → 매역 push 0건.

### backend가 이미 가진 anchor(추가 device 변경 불필요)

- `trip.promptDisplay = { originStation, line }` — 매 register마다 device가 보냄(POST /trips 기존 필드, validateTrip에서 이미 파싱됨).
- `trip.infoModeEnabled === true` — ADR-014 "사용자 명시 의향" stamp. boarding-prompt 응답 / BoardingTrainList 탭 / C 토글 3개 경로가 전부 이 필드를 true로 세팅한다(코드베이스 전역에서 이미 동급으로 취급 — `runLocklessIntermediate`/`tryFireConsensusTrainLeg`와 동일 게이트).
- 방향(direction)은 `promptDisplay.originStation → trip.waypoints[0].stationName`으로 기존 `inferLegDirection`(#1719, lockSwap.ts가 이미 쓰는 함수)을 그대로 재사용해 추론 — **새 필드 불필요**.

→ **device 변경 0건.** 필요한 anchor가 이미 매 등록마다 도달하고 있었다.

### resolver 트리거 — 2개 지점 (리뷰 반영, 최종)

최초 설계는 cron-only였다. **리뷰 지적**: 실제 열차는 탑승역에서 ~20-30초 안에 떠난다 — cron(≤60s 주기)만 기다리면 그 dwell window를 놓쳐 `stationName` 정확 일치 매칭이 **영구 실패**한다(열차가 이미 다음 역으로 넘어가고, 다음 cron엔 더 멀어짐). 그래서 트리거를 2단으로 재설계했다:

1. **tap-시점 즉시 시도 (freshest, 신규)** — `POST /trips`(index.ts) 핸들러가 trip을 persist한 직후, `infoModeEnabled===true && boardingLock===undefined`면 `resolveBoardingAnchorAtRegister`를 `scheduleTripEvent`(기존 `waitUntil` 패턴, #2283 trip_events와 동일)로 스케줄한다 — **응답 latency에 얹지 않고**, 실패/예외는 전부 swallow(register 응답은 절대 안 깨짐). anchor가 backend에 처음 도달하는 이 순간이 열차가 탑승역에 있을 가능성이 가장 높은 시점이라 dwell window를 잡을 확률이 가장 높다.
2. **cron retry (기존 유지)** — `scheduled.ts`의 `isBoardingLockActive===false` 분기 최상단. tap-시점이 놓치면(dwell window 종료 전 register가 안 왔거나, ambiguous였거나, 열차가 아직 도착 전) 다음 cycle들이 계속 재시도.

두 트리거가 경합하면(예: tap-resolve의 waitUntil이 완료되기 전 cron이 먼저 실행) `resolveBoardingAnchorAtRegister`가 write 직전 `getTrip`으로 최신 상태를 재조회해 `boardingLock`이 이미 있으면 skip — 어느 쪽이 먼저 승격했든 결과 정책은 동일하므로 덮어쓸 필요가 없다.

resolver 로직(`boardingAnchorResolver.ts`) 자체는 이번 라운드에서 변경하지 않았다 — 트리거 배선만 추가.

## 안전 조건 (#1729 auto-lock 폐기와 다른 점)

1. 트리거 자체가 `infoModeEnabled===true`(명시 의향)가 있어야만 평가 — lockless라고 아무 trip이나 대상 아님.
2. `resolveTrainCodeFromPositions`는 realtimePosition에서 station 정확 일치 + direction 일치 + freshness(120s) + `trainSttus ∈ {ARRIVED(1), APPROACHING(0)}`(DEPARTED(2) 제외)로 후보를 추린 뒤, **정확히 1개만 남을 때만** resolved. 0개(none) 또는 2개+(ambiguous)는 **절대 승격하지 않는다** — 다음 cycle 재시도 또는 device BoardingTrainList manual fallback.
3. express contention 시 "directAt tie-break"는 신뢰할 근거가 없어 **구현하지 않았다**(ambiguous 그대로 유지) — 자세한 사유는 `boardingAnchorResolver.ts` 상단 docstring.

## 리뷰 요청 — 잔존 위험

C 토글만 켠 채 아직 플랫폼에 도착하지 않은 사용자가 있다면, 마침 그 역에 정차/진입 중인 열차 1대와 우연히 매칭돼 lock이 승격될 수 있다 — realtimePosition만으로는 "이 열차가 그 역에 있다"만 확인되지 "사용자가 그 열차 안에 있다"까지는 확인 못 한다(GPS 근접 게이트 없음). 이 위험은 새로 생긴 게 아니라 기존 `runLocklessIntermediate`/`tryFireConsensusTrainLeg`가 같은 `infoModeEnabled` 게이트만으로 매역 push를 발사하는 것과 동일한 신뢰 수준이다 — 본 PR이 이 수준을 낮추지 않지만 새로 높이지도 않는다.

## 테스트

- `boardingAnchorResolver.test.ts` (18건, 신규 파일 100% coverage): resolver 단위 — 1개→resolved / 0개→none / 2개+→ambiguous(no-wrong-train guard) / direction 불일치 제외 / DEPARTED 제외 / freshness 경계 / tier 우선순위(ARRIVED>APPROACHING) / `attemptBoardingAnchorResolution` wrapper(anchor 부재 시 seoul 미호출 검증 포함)
- `scheduled.test.ts` (신규 describe 3건): cron wiring 통합 — anchor+1개 매칭 → `trip.boardingLock` 실제 persist 확인, anchor+2개(ambiguous) → 승격 안 함 확인, `infoModeEnabled=false` → 기존 lockMissing 동작 무변경 확인
- `index.test.ts` (신규 describe 5건): tap-시점 wiring — 1개 매칭 시 waitUntil 완료 후에만 lock 승격(응답 자체는 지장 없음 확인) / resolver 예외(fetch reject) 시에도 register 200 유지 / `infoModeEnabled!==true`·active-lock-존재 시 시도 자체 skip(fetch 미호출로 확인) / executionCtx 미제공 하위호환
- 터치한 파일 전체(`index.test.ts`/`scheduled.test.ts`/`boardingAnchorResolver.test.ts`/`replay_20260807_storm.test.ts`/`index.scheduledGate.test.ts`/`index.boardingPromptCounterWiring.test.ts`, 1030 tests) 그린 + 전체 backend suite(3119 tests, 88 files, 1차 커밋 시점) 그린 — `tsc --noEmit` 클린

## Wire-completion 5단

1. **Orphan 없음** — 신규 export는 `scheduled.ts`(cron 경로) + `index.ts`(tap 경로) 양쪽이 즉시 소비. `npm run lint:orphan` pass(frontend orphan 스캐너 — backend는 스코프 밖, `tsc --noEmit` + wiring 테스트로 실사용 확인).
2. **V/X dashboard** — `ScheduledStats.boardingAnchorResolved`/`boardingAnchorUnresolved`가 매 `scheduled run complete` 로그(`wrangler tail`)에 실린다. tap-시점 성공/실패는 `console.log`(`boarding-anchor: trainCode resolved at register` / `... resolution error`, `wrangler tail`로 관측). D1: 승격된 trip이 이어서 `cron-fire-attempt`(`fireArvlCdStationPush`)로 이어지는지 `trip_events` 쿼리로 관측 가능.
3. **의존 PR** — N/A (backend-only, 이 PR 자체로 완결).
4. **측정 plan** — 1주 production: (a) tap-시점 resolved 비율(로그) vs cron-시점 resolved 비율(`boardingAnchorResolved`) — tap-시점이 dwell window 개선 효과를 실제로 내는지 cross-check, (b) `boardingAnchorUnresolved`가 비정상적으로 크지 않음(ambiguous 다발 시 disambiguation rule 재검토 신호), (c) 승격된 trip의 `trip_events`에서 `cron-fire-attempt` 후속 발생 여부, (d) 실기기 탑승 trip에서 "탑승했어요" 탭 후 매역 push 도달 여부/지연.
5. **Device verify** — **필요**. 실기기 시나리오: "탑승했어요" 탭 → 수 초~수십 초 내(tap-시점 성공 시) 또는 1~2 cron cycle(≈60~120s, cron retry 성공 시) 내 매역 push 도달 확인. **`wrangler deploy` 별도 필요** — backend merge ≠ deploy.

https://claude.ai/code/session_01RyeFzkUY71fq4feDXMfDB9